### PR TITLE
fix: add "web" to default verified trust channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ my-entity/
 | `security`     | `secret`                 | --                   | Auth secret (enables `X-Echo-Secret` header)   |
 | `security`     | `injection_detection`    | `true`               | Prompt injection scanning                      |
 | `trust`        | `trusted`                | `["reflection", "system"]` | Channels with full access                |
-| `trust`        | `verified`               | `["chat", "voice"]`  | Channels with limited access                   |
+| `trust`        | `verified`               | `["chat", "voice", "web"]` | Channels with limited access              |
 | `scheduler`    | `enabled`                | `true`               | Enable scheduled tasks                         |
 | `scheduler`    | `timezone`               | `UTC`                | Timezone for cron expressions                  |
 | `pipeline`     | `enabled`                | `true`               | Document threshold enforcement                 |

--- a/src/init/templates.rs
+++ b/src/init/templates.rs
@@ -47,7 +47,7 @@ injection_detection = true
 
 [trust]
 trusted = ["reflection", "system"]
-verified = ["chat", "voice"]
+verified = ["chat", "voice", "web"]
 
 [memory]
 memory_max_lines = 200


### PR DESCRIPTION
## Summary

- Adds `"web"` to the default `verified` trust channel list in the init template and README
- Required for chat-echo compatibility — chat-echo sends `channel: "web"` which needs to be in the verified list

## Test plan

- [x] `cargo fmt && cargo clippy` — clean
- [x] `cargo test` — 53 tests passing
- [ ] Start echo-system + chat-echo together and verify web chat works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)