### PR TITLE
feat(tools): add grep tool for searching file contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "echo-system"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "chrono",
@@ -336,6 +346,7 @@ dependencies = [
  "console",
  "cron",
  "dialoguer",
+ "globset",
  "regex",
  "reqwest",
  "serde",
@@ -348,6 +359,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -499,6 +511,19 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1297,6 +1322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1934,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2077,15 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ reqwest = { version = "0.12", features = ["json"] }
 # Security
 regex = "1"
 
+# File tools
+walkdir = "2"
+globset = "0.4"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -54,6 +54,9 @@ pub async fn start(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     tools.register(Box::new(crate::tools::file_list::FileListTool::new(
         root_dir.clone(),
     )));
+    tools.register(Box::new(crate::tools::grep::GrepTool::new(
+        root_dir.clone(),
+    )));
     tools.register(Box::new(crate::tools::web_fetch::WebFetchTool::new()));
     tracing::info!("Registered {} built-in tool(s)", tools.definitions().len());
 

--- a/src/tools/grep.rs
+++ b/src/tools/grep.rs
@@ -1,0 +1,225 @@
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use globset::{Glob, GlobMatcher};
+use regex::Regex;
+
+use super::{resolve_sandboxed_path, Tool, ToolError, ToolResult};
+
+/// Maximum number of matching lines returned.
+const MAX_MATCHES: usize = 200;
+
+/// Maximum file size to search (1 MB). Larger files are skipped.
+const MAX_FILE_SIZE: u64 = 1_024 * 1_024;
+
+/// Search file contents for a pattern within the entity's data directory.
+pub struct GrepTool {
+    entity_root: PathBuf,
+}
+
+impl GrepTool {
+    pub fn new(entity_root: PathBuf) -> Self {
+        Self { entity_root }
+    }
+}
+
+impl Tool for GrepTool {
+    fn name(&self) -> &str {
+        "grep"
+    }
+
+    fn description(&self) -> &str {
+        "Search file contents for a regex pattern within the entity's data directory. \
+         Returns matching lines with file paths and line numbers."
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Regex pattern to search for"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Directory or file path relative to entity root. Defaults to root."
+                },
+                "glob": {
+                    "type": "string",
+                    "description": "Glob pattern to filter files, e.g. \"*.md\" or \"**/*.toml\""
+                }
+            },
+            "required": ["pattern"]
+        })
+    }
+
+    fn execute(&self, input: serde_json::Value) -> ToolResult<'_> {
+        let entity_root = self.entity_root.clone();
+        Box::pin(async move {
+            let pattern_str = input["pattern"].as_str().ok_or_else(|| {
+                ToolError::ExecutionFailed("Missing 'pattern' parameter".to_string())
+            })?;
+
+            let re = Regex::new(pattern_str)
+                .map_err(|e| ToolError::ExecutionFailed(format!("Invalid regex pattern: {}", e)))?;
+
+            let path = input["path"].as_str().unwrap_or(".");
+            let resolved = resolve_sandboxed_path(&entity_root, path)?;
+
+            if !resolved.exists() {
+                return Err(ToolError::NotFound(format!("Path not found: {}", path)));
+            }
+
+            let glob_matcher = match input["glob"].as_str() {
+                Some(glob_str) => {
+                    let glob = Glob::new(glob_str).map_err(|e| {
+                        ToolError::ExecutionFailed(format!("Invalid glob pattern: {}", e))
+                    })?;
+                    Some(glob.compile_matcher())
+                }
+                None => None,
+            };
+
+            // Collect files to search — run the blocking walk on a thread pool
+            let files = tokio::task::spawn_blocking({
+                let resolved = resolved.clone();
+                let entity_root = entity_root.clone();
+                let glob_matcher = glob_matcher.clone();
+                move || collect_files(&resolved, &entity_root, glob_matcher.as_ref())
+            })
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Task join error: {}", e)))?;
+
+            // Search each file — also blocking I/O
+            let matches = tokio::task::spawn_blocking({
+                let entity_root = entity_root.clone();
+                move || search_files(&files, &re, &entity_root)
+            })
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Task join error: {}", e)))?;
+
+            if matches.is_empty() {
+                return Ok(format!("No matches found for pattern '{}'", pattern_str));
+            }
+
+            let total = matches.len();
+            let truncated = total > MAX_MATCHES;
+            let mut output: Vec<String> = matches.into_iter().take(MAX_MATCHES).collect();
+
+            if truncated {
+                output.push(format!(
+                    "\n... truncated ({} total matches, showing first {})",
+                    total, MAX_MATCHES
+                ));
+            }
+
+            Ok(output.join("\n"))
+        })
+    }
+}
+
+/// Walk the directory tree and collect files to search.
+fn collect_files(
+    start: &PathBuf,
+    entity_root: &PathBuf,
+    glob_matcher: Option<&GlobMatcher>,
+) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+
+    if start.is_file() {
+        if should_search_file(start, entity_root, glob_matcher) {
+            files.push(start.clone());
+        }
+        return files;
+    }
+
+    for entry in walkdir::WalkDir::new(start)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if path.is_file() && should_search_file(&path.to_path_buf(), entity_root, glob_matcher) {
+            files.push(path.to_path_buf());
+        }
+    }
+
+    files.sort();
+    files
+}
+
+/// Check whether a file should be searched.
+fn should_search_file(
+    path: &PathBuf,
+    entity_root: &PathBuf,
+    glob_matcher: Option<&GlobMatcher>,
+) -> bool {
+    // Skip files over the size limit
+    if let Ok(metadata) = std::fs::metadata(path) {
+        if metadata.len() > MAX_FILE_SIZE {
+            return false;
+        }
+    }
+
+    // Apply glob filter against the relative path
+    if let Some(matcher) = glob_matcher {
+        if let Ok(relative) = path.strip_prefix(entity_root) {
+            if !matcher.is_match(relative) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    // Skip likely binary files by extension
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        let binary_exts = [
+            "png", "jpg", "jpeg", "gif", "bmp", "ico", "svg", "webp", "mp3", "mp4", "wav", "ogg",
+            "flac", "avi", "mkv", "zip", "tar", "gz", "bz2", "xz", "7z", "rar", "bin", "exe",
+            "dll", "so", "dylib", "o", "a", "wasm", "pdf", "db", "sqlite",
+        ];
+        if binary_exts.contains(&ext.to_lowercase().as_str()) {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Search files for the regex pattern and return formatted match lines.
+fn search_files(files: &[PathBuf], re: &Regex, entity_root: &PathBuf) -> Vec<String> {
+    let mut matches = Vec::new();
+
+    for file_path in files {
+        let file = match std::fs::File::open(file_path) {
+            Ok(f) => f,
+            Err(_) => continue,
+        };
+
+        let relative = file_path
+            .strip_prefix(entity_root)
+            .unwrap_or(file_path)
+            .to_string_lossy();
+
+        let reader = BufReader::new(file);
+        for (line_num, line) in reader.lines().enumerate() {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => continue, // skip unreadable lines (binary content)
+            };
+
+            if re.is_match(&line) {
+                matches.push(format!("{}:{}:{}", relative, line_num + 1, line));
+
+                // Early exit if we've collected way more than we'll show
+                if matches.len() > MAX_MATCHES * 2 {
+                    return matches;
+                }
+            }
+        }
+    }
+
+    matches
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,6 +1,7 @@
 pub mod file_list;
 pub mod file_read;
 pub mod file_write;
+pub mod grep;
 pub mod web_fetch;
 
 use std::fmt;


### PR DESCRIPTION
## Summary
- Implements the `grep` tool (Phase 2) — entities can now search their own file contents by regex pattern
- Three parameters: `pattern` (required, regex), `path` (optional, defaults to root), `glob` (optional, file filter like `*.md`)
- Output format: `path:line_number:matching_content`, capped at 200 matches
- Sandboxed to entity root via `resolve_sandboxed_path()`, skips binary files, 1MB file size limit
- Uses `walkdir` for recursive traversal, `globset` for file pattern matching, `regex` (existing) for content search
- Registered in tool registry alongside existing file_read, file_write, file_list, web_fetch

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — no new warnings
- [x] `cargo test` — 56 tests pass
- [ ] Manual test: `echo-system up` and invoke grep via chat
- [ ] Verify sandboxing: cannot escape entity root
- [ ] Verify glob filtering works (e.g. `*.md` only searches markdown)
- [ ] Verify binary files are skipped
- [ ] Verify 200-match cap with truncation message