### PR TITLE
feat(ES-19): voice-echo plugin scaffolding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,12 @@ chrono-tz = "0.10"
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 
+[features]
+default = []
+voice = []
+discord = ["voice"]
+all-plugins = ["voice", "discord"]
+
 [dev-dependencies]
 tempfile = "3"
 tower = { version = "0.5.3", features = ["util"] }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,6 +1,9 @@
 pub mod manager;
 pub mod registry;
 
+#[cfg(feature = "voice")]
+pub mod voice_echo;
+
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;

--- a/src/plugins/registry.rs
+++ b/src/plugins/registry.rs
@@ -16,7 +16,7 @@ pub fn known_plugins() -> Vec<RegistryEntry> {
             name: "voice-echo".to_string(),
             description: "Phone calls via Twilio (STT + TTS + voice pipeline)".to_string(),
             version: "0.1.0".to_string(),
-            available: false, // Not yet implemented
+            available: cfg!(feature = "voice"),
         },
         RegistryEntry {
             name: "discord-echo".to_string(),
@@ -41,12 +41,14 @@ pub fn find_plugin(name: &str) -> Option<RegistryEntry> {
 /// Factory function: create a plugin instance by name.
 /// Returns None if the plugin is not known or not yet implemented.
 pub fn create_plugin(name: &str) -> Option<Box<dyn Plugin>> {
-    // Plugins will be added here as they're implemented:
-    // "voice-echo" => Some(Box::new(voice_echo::VoiceEchoPlugin::new())),
-    // "discord-echo" => Some(Box::new(discord_echo::DiscordEchoPlugin::new())),
-    let _ = name; // suppress unused warning when no plugins exist
-    tracing::debug!("Plugin '{}' is not yet available", name);
-    None
+    match name {
+        #[cfg(feature = "voice")]
+        "voice-echo" => Some(Box::new(super::voice_echo::VoiceEchoPlugin::new())),
+        _ => {
+            tracing::debug!("Plugin '{}' is not available", name);
+            None
+        }
+    }
 }
 
 #[cfg(test)]
@@ -74,15 +76,25 @@ mod tests {
     }
 
     #[test]
-    fn test_create_plugin_not_available() {
-        // Known plugins exist but aren't implemented yet
+    fn test_create_voice_echo_plugin() {
         let plugin = create_plugin("voice-echo");
-        assert!(plugin.is_none());
+        if cfg!(feature = "voice") {
+            assert!(plugin.is_some());
+            assert_eq!(plugin.unwrap().meta().name, "voice-echo");
+        } else {
+            assert!(plugin.is_none());
+        }
     }
 
     #[test]
     fn test_create_unknown_plugin() {
         let plugin = create_plugin("totally-unknown");
         assert!(plugin.is_none());
+    }
+
+    #[test]
+    fn test_voice_echo_availability_matches_feature() {
+        let entry = find_plugin("voice-echo").unwrap();
+        assert_eq!(entry.available, cfg!(feature = "voice"));
     }
 }

--- a/src/plugins/voice_echo/config.rs
+++ b/src/plugins/voice_echo/config.rs
@@ -1,0 +1,168 @@
+use serde::Deserialize;
+
+/// Configuration for the voice-echo plugin.
+/// Deserialized from `[plugins.voice-echo]` in echo-system.toml.
+#[derive(Debug, Clone, Deserialize)]
+pub struct VoiceEchoConfig {
+    /// Host to bind the voice HTTP server to
+    #[serde(default = "default_host")]
+    pub host: String,
+
+    /// Port for the voice HTTP server (Twilio webhooks + internal API)
+    #[serde(default = "default_port")]
+    pub port: u16,
+
+    /// External URL where Twilio can reach this server (e.g. https://your-domain.com)
+    pub external_url: String,
+
+    /// Twilio Account SID
+    pub twilio_account_sid: String,
+
+    /// Twilio Auth Token
+    pub twilio_auth_token: String,
+
+    /// Twilio phone number (E.164 format)
+    pub twilio_phone_number: String,
+
+    /// Groq API key for Whisper STT
+    pub groq_api_key: String,
+
+    /// Inworld API key for TTS
+    pub inworld_api_key: String,
+
+    /// Inworld voice ID (e.g. "Olivia")
+    #[serde(default = "default_voice_id")]
+    pub inworld_voice_id: String,
+
+    /// Session timeout in seconds (cleanup inactive voice sessions)
+    #[serde(default = "default_session_timeout")]
+    pub session_timeout_secs: u64,
+
+    /// API token for authenticating outbound call requests
+    pub api_token: Option<String>,
+}
+
+impl VoiceEchoConfig {
+    /// Parse from a toml::Value (the plugin's config table)
+    pub fn from_toml(
+        value: &toml::Value,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let config: VoiceEchoConfig = value.clone().try_into().map_err(|e: toml::de::Error| {
+            Box::new(e) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn validate(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.external_url.is_empty() {
+            return Err("voice-echo: external_url is required".into());
+        }
+        if self.twilio_account_sid.is_empty() {
+            return Err("voice-echo: twilio_account_sid is required".into());
+        }
+        if self.twilio_auth_token.is_empty() {
+            return Err("voice-echo: twilio_auth_token is required".into());
+        }
+        if self.twilio_phone_number.is_empty() {
+            return Err("voice-echo: twilio_phone_number is required".into());
+        }
+        if self.groq_api_key.is_empty() {
+            return Err("voice-echo: groq_api_key is required".into());
+        }
+        if self.inworld_api_key.is_empty() {
+            return Err("voice-echo: inworld_api_key is required".into());
+        }
+        Ok(())
+    }
+}
+
+fn default_host() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_port() -> u16 {
+    8443
+}
+
+fn default_voice_id() -> String {
+    "Olivia".to_string()
+}
+
+fn default_session_timeout() -> u64 {
+    300
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_toml() -> toml::Value {
+        toml::Value::Table(toml::toml! {
+            external_url = "https://example.com"
+            twilio_account_sid = "ACtest123"
+            twilio_auth_token = "token123"
+            twilio_phone_number = "+15551234567"
+            groq_api_key = "gsk_test"
+            inworld_api_key = "iw_test"
+        })
+    }
+
+    #[test]
+    fn parse_valid_config() {
+        let config = VoiceEchoConfig::from_toml(&valid_toml()).unwrap();
+        assert_eq!(config.host, "0.0.0.0");
+        assert_eq!(config.port, 8443);
+        assert_eq!(config.external_url, "https://example.com");
+        assert_eq!(config.inworld_voice_id, "Olivia");
+        assert_eq!(config.session_timeout_secs, 300);
+        assert!(config.api_token.is_none());
+    }
+
+    #[test]
+    fn parse_with_overrides() {
+        let val = toml::Value::Table(toml::toml! {
+            host = "127.0.0.1"
+            port = 9443
+            external_url = "https://custom.com"
+            twilio_account_sid = "ACtest"
+            twilio_auth_token = "tok"
+            twilio_phone_number = "+1555"
+            groq_api_key = "gsk"
+            inworld_api_key = "iw"
+            inworld_voice_id = "Luna"
+            session_timeout_secs = 600
+            api_token = "secret"
+        });
+        let config = VoiceEchoConfig::from_toml(&val).unwrap();
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.port, 9443);
+        assert_eq!(config.inworld_voice_id, "Luna");
+        assert_eq!(config.session_timeout_secs, 600);
+        assert_eq!(config.api_token.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn missing_required_field() {
+        let val = toml::Value::Table(toml::toml! {
+            external_url = "https://example.com"
+        });
+        let result = VoiceEchoConfig::from_toml(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_required_field_fails_validation() {
+        let val = toml::Value::Table(toml::toml! {
+            external_url = ""
+            twilio_account_sid = "AC123"
+            twilio_auth_token = "tok"
+            twilio_phone_number = "+1555"
+            groq_api_key = "gsk"
+            inworld_api_key = "iw"
+        });
+        let result = VoiceEchoConfig::from_toml(&val);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("external_url"));
+    }
+}

--- a/src/plugins/voice_echo/mod.rs
+++ b/src/plugins/voice_echo/mod.rs
@@ -1,0 +1,299 @@
+pub mod config;
+
+use std::future::Future;
+use std::pin::Pin;
+
+use super::{Plugin, PluginContext, PluginHealth, PluginMeta, PluginResult, SetupPrompt};
+
+/// The voice-echo plugin: phone calls via Twilio with STT + LLM + TTS pipeline.
+///
+/// Lifecycle:
+/// - `init()`: parse config, build internal state
+/// - `start()`: spawn voice HTTP server on configured port
+/// - `stop()`: shutdown server, clean up sessions
+/// - `health()`: check STT/TTS/Twilio reachability
+///
+/// The voice server runs on its own port (default 8443) because Twilio webhooks
+/// need specific external URLs with different security characteristics than the
+/// main echo-system API.
+pub struct VoiceEchoPlugin {
+    config: Option<config::VoiceEchoConfig>,
+    started: bool,
+}
+
+impl VoiceEchoPlugin {
+    pub fn new() -> Self {
+        Self {
+            config: None,
+            started: false,
+        }
+    }
+}
+
+impl Plugin for VoiceEchoPlugin {
+    fn meta(&self) -> PluginMeta {
+        PluginMeta {
+            name: "voice-echo".to_string(),
+            version: "0.1.0".to_string(),
+            description: "Phone calls via Twilio (STT + TTS + voice pipeline)".to_string(),
+        }
+    }
+
+    fn init<'a>(
+        &'a mut self,
+        config: &'a toml::Value,
+        _ctx: &'a PluginContext,
+    ) -> PluginResult<'a> {
+        Box::pin(async move {
+            let voice_config = config::VoiceEchoConfig::from_toml(config)?;
+            tracing::info!(
+                "voice-echo: configured for {} on {}:{}",
+                voice_config.external_url,
+                voice_config.host,
+                voice_config.port
+            );
+            self.config = Some(voice_config);
+            Ok(())
+        })
+    }
+
+    fn start(&mut self) -> PluginResult<'_> {
+        Box::pin(async move {
+            let config = self.config.as_ref().ok_or("voice-echo: not initialized")?;
+            // TODO (PR 5): spawn voice HTTP server, load hold music, init STT/TTS clients
+            tracing::info!(
+                "voice-echo: starting on {}:{} (stub)",
+                config.host,
+                config.port
+            );
+            self.started = true;
+            Ok(())
+        })
+    }
+
+    fn stop(&mut self) -> PluginResult<'_> {
+        Box::pin(async move {
+            if self.started {
+                // TODO (PR 5): graceful shutdown — stop accepting calls, drain active sessions
+                tracing::info!("voice-echo: stopping (stub)");
+                self.started = false;
+            }
+            Ok(())
+        })
+    }
+
+    fn health(&self) -> Pin<Box<dyn Future<Output = PluginHealth> + Send + '_>> {
+        Box::pin(async move {
+            if !self.started {
+                return PluginHealth::Down("not started".to_string());
+            }
+            // TODO (PR 5): check STT/TTS/Twilio reachability
+            PluginHealth::Healthy
+        })
+    }
+
+    fn setup_prompts(&self) -> Vec<SetupPrompt> {
+        vec![
+            SetupPrompt {
+                key: "external_url".to_string(),
+                question:
+                    "External URL where Twilio can reach this server (e.g. https://your-domain.com)"
+                        .to_string(),
+                default: None,
+                required: true,
+                secret: false,
+            },
+            SetupPrompt {
+                key: "twilio_account_sid".to_string(),
+                question: "Twilio Account SID".to_string(),
+                default: None,
+                required: true,
+                secret: false,
+            },
+            SetupPrompt {
+                key: "twilio_auth_token".to_string(),
+                question: "Twilio Auth Token".to_string(),
+                default: None,
+                required: true,
+                secret: true,
+            },
+            SetupPrompt {
+                key: "twilio_phone_number".to_string(),
+                question: "Twilio phone number (E.164 format, e.g. +15551234567)".to_string(),
+                default: None,
+                required: true,
+                secret: false,
+            },
+            SetupPrompt {
+                key: "groq_api_key".to_string(),
+                question: "Groq API key (for Whisper STT)".to_string(),
+                default: None,
+                required: true,
+                secret: true,
+            },
+            SetupPrompt {
+                key: "inworld_api_key".to_string(),
+                question: "Inworld API key (for TTS)".to_string(),
+                default: None,
+                required: true,
+                secret: true,
+            },
+            SetupPrompt {
+                key: "inworld_voice_id".to_string(),
+                question: "Inworld voice ID".to_string(),
+                default: Some("Olivia".to_string()),
+                required: false,
+                secret: false,
+            },
+            SetupPrompt {
+                key: "api_token".to_string(),
+                question: "API token for authenticating outbound call requests".to_string(),
+                default: None,
+                required: false,
+                secret: true,
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use crate::llm::{LlmResponse, LlmResult, LmProvider, Message};
+
+    /// Minimal mock LmProvider for testing
+    struct MockProvider;
+
+    impl LmProvider for MockProvider {
+        fn invoke(
+            &self,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _max_tokens: u32,
+            _tools: Option<&[serde_json::Value]>,
+        ) -> LlmResult<'_> {
+            Box::pin(async {
+                Ok(LlmResponse {
+                    content: vec![],
+                    stop_reason: crate::llm::StopReason::EndTurn,
+                    model: "mock".to_string(),
+                    input_tokens: None,
+                    output_tokens: None,
+                })
+            })
+        }
+
+        fn name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    fn test_ctx() -> PluginContext {
+        PluginContext {
+            entity_root: PathBuf::from("/tmp/test-entity"),
+            entity_name: "TestEntity".to_string(),
+            provider: Arc::new(Box::new(MockProvider)),
+        }
+    }
+
+    fn valid_config() -> toml::Value {
+        toml::Value::Table(toml::toml! {
+            external_url = "https://example.com"
+            twilio_account_sid = "ACtest123"
+            twilio_auth_token = "token123"
+            twilio_phone_number = "+15551234567"
+            groq_api_key = "gsk_test"
+            inworld_api_key = "iw_test"
+        })
+    }
+
+    #[test]
+    fn meta_returns_correct_info() {
+        let plugin = VoiceEchoPlugin::new();
+        let meta = plugin.meta();
+        assert_eq!(meta.name, "voice-echo");
+        assert_eq!(meta.version, "0.1.0");
+    }
+
+    #[tokio::test]
+    async fn init_with_valid_config() {
+        let mut plugin = VoiceEchoPlugin::new();
+        let config = valid_config();
+        let ctx = test_ctx();
+        let result = plugin.init(&config, &ctx).await;
+        assert!(result.is_ok());
+        assert!(plugin.config.is_some());
+    }
+
+    #[tokio::test]
+    async fn init_with_invalid_config_fails() {
+        let mut plugin = VoiceEchoPlugin::new();
+        let config = toml::Value::Table(toml::toml! { host = "localhost" });
+        let ctx = test_ctx();
+        let result = plugin.init(&config, &ctx).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn lifecycle_start_stop() {
+        let mut plugin = VoiceEchoPlugin::new();
+        let config = valid_config();
+        let ctx = test_ctx();
+
+        plugin.init(&config, &ctx).await.unwrap();
+        assert!(!plugin.started);
+
+        plugin.start().await.unwrap();
+        assert!(plugin.started);
+
+        let health = plugin.health().await;
+        assert!(matches!(health, PluginHealth::Healthy));
+
+        plugin.stop().await.unwrap();
+        assert!(!plugin.started);
+
+        let health = plugin.health().await;
+        assert!(matches!(health, PluginHealth::Down(_)));
+    }
+
+    #[tokio::test]
+    async fn start_without_init_fails() {
+        let mut plugin = VoiceEchoPlugin::new();
+        let result = plugin.start().await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn setup_prompts_not_empty() {
+        let plugin = VoiceEchoPlugin::new();
+        let prompts = plugin.setup_prompts();
+        assert!(!prompts.is_empty());
+        // All required keys should be present
+        let keys: Vec<&str> = prompts.iter().map(|p| p.key.as_str()).collect();
+        assert!(keys.contains(&"external_url"));
+        assert!(keys.contains(&"twilio_account_sid"));
+        assert!(keys.contains(&"groq_api_key"));
+        assert!(keys.contains(&"inworld_api_key"));
+    }
+
+    #[test]
+    fn secret_fields_marked_correctly() {
+        let plugin = VoiceEchoPlugin::new();
+        let prompts = plugin.setup_prompts();
+        let secret_keys: Vec<&str> = prompts
+            .iter()
+            .filter(|p| p.secret)
+            .map(|p| p.key.as_str())
+            .collect();
+        assert!(secret_keys.contains(&"twilio_auth_token"));
+        assert!(secret_keys.contains(&"groq_api_key"));
+        assert!(secret_keys.contains(&"inworld_api_key"));
+        assert!(secret_keys.contains(&"api_token"));
+        // Non-secret fields should NOT be in this list
+        assert!(!secret_keys.contains(&"external_url"));
+        assert!(!secret_keys.contains(&"twilio_account_sid"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `VoiceEchoPlugin` struct implementing the `Plugin` trait with config parsing, setup prompts, and stub lifecycle methods (`init`, `start`, `stop`, `health`)
- Wire `voice-echo` in the plugin registry behind `#[cfg(feature = "voice")]` — `create_plugin("voice-echo")` returns `Some(...)` when compiled with `--features voice`
- Add `voice`, `discord` (depends on `voice`), and `all-plugins` feature flags to `Cargo.toml`
- `VoiceEchoConfig` deserializes from `[plugins.voice-echo]` TOML table with validation for all required fields (Twilio creds, Groq key, Inworld key, external URL)

## What this enables
First PR in the Phase 5 plugin port series. This is scaffolding only — no voice pipeline code yet. Future PRs will port audio processing, VAD, STT, TTS, LLM bridge, and Twilio integration into this plugin structure.

## Feature flag behavior
- `cargo install echo-system` → slim binary, voice-echo listed as "not available"
- `cargo install echo-system --features voice` → voice-echo available and configurable
- `cargo install echo-system --features all-plugins` → all plugins enabled

## Test plan
- [x] `cargo test` — 91 existing tests pass (no features)
- [x] `cargo test --features voice` — 102 tests pass (11 new: config parsing, lifecycle, setup prompts, registry wiring)
- [x] `cargo clippy --features voice -- -D warnings -A dead_code` — clean
- [x] `cargo fmt -- --check` — clean