### PR TITLE
feat: TUI Caliber tab — operational self-knowledge dashboard

### DIFF
--- a/src/tui/screens/main_screen.rs
+++ b/src/tui/screens/main_screen.rs
@@ -12,6 +12,7 @@ use crate::tui::tabs::comms::{CommsFooter, CommsTab};
 use crate::tui::tabs::entity::EntityTab;
 use crate::tui::tabs::evolution::EvolutionTab;
 use crate::tui::tabs::files::FilesTab;
+use crate::tui::tabs::caliber::CaliberTab;
 use crate::tui::tabs::recall::RecallTab;
 use crate::tui::tabs::{Tab, TabView};
 use crate::tui::theme::*;
@@ -25,6 +26,7 @@ pub struct MainScreen {
     pub files: FilesTab,
     pub comms: CommsTab,
     pub recall: RecallTab,
+    pub caliber: CaliberTab,
     pub fullscreen: bool,
     pub show_help: bool,
     pub multi_entity: bool,
@@ -40,6 +42,7 @@ impl MainScreen {
             files: FilesTab::new(),
             comms: CommsTab::new(entity_name),
             recall: RecallTab::new(),
+            caliber: CaliberTab::new(),
             fullscreen: false,
             show_help: false,
             multi_entity: false,
@@ -192,6 +195,9 @@ impl Screen for MainScreen {
             Tab::Recall => {
                 self.recall.render(frame, chunks[content_idx], ctx);
             }
+            Tab::Caliber => {
+                self.caliber.render(frame, chunks[content_idx], ctx);
+            }
         }
 
         // Footer hints
@@ -313,6 +319,16 @@ impl Screen for MainScreen {
                     Span::styled(" ? ", hint_style_key),
                     Span::styled(" Help ", hint_style_desc),
                 ],
+                Tab::Caliber => vec![
+                    Span::styled(" j/k ", hint_style_key),
+                    Span::styled(" Scroll  ", hint_style_desc),
+                    Span::styled(" r ", hint_style_key),
+                    Span::styled(" Refresh  ", hint_style_desc),
+                    Span::styled(" Tab ", hint_style_key),
+                    Span::styled(" Next tab  ", hint_style_desc),
+                    Span::styled(" ? ", hint_style_key),
+                    Span::styled(" Help ", hint_style_desc),
+                ],
             };
             frame.render_widget(Paragraph::new(Line::from(hints)), chunks[footer_idx]);
         }
@@ -389,6 +405,10 @@ impl Screen for MainScreen {
                     self.active_tab = Tab::Recall;
                     return ScreenAction::None;
                 }
+                KeyCode::Char('7') => {
+                    self.active_tab = Tab::Caliber;
+                    return ScreenAction::None;
+                }
                 // ? opens help (only when not typing)
                 KeyCode::Char('?') => {
                     self.show_help = true;
@@ -424,6 +444,7 @@ impl Screen for MainScreen {
             Tab::Files => self.files.handle_key(key, ctx),
             Tab::Comms => self.comms.handle_key(key, ctx),
             Tab::Recall => self.recall.handle_key(key, ctx),
+            Tab::Caliber => self.caliber.handle_key(key, ctx),
         }
     }
 
@@ -444,6 +465,7 @@ impl Screen for MainScreen {
         self.files.handle_tick(ctx);
         self.comms.handle_tick(ctx);
         self.recall.handle_tick(ctx);
+        self.caliber.handle_tick(ctx);
     }
 }
 

--- a/src/tui/tabs/caliber.rs
+++ b/src/tui/tabs/caliber.rs
@@ -44,6 +44,7 @@ pub struct CaliberTab {
 }
 
 const REFRESH_INTERVAL_SECS: u64 = 30;
+const VISIBLE_OUTCOMES: usize = 10;
 
 impl CaliberTab {
     pub fn new() -> Self {
@@ -64,7 +65,7 @@ impl CaliberTab {
     }
 
     pub fn scroll_down(&mut self, _amount: u16) {
-        let max = self.outcomes.len().saturating_sub(8);
+        let max = self.outcomes.len().saturating_sub(VISIBLE_OUTCOMES);
         if self.scroll_offset < max {
             self.scroll_offset += 1;
         }
@@ -107,13 +108,20 @@ impl CaliberTab {
 
     fn check_pending(&mut self) {
         if let Some(ref rx) = self.pending_load {
-            if let Ok(result) = rx.try_recv() {
-                self.caliber_doc = result.caliber_doc;
-                self.outcomes = result.outcomes;
-                self.today_outcomes = result.today_outcomes;
-                self.loaded = true;
-                self.pending_load = None;
-                self.last_refresh = std::time::Instant::now();
+            match rx.try_recv() {
+                Ok(result) => {
+                    self.caliber_doc = result.caliber_doc;
+                    self.outcomes = result.outcomes;
+                    self.today_outcomes = result.today_outcomes;
+                    self.loaded = true;
+                    self.pending_load = None;
+                    self.last_refresh = std::time::Instant::now();
+                }
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    // Sender dropped (panic or early exit) — clear and allow retry
+                    self.pending_load = None;
+                }
+                Err(mpsc::TryRecvError::Empty) => {} // still loading
             }
         }
     }
@@ -320,8 +328,8 @@ impl CaliberTab {
         }
 
         let visible_count = inner.height.saturating_sub(1) as usize; // -1 for header
-        let start = self.outcomes.len().saturating_sub(10 + self.scroll_offset);
-        let end = self.outcomes.len().saturating_sub(self.scroll_offset);
+        let end = self.outcomes.len().saturating_sub(self.scroll_offset).min(self.outcomes.len());
+        let start = end.saturating_sub(VISIBLE_OUTCOMES);
         let visible: Vec<&OutcomeRecord> = self.outcomes[start..end].iter().rev().collect();
 
         let header = Row::new(vec!["Time", "Domain", "Result", "Tokens"])
@@ -371,7 +379,8 @@ fn score_color(score: f64) -> ratatui::style::Color {
 }
 
 fn score_bar(score: f64, width: usize) -> String {
-    let filled = (score * width as f64).round() as usize;
+    let clamped = score.clamp(0.0, 1.0);
+    let filled = (clamped * width as f64).round() as usize;
     let empty = width.saturating_sub(filled);
     format!("{}{}", "█".repeat(filled), "░".repeat(empty))
 }

--- a/src/tui/tabs/caliber.rs
+++ b/src/tui/tabs/caliber.rs
@@ -13,10 +13,9 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Paragraph, Row, Table};
 use ratatui::Frame;
 
-use crate::caliber::document::{self, CaliberDocument, CapabilityEntry};
+use crate::caliber::document::{self, CaliberDocument};
 use crate::caliber::outcome::{Outcome, OutcomeRecord};
 use crate::caliber::runtime;
-use crate::caliber::state::CaliberState;
 use crate::tui::app::AppContext;
 use crate::tui::screens::ScreenAction;
 use crate::tui::theme::*;
@@ -171,13 +170,17 @@ impl TabView for CaliberTab {
     fn handle_key(&mut self, key: KeyEvent, ctx: &mut AppContext) -> ScreenAction {
         match key.code {
             KeyCode::Char('r') => {
-                self.start_load(&ctx.root_dir);
+                if let Some(ref root) = ctx.root_dir {
+                    if self.pending_load.is_none() {
+                        self.start_load(root);
+                    }
+                }
             }
             KeyCode::Char('j') | KeyCode::Down => self.scroll_down(1),
             KeyCode::Char('k') | KeyCode::Up => self.scroll_up(1),
             _ => {}
         }
-        ScreenAction::Continue
+        ScreenAction::None
     }
 
     fn handle_tick(&mut self, ctx: &mut AppContext) {
@@ -185,14 +188,18 @@ impl TabView for CaliberTab {
 
         // Auto-load on first tick
         if !self.loaded && self.pending_load.is_none() {
-            self.start_load(&ctx.root_dir);
+            if let Some(ref root) = ctx.root_dir {
+                self.start_load(root);
+            }
         }
 
         // Auto-refresh
         if self.last_refresh.elapsed().as_secs() >= REFRESH_INTERVAL_SECS
             && self.pending_load.is_none()
         {
-            self.start_load(&ctx.root_dir);
+            if let Some(ref root) = ctx.root_dir {
+                self.start_load(root);
+            }
         }
     }
 }
@@ -278,11 +285,16 @@ impl CaliberTab {
         }
 
         let total = self.today_outcomes.len();
-        let success = self.today_outcomes.iter().filter(|o| o.outcome == Outcome::Success).count();
-        let partial = self.today_outcomes.iter().filter(|o| o.outcome == Outcome::Partial).count();
-        let failed = self.today_outcomes.iter().filter(|o| o.outcome == Outcome::Failed).count();
-        let surprising = self.today_outcomes.iter().filter(|o| o.outcome == Outcome::Surprising).count();
-        let tokens: u32 = self.today_outcomes.iter().map(|o| o.tokens_used).sum();
+        let (mut success, mut partial, mut failed, mut surprising, mut tokens) = (0, 0, 0, 0, 0u32);
+        for o in &self.today_outcomes {
+            match o.outcome {
+                Outcome::Success => success += 1,
+                Outcome::Partial => partial += 1,
+                Outcome::Failed => failed += 1,
+                Outcome::Surprising => surprising += 1,
+            }
+            tokens = tokens.saturating_add(o.tokens_used);
+        }
         let success_rate = if total > 0 { success as f64 / total as f64 * 100.0 } else { 0.0 };
 
         let lines = vec![

--- a/src/tui/tabs/caliber.rs
+++ b/src/tui/tabs/caliber.rs
@@ -1,0 +1,386 @@
+//! Caliber tab — operational self-knowledge visualization.
+//!
+//! Shows capability scores, outcome history, prediction errors,
+//! and today's performance summary. Phase 1: Overview only.
+
+use std::path::Path;
+use std::sync::mpsc;
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Paragraph, Row, Table};
+use ratatui::Frame;
+
+use crate::caliber::document::{self, CaliberDocument, CapabilityEntry};
+use crate::caliber::outcome::{Outcome, OutcomeRecord};
+use crate::caliber::runtime;
+use crate::caliber::state::CaliberState;
+use crate::tui::app::AppContext;
+use crate::tui::screens::ScreenAction;
+use crate::tui::theme::*;
+
+use super::TabView;
+
+// ─── Background load result ───
+
+struct CaliberLoadResult {
+    caliber_doc: Option<CaliberDocument>,
+    outcomes: Vec<OutcomeRecord>,
+    today_outcomes: Vec<OutcomeRecord>,
+}
+
+// ─── Caliber Tab ───
+
+pub struct CaliberTab {
+    caliber_doc: Option<CaliberDocument>,
+    outcomes: Vec<OutcomeRecord>,
+    today_outcomes: Vec<OutcomeRecord>,
+    loaded: bool,
+    scroll_offset: usize,
+    pending_load: Option<mpsc::Receiver<CaliberLoadResult>>,
+    last_refresh: std::time::Instant,
+}
+
+const REFRESH_INTERVAL_SECS: u64 = 30;
+
+impl CaliberTab {
+    pub fn new() -> Self {
+        Self {
+            caliber_doc: None,
+            outcomes: Vec::new(),
+            today_outcomes: Vec::new(),
+            loaded: false,
+            scroll_offset: 0,
+            pending_load: None,
+            last_refresh: std::time::Instant::now()
+                - std::time::Duration::from_secs(REFRESH_INTERVAL_SECS + 1),
+        }
+    }
+
+    pub fn scroll_up(&mut self, _amount: u16) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(1);
+    }
+
+    pub fn scroll_down(&mut self, _amount: u16) {
+        let max = self.outcomes.len().saturating_sub(8);
+        if self.scroll_offset < max {
+            self.scroll_offset += 1;
+        }
+    }
+
+    fn start_load(&mut self, root_dir: &Path) {
+        let root = root_dir.to_path_buf();
+        let (tx, rx) = mpsc::channel();
+        self.pending_load = Some(rx);
+
+        #[allow(clippy::let_underscore_future)]
+        let _ = tokio::task::spawn_blocking(move || {
+            let outcomes = runtime::load_outcomes(&root);
+
+            // Parse CALIBER.md if it exists
+            let caliber_path = root.join("caliber").join("CALIBER.md");
+            let caliber_doc = if caliber_path.exists() {
+                std::fs::read_to_string(&caliber_path)
+                    .ok()
+                    .map(|content| document::parse_caliber_md(&content))
+            } else {
+                None
+            };
+
+            // Filter today's outcomes
+            let today = chrono::Utc::now().date_naive();
+            let today_outcomes: Vec<OutcomeRecord> = outcomes
+                .iter()
+                .filter(|o| o.timestamp.date_naive() == today)
+                .cloned()
+                .collect();
+
+            let _ = tx.send(CaliberLoadResult {
+                caliber_doc,
+                outcomes,
+                today_outcomes,
+            });
+        });
+    }
+
+    fn check_pending(&mut self) {
+        if let Some(ref rx) = self.pending_load {
+            if let Ok(result) = rx.try_recv() {
+                self.caliber_doc = result.caliber_doc;
+                self.outcomes = result.outcomes;
+                self.today_outcomes = result.today_outcomes;
+                self.loaded = true;
+                self.pending_load = None;
+                self.last_refresh = std::time::Instant::now();
+            }
+        }
+    }
+}
+
+impl TabView for CaliberTab {
+    fn render(&self, frame: &mut Frame, area: Rect, _ctx: &AppContext) {
+        if !self.loaded {
+            let msg = Paragraph::new("Loading caliber data...")
+                .style(Style::default().fg(NORD4))
+                .block(
+                    Block::bordered()
+                        .border_type(BorderType::Rounded)
+                        .border_style(Style::default().fg(NORD3)),
+                );
+            frame.render_widget(msg, area);
+            return;
+        }
+
+        if self.outcomes.is_empty() && self.caliber_doc.is_none() {
+            let msg = Paragraph::new(
+                "No caliber data yet. Outcomes are recorded as the entity runs tasks and conversations.",
+            )
+            .style(Style::default().fg(NORD4))
+            .block(
+                Block::bordered()
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(NORD3)),
+            );
+            frame.render_widget(msg, area);
+            return;
+        }
+
+        // Layout: Capability Map (40%), Today (20%), Recent Outcomes (40%)
+        let chunks = Layout::vertical([
+            Constraint::Percentage(40),
+            Constraint::Percentage(20),
+            Constraint::Percentage(40),
+        ])
+        .split(area);
+
+        self.render_capability_map(frame, chunks[0]);
+        self.render_today_summary(frame, chunks[1]);
+        self.render_recent_outcomes(frame, chunks[2]);
+    }
+
+    fn handle_key(&mut self, key: KeyEvent, ctx: &mut AppContext) -> ScreenAction {
+        match key.code {
+            KeyCode::Char('r') => {
+                self.start_load(&ctx.root_dir);
+            }
+            KeyCode::Char('j') | KeyCode::Down => self.scroll_down(1),
+            KeyCode::Char('k') | KeyCode::Up => self.scroll_up(1),
+            _ => {}
+        }
+        ScreenAction::Continue
+    }
+
+    fn handle_tick(&mut self, ctx: &mut AppContext) {
+        self.check_pending();
+
+        // Auto-load on first tick
+        if !self.loaded && self.pending_load.is_none() {
+            self.start_load(&ctx.root_dir);
+        }
+
+        // Auto-refresh
+        if self.last_refresh.elapsed().as_secs() >= REFRESH_INTERVAL_SECS
+            && self.pending_load.is_none()
+        {
+            self.start_load(&ctx.root_dir);
+        }
+    }
+}
+
+// ─── Rendering helpers ───
+
+impl CaliberTab {
+    fn render_capability_map(&self, frame: &mut Frame, area: Rect) {
+        let block = Block::bordered()
+            .title(Line::from(vec![
+                Span::styled(" Capability Map ", Style::default().fg(NORD8).add_modifier(Modifier::BOLD)),
+            ]))
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(NORD3));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if let Some(ref doc) = self.caliber_doc {
+            if doc.capabilities.is_empty() {
+                let msg = Paragraph::new("No capabilities scored yet. Run trajectory mining.")
+                    .style(Style::default().fg(NORD4));
+                frame.render_widget(msg, inner);
+                return;
+            }
+
+            let header = Row::new(vec!["Domain", "Score", "Bar", "Samples", "Last Calibrated"])
+                .style(Style::default().fg(NORD8).add_modifier(Modifier::BOLD));
+
+            let rows: Vec<Row> = doc
+                .capabilities
+                .iter()
+                .map(|cap| {
+                    let color = score_color(cap.confidence);
+                    let bar = score_bar(cap.confidence, 15);
+                    Row::new(vec![
+                        cap.domain.clone(),
+                        format!("{:.2}", cap.confidence),
+                        bar,
+                        format!("{}", cap.sample_count),
+                        cap.last_calibrated.clone(),
+                    ])
+                    .style(Style::default().fg(color))
+                })
+                .collect();
+
+            let table = Table::new(
+                rows,
+                [
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(10),
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(15),
+                    Constraint::Percentage(25),
+                ],
+            )
+            .header(header);
+
+            frame.render_widget(table, inner);
+        } else {
+            let msg = Paragraph::new("CALIBER.md not found. Run trajectory mining to generate capability scores.")
+                .style(Style::default().fg(NORD4));
+            frame.render_widget(msg, inner);
+        }
+    }
+
+    fn render_today_summary(&self, frame: &mut Frame, area: Rect) {
+        let block = Block::bordered()
+            .title(Line::from(vec![
+                Span::styled(" Today ", Style::default().fg(NORD13).add_modifier(Modifier::BOLD)),
+            ]))
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(NORD3));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if self.today_outcomes.is_empty() {
+            let msg = Paragraph::new("No activity recorded today.")
+                .style(Style::default().fg(NORD4));
+            frame.render_widget(msg, inner);
+            return;
+        }
+
+        let total = self.today_outcomes.len();
+        let success = self.today_outcomes.iter().filter(|o| o.outcome == Outcome::Success).count();
+        let partial = self.today_outcomes.iter().filter(|o| o.outcome == Outcome::Partial).count();
+        let failed = self.today_outcomes.iter().filter(|o| o.outcome == Outcome::Failed).count();
+        let surprising = self.today_outcomes.iter().filter(|o| o.outcome == Outcome::Surprising).count();
+        let tokens: u32 = self.today_outcomes.iter().map(|o| o.tokens_used).sum();
+        let success_rate = if total > 0 { success as f64 / total as f64 * 100.0 } else { 0.0 };
+
+        let lines = vec![
+            Line::from(vec![
+                Span::styled(format!("{total} outcomes"), Style::default().fg(NORD4)),
+                Span::raw("  "),
+                Span::styled(format!("{success_rate:.0}% success"), Style::default().fg(NORD14)),
+                Span::raw("  "),
+                Span::styled(format!("{tokens} tokens"), Style::default().fg(NORD4)),
+            ]),
+            Line::from(vec![
+                Span::styled(format!("{success} "), Style::default().fg(NORD14)),
+                Span::styled("success  ", Style::default().fg(NORD4)),
+                Span::styled(format!("{partial} "), Style::default().fg(NORD13)),
+                Span::styled("partial  ", Style::default().fg(NORD4)),
+                Span::styled(format!("{failed} "), Style::default().fg(NORD11)),
+                Span::styled("failed  ", Style::default().fg(NORD4)),
+                Span::styled(format!("{surprising} "), Style::default().fg(NORD15)),
+                Span::styled("surprising", Style::default().fg(NORD4)),
+            ]),
+        ];
+
+        let paragraph = Paragraph::new(lines);
+        frame.render_widget(paragraph, inner);
+    }
+
+    fn render_recent_outcomes(&self, frame: &mut Frame, area: Rect) {
+        let block = Block::bordered()
+            .title(Line::from(vec![
+                Span::styled(" Recent Outcomes ", Style::default().fg(NORD9).add_modifier(Modifier::BOLD)),
+            ]))
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(NORD3));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        if self.outcomes.is_empty() {
+            let msg = Paragraph::new("No outcomes recorded yet.")
+                .style(Style::default().fg(NORD4));
+            frame.render_widget(msg, inner);
+            return;
+        }
+
+        let visible_count = inner.height.saturating_sub(1) as usize; // -1 for header
+        let start = self.outcomes.len().saturating_sub(10 + self.scroll_offset);
+        let end = self.outcomes.len().saturating_sub(self.scroll_offset);
+        let visible: Vec<&OutcomeRecord> = self.outcomes[start..end].iter().rev().collect();
+
+        let header = Row::new(vec!["Time", "Domain", "Result", "Tokens"])
+            .style(Style::default().fg(NORD8).add_modifier(Modifier::BOLD));
+
+        let rows: Vec<Row> = visible
+            .iter()
+            .take(visible_count)
+            .map(|o| {
+                let time = o.timestamp.format("%m-%d %H:%M").to_string();
+                let (icon, color) = outcome_display(&o.outcome);
+                Row::new(vec![
+                    time,
+                    o.domain.clone(),
+                    icon.to_string(),
+                    format!("{}", o.tokens_used),
+                ])
+                .style(Style::default().fg(color))
+            })
+            .collect();
+
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Percentage(25),
+                Constraint::Percentage(30),
+                Constraint::Percentage(20),
+                Constraint::Percentage(25),
+            ],
+        )
+        .header(header);
+
+        frame.render_widget(table, inner);
+    }
+}
+
+// ─── Display helpers ───
+
+fn score_color(score: f64) -> ratatui::style::Color {
+    if score >= 0.8 {
+        NORD14 // green
+    } else if score >= 0.5 {
+        NORD13 // yellow
+    } else {
+        NORD11 // red
+    }
+}
+
+fn score_bar(score: f64, width: usize) -> String {
+    let filled = (score * width as f64).round() as usize;
+    let empty = width.saturating_sub(filled);
+    format!("{}{}", "█".repeat(filled), "░".repeat(empty))
+}
+
+fn outcome_display(outcome: &Outcome) -> (&str, ratatui::style::Color) {
+    match outcome {
+        Outcome::Success => ("✓ success", NORD14),
+        Outcome::Partial => ("◐ partial", NORD13),
+        Outcome::Failed => ("✗ failed", NORD11),
+        Outcome::Surprising => ("? surprising", NORD15),
+    }
+}

--- a/src/tui/tabs/mod.rs
+++ b/src/tui/tabs/mod.rs
@@ -1,3 +1,4 @@
+pub mod caliber;
 pub mod chat;
 pub mod comms;
 pub mod entity;
@@ -20,6 +21,7 @@ pub enum Tab {
     Files,
     Comms,
     Recall,
+    Caliber,
 }
 
 impl Tab {
@@ -31,6 +33,7 @@ impl Tab {
             Tab::Files => 3,
             Tab::Comms => 4,
             Tab::Recall => 5,
+            Tab::Caliber => 6,
         }
     }
 
@@ -42,6 +45,7 @@ impl Tab {
             3 => Tab::Files,
             4 => Tab::Comms,
             5 => Tab::Recall,
+            6 => Tab::Caliber,
             _ => Tab::Chat,
         }
     }
@@ -54,10 +58,11 @@ impl Tab {
             Tab::Files => "files",
             Tab::Comms => "comms",
             Tab::Recall => "recall",
+            Tab::Caliber => "caliber",
         }
     }
 
-    pub const COUNT: usize = 6;
+    pub const COUNT: usize = 7;
 }
 
 pub trait TabView {


### PR DESCRIPTION
## Summary
- New 7th TUI tab (key: 7) showing capability scores, today's outcome summary, and recent outcomes
- Background loading from local JSON/markdown (no SurrealDB queries)
- Scrollable outcomes list, color-coded scores, empty states
- Audit fixes: stuck load recovery, scroll safety, compilation fixes

## Test plan
- [ ] Verify tab renders with no caliber data (empty state)
- [ ] Verify tab renders with outcomes.json and CALIBER.md present
- [ ] Verify scroll works correctly at boundaries
- [ ] Verify background refresh doesn't block TUI
- [ ] Verify key 7 switches to caliber tab