### PR TITLE
fix(tui): route tracing to log file in TUI modes

### DIFF
--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -9,11 +9,12 @@ use crate::tools::ToolRegistry;
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
 
-    let provider = providers::create_streaming_provider(&config)?;
-    let provider: Arc<dyn crate::streaming::StreamingProvider> = Arc::from(provider);
-
     // Build system prompt from identity documents
     let root_dir = config.root_dir()?;
+    crate::cli::init_file_tracing(&root_dir);
+
+    let provider = providers::create_streaming_provider(&config)?;
+    let provider: Arc<dyn crate::streaming::StreamingProvider> = Arc::from(provider);
     let system_prompt = prompt::build_system_prompt(&root_dir, &config, None, None)?;
 
     // Initialize session store for TUI persistence (with identity for key migration)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,3 +12,45 @@ pub mod schedule;
 pub mod status;
 pub mod up;
 pub mod vigil;
+
+use std::io;
+use std::path::Path;
+use std::sync::Mutex;
+
+use tracing_subscriber::fmt::writer::BoxMakeWriter;
+use tracing_subscriber::EnvFilter;
+
+fn env_filter() -> EnvFilter {
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| "pulse_null=info".into())
+}
+
+/// Standard stdout tracing for non-interactive CLI commands.
+pub fn init_stdout_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter())
+        .init();
+}
+
+/// File-backed tracing for TUI commands. Logs land in `<log_dir>/logs/pulse-null.log`
+/// so they don't bleed onto the alternate screen and corrupt ratatui's render.
+/// Falls back to a sink (discards output) if the file can't be opened.
+pub fn init_file_tracing(log_dir: &Path) {
+    let logs_dir = log_dir.join("logs");
+    let _ = std::fs::create_dir_all(&logs_dir);
+    let log_path = logs_dir.join("pulse-null.log");
+
+    let writer: BoxMakeWriter = match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+    {
+        Ok(file) => BoxMakeWriter::new(Mutex::new(file)),
+        Err(_) => BoxMakeWriter::new(io::sink),
+    };
+
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter())
+        .with_ansi(false)
+        .with_writer(writer)
+        .init();
+}

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -28,10 +28,11 @@ async fn run_single_entity(headless: bool) -> Result<(), Box<dyn std::error::Err
         return server::start(config).await;
     }
 
+    let root_dir = config.root_dir()?;
+    crate::cli::init_file_tracing(&root_dir);
+
     let provider = crate::providers::create_streaming_provider(&config)?;
     let provider: Arc<dyn crate::streaming::StreamingProvider> = Arc::from(provider);
-
-    let root_dir = config.root_dir()?;
     let system_prompt = crate::server::prompt::build_system_prompt(&root_dir, &config, None, None)?;
 
     let mut tools = crate::tools::ToolRegistry::new();
@@ -65,6 +66,10 @@ async fn run_multi_entity(
     headless: bool,
     entity_home: PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if !headless {
+        crate::cli::init_file_tracing(&entity_home);
+    }
+
     let discovered = crate::discovery::discover_entities(&entity_home);
 
     tracing::info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,14 +271,17 @@ enum ArchiveAction {
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "pulse_null=info".into()),
-        )
-        .init();
-
     let cli = Cli::parse();
+
+    // TUI commands defer tracing init to their handler so logs land in a file
+    // instead of bleeding onto the alternate screen. Everything else gets stdout.
+    let tui_mode = matches!(
+        &cli.command,
+        Commands::Chat | Commands::Up { headless: false }
+    );
+    if !tui_mode {
+        cli::init_stdout_tracing();
+    }
 
     match cli.command {
         Commands::Init { dir } => {


### PR DESCRIPTION
## Summary
- Stdout tracing was bleeding onto the ratatui alternate screen, corrupting renders in `chat` and interactive `up`.
- Splits tracing init into `init_stdout_tracing` (default CLI) and `init_file_tracing` (TUI). TUI logs land in `<root>/logs/pulse-null.log`.
- `main` detects TUI commands (`Chat`, `Up { headless: false }`) and skips stdout init; the TUI handlers initialize the file writer themselves once they know their entity root.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -A dead_code` (matches CI)
- [x] `cargo build` (default features)
- [ ] CI: `cargo test` + `cargo build --release`
- [ ] Manual: `pulse-null chat` — render is clean, logs accumulate in `<root>/logs/pulse-null.log`
- [ ] Manual: `pulse-null up` (interactive) — same
- [ ] Manual: `pulse-null up --headless` — logs still go to stdout (server mode unchanged)