### PR TITLE
chore(PN-69): audit MEDIUMs cleanup

### DIFF
--- a/src/prediction/integration_tests.rs
+++ b/src/prediction/integration_tests.rs
@@ -42,14 +42,14 @@ async fn round_trip_predict_resolve_via_markers() {
         r#"Working...
         [RESOLVE:{{"id":"{prediction_id}","outcome":"got pulled into async IO instead","surprise":0.6,"direction":"misdirected","insight":"caliber dragged me sideways"}}]"#
     );
-    let new_errors =
+    let new_error_count =
         process_task_output(&mut reloaded, &resolve_output, "task-2", Timescale::Cycle);
 
     // Step 4: persist and verify final state.
     save_async(root.clone(), reloaded).await.unwrap();
     let final_state = load_async(root.clone(), config).await;
 
-    assert_eq!(new_errors.len(), 1);
+    assert_eq!(new_error_count, 1);
     assert_eq!(final_state.predictions.len(), 1);
     assert!(!final_state.predictions[0].is_pending());
     assert_eq!(final_state.errors.len(), 1);

--- a/src/prediction/mod.rs
+++ b/src/prediction/mod.rs
@@ -324,58 +324,47 @@ impl PredictionStack {
     /// Prune the stack to stay within size limits.
     ///
     /// Keeps the most recent predictions and errors, dropping the oldest
-    /// resolved predictions and processed errors first.
+    /// resolved predictions and processed errors first. Pending predictions
+    /// and unprocessed errors are always kept (even if their count alone
+    /// exceeds the cap); insertion order is preserved within each group
+    /// thanks to the stable sort.
+    ///
+    /// (M3: rewritten in-place — was double-cloning the stack via two
+    /// `filter().cloned().collect()` passes per side.)
     pub fn prune(&mut self, max_predictions: usize, max_errors: usize) {
         if self.predictions.len() > max_predictions {
-            // Partition: pending predictions are always kept; resolved ones are pruned oldest-first
-            let mut pending: Vec<Prediction> = self
+            // Stable sort: pending first (insertion order), resolved after
+            // (newest first within resolved). Equal-key elements keep their
+            // relative order so pending entries don't get reshuffled.
+            self.predictions.sort_by(|a, b| {
+                match (a.is_pending(), b.is_pending()) {
+                    (true, false) => std::cmp::Ordering::Less,
+                    (false, true) => std::cmp::Ordering::Greater,
+                    (false, false) => b.created_at.cmp(&a.created_at), // newest first among resolved
+                    (true, true) => std::cmp::Ordering::Equal,         // preserve insertion order
+                }
+            });
+            let pending_count = self
                 .predictions
                 .iter()
-                .filter(|p| p.is_pending())
-                .cloned()
-                .collect();
-            let mut resolved: Vec<Prediction> = self
-                .predictions
-                .iter()
-                .filter(|p| !p.is_pending())
-                .cloned()
-                .collect();
-
-            // Sort resolved by created_at descending (newest first)
-            resolved.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-
-            // Keep as many resolved as we can after reserving space for pending
-            let resolved_budget = max_predictions.saturating_sub(pending.len());
-            resolved.truncate(resolved_budget);
-
-            pending.extend(resolved);
-            self.predictions = pending;
+                .take_while(|p| p.is_pending())
+                .count();
+            let target = max_predictions.max(pending_count);
+            self.predictions.truncate(target);
         }
 
         if self.errors.len() > max_errors {
-            // Partition: unprocessed errors are always kept; processed ones are pruned oldest-first
-            let mut unprocessed: Vec<PredictionError> = self
-                .errors
-                .iter()
-                .filter(|e| !e.processed)
-                .cloned()
-                .collect();
-            let mut processed: Vec<PredictionError> = self
-                .errors
-                .iter()
-                .filter(|e| e.processed)
-                .cloned()
-                .collect();
-
-            // Sort processed by created_at descending (newest first)
-            processed.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-
-            // Keep as many processed as we can after reserving space for unprocessed
-            let processed_budget = max_errors.saturating_sub(unprocessed.len());
-            processed.truncate(processed_budget);
-
-            unprocessed.extend(processed);
-            self.errors = unprocessed;
+            // Unprocessed first (insertion order); processed after (newest
+            // first). Same stable-sort trick — preserves order of equal keys.
+            self.errors.sort_by(|a, b| match (a.processed, b.processed) {
+                (false, true) => std::cmp::Ordering::Less,
+                (true, false) => std::cmp::Ordering::Greater,
+                (true, true) => b.created_at.cmp(&a.created_at), // newest first among processed
+                (false, false) => std::cmp::Ordering::Equal,     // preserve insertion order
+            });
+            let unprocessed_count = self.errors.iter().take_while(|e| !e.processed).count();
+            let target = max_errors.max(unprocessed_count);
+            self.errors.truncate(target);
         }
     }
 

--- a/src/prediction/mod.rs
+++ b/src/prediction/mod.rs
@@ -175,17 +175,51 @@ pub struct PredictionError {
 /// This is the main data structure for the prediction engine. It accumulates
 /// predictions from cognitive cycles, tracks their resolution, and surfaces
 /// high-surprise errors for the attention system to consume.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+///
+/// Not directly `Serialize`/`Deserialize`. The on-disk format is
+/// [`PredictionStackSnapshot`] — `config` lives in `pulse-null.toml`, not
+/// the per-entity JSON snapshot, so any deserializer that produced a
+/// `PredictionStack` directly would silently default the config and
+/// quietly drift away from `Config::prediction` (M7).
+#[derive(Debug, Clone, Default)]
 pub struct PredictionStack {
     /// All predictions (pending and resolved).
     pub predictions: Vec<Prediction>,
     /// Prediction errors generated from high-surprise resolutions.
     pub errors: Vec<PredictionError>,
     /// Calibration knobs (thresholds, caps) — loaded from `Config::prediction`.
-    /// `#[serde(skip)]` because config lives in `pulse-null.toml`, not the
-    /// per-entity `predictions.json` snapshot; reload from `Config` on boot.
-    #[serde(skip)]
     pub config: PredictionConfig,
+}
+
+/// On-disk format for the prediction stack — predictions and errors only.
+/// `PredictionStack::config` is intentionally not serialized; the loader
+/// rehydrates it from the live `PredictionConfig`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PredictionStackSnapshot {
+    pub predictions: Vec<Prediction>,
+    pub errors: Vec<PredictionError>,
+}
+
+impl PredictionStackSnapshot {
+    /// Build the on-disk snapshot view of a stack (borrowed clone — cheap
+    /// for typical stack sizes capped by `PredictionConfig::max_*`).
+    pub fn from_stack(stack: &PredictionStack) -> Self {
+        Self {
+            predictions: stack.predictions.clone(),
+            errors: stack.errors.clone(),
+        }
+    }
+
+    /// Promote a deserialized snapshot into a runtime `PredictionStack`,
+    /// stamped with the entity's live `PredictionConfig`.
+    #[must_use]
+    pub fn into_stack(self, config: PredictionConfig) -> PredictionStack {
+        PredictionStack {
+            predictions: self.predictions,
+            errors: self.errors,
+            config,
+        }
+    }
 }
 
 impl PredictionStack {
@@ -698,8 +732,11 @@ mod tests {
         assert_eq!(ErrorDirection::from_str_loose("unknown"), None);
     }
 
+    /// Snapshot is the only thing that round-trips via JSON; `PredictionStack`
+    /// itself no longer derives Serialize/Deserialize so that callers can't
+    /// silently get a default config (M7).
     #[test]
-    fn serde_roundtrip() {
+    fn snapshot_roundtrip_preserves_predictions_and_errors() {
         let mut stack = PredictionStack::new();
         let id = stack
             .add_prediction(Timescale::Session, "will it rain".to_string(), 0.6)
@@ -715,11 +752,23 @@ mod tests {
             },
         );
 
-        let json = serde_json::to_string_pretty(&stack).unwrap();
-        let deserialized: PredictionStack = serde_json::from_str(&json).unwrap();
+        let snapshot = PredictionStackSnapshot::from_stack(&stack);
+        let json = serde_json::to_string_pretty(&snapshot).unwrap();
+        let deserialized: PredictionStackSnapshot = serde_json::from_str(&json).unwrap();
 
+        // Snapshot carries predictions + errors only — no config field.
+        assert!(!json.contains("\"config\""));
         assert_eq!(deserialized.predictions.len(), 1);
         assert_eq!(deserialized.errors.len(), 1);
         assert_eq!(deserialized.predictions[0].id, id);
+
+        // Rehydrating into a stack uses the caller-supplied config —
+        // never the default just because the file didn't contain one.
+        let custom = PredictionConfig {
+            surprise_threshold: 0.95,
+            ..PredictionConfig::default()
+        };
+        let restored = deserialized.into_stack(custom);
+        assert!((restored.config.surprise_threshold - 0.95).abs() < f64::EPSILON);
     }
 }

--- a/src/prediction/mod.rs
+++ b/src/prediction/mod.rs
@@ -368,13 +368,20 @@ impl PredictionStack {
         }
     }
 
-    /// Get the most recent prediction errors, regardless of processed state.
+    /// Get the most recent prediction errors by `created_at`, regardless
+    /// of processed state. Returns at most `count` items, newest first.
     ///
-    /// Useful for injecting recent prediction error context into prompts.
+    /// (M6: previously returned `&self.errors[len-count..]` — the tail of
+    /// the Vec — which was insertion-order until `prune` reordered the
+    /// processed errors. After a prune the tail wasn't necessarily the
+    /// time-newest entries. Now sorts by `created_at` descending and
+    /// borrows the chosen entries into a `Vec<&PredictionError>`.)
     #[must_use]
-    pub fn recent_errors(&self, count: usize) -> &[PredictionError] {
-        let start = self.errors.len().saturating_sub(count);
-        &self.errors[start..]
+    pub fn recent_errors(&self, count: usize) -> Vec<&PredictionError> {
+        let mut by_recency: Vec<&PredictionError> = self.errors.iter().collect();
+        by_recency.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        by_recency.truncate(count);
+        by_recency
     }
 }
 

--- a/src/prediction/resolve.rs
+++ b/src/prediction/resolve.rs
@@ -17,7 +17,7 @@ use regex::Regex;
 use serde::Deserialize;
 use std::sync::LazyLock;
 
-use super::{ErrorDirection, PredictionError, PredictionResolution, PredictionStack, Timescale};
+use super::{ErrorDirection, PredictionResolution, PredictionStack, Timescale};
 
 /// A prediction parsed from a `[PREDICT:{...}]` marker.
 #[derive(Debug, Clone)]
@@ -252,78 +252,90 @@ pub fn parse_resolutions(text: &str) -> Vec<ParsedResolution> {
 
 /// Process a task's output: extract new predictions, resolve existing ones.
 ///
-/// This is the main entry point for integrating predictions into the cognitive cycle.
-/// It parses both `[PREDICT:...]` and `[RESOLVE:...]` markers from the task output,
-/// adds new predictions to the stack, resolves existing ones, and returns any
-/// new `PredictionError`s that were generated. The surprise cutoff for promoting
-/// a resolution into a `PredictionError` is `stack.config.surprise_threshold`.
+/// Parses `[PREDICT:...]` and `[RESOLVE:...]` markers from `task_output`,
+/// adds new predictions to the stack and applies resolutions. Returns the
+/// **number** of new `PredictionError`s created during this call — callers
+/// can inspect the actual errors via `stack.errors` if they need details.
+///
+/// (M4: previously returned `Vec<PredictionError>` by cloning the new
+/// errors out of the stack; callers only used `.len()` and `.is_empty()`.
+/// Parsed marker fields are now consumed by-value into the stack instead
+/// of cloned per loop iteration.)
 ///
 /// # Arguments
 ///
-/// * `stack` - The prediction stack to update. Surprise threshold is read from
-///   `stack.config.surprise_threshold` so callers configure once at stack
-///   construction rather than on every call.
+/// * `stack` - The prediction stack to update. Surprise threshold is read
+///   from `stack.config.surprise_threshold`.
 /// * `task_output` - The raw text output from the entity's cognitive cycle.
 /// * `task_id` - Identifier for the task (used for logging).
-/// * `default_timescale` - The timescale to assign to new predictions from this task.
-///
-/// # Returns
-///
-/// A list of `PredictionError`s created during resolution (only for high-surprise outcomes).
+/// * `default_timescale` - The timescale to assign to new predictions from
+///   this task.
 pub fn process_task_output(
     stack: &mut PredictionStack,
     task_output: &str,
     task_id: &str,
     default_timescale: Timescale,
-) -> Vec<PredictionError> {
+) -> usize {
     let errors_before = stack.errors.len();
 
-    // Phase 1: Parse and add new predictions
+    // Phase 1: parse and add new predictions. Consume the Vec by value so
+    // `content` moves into the stack rather than being cloned.
     let new_predictions = parse_predictions(task_output, default_timescale);
-    for parsed in &new_predictions {
-        let prediction =
-            stack.add_prediction(parsed.timescale, parsed.content.clone(), parsed.confidence);
+    let new_predictions_count = new_predictions.len();
+    for parsed in new_predictions {
+        let ParsedPrediction {
+            content,
+            confidence,
+            timescale,
+        } = parsed;
+        let prediction = stack.add_prediction(timescale, content, confidence);
         tracing::info!(
             task_id = %task_id,
             prediction_id = %prediction.id,
-            timescale = %parsed.timescale,
-            confidence = %parsed.confidence,
+            timescale = %timescale,
+            confidence = %confidence,
             "New prediction registered"
         );
     }
 
-    // Phase 2: Parse and apply resolutions
+    // Phase 2: parse and apply resolutions. Same by-value consume pattern.
     let resolutions = parse_resolutions(task_output);
-    for parsed in &resolutions {
+    let resolutions_count = resolutions.len();
+    for parsed in resolutions {
+        let ParsedResolution {
+            prediction_id,
+            actual,
+            surprise,
+            direction,
+            insight,
+        } = parsed;
         let resolution = PredictionResolution {
-            actual: parsed.actual.clone(),
-            surprise: parsed.surprise,
-            direction: parsed.direction,
-            insight: parsed.insight.clone(),
+            actual,
+            surprise,
+            direction,
+            insight,
         };
-
-        if stack.resolve(&parsed.prediction_id, resolution) {
+        if stack.resolve(&prediction_id, resolution) {
             tracing::info!(
                 task_id = %task_id,
-                prediction_id = %parsed.prediction_id,
-                surprise = %parsed.surprise,
-                direction = %parsed.direction,
+                prediction_id = %prediction_id,
+                surprise = %surprise,
+                direction = %direction,
                 "Prediction resolved"
             );
         }
     }
 
-    if !new_predictions.is_empty() || !resolutions.is_empty() {
+    if new_predictions_count > 0 || resolutions_count > 0 {
         tracing::info!(
             task_id = %task_id,
-            new_predictions = new_predictions.len(),
-            resolutions = resolutions.len(),
+            new_predictions = new_predictions_count,
+            resolutions = resolutions_count,
             "Processed prediction markers from task output"
         );
     }
 
-    // Return only the errors created during this call
-    stack.errors[errors_before..].to_vec()
+    stack.errors.len() - errors_before
 }
 
 #[cfg(test)]
@@ -452,9 +464,9 @@ mod tests {
         let mut stack = PredictionStack::new();
         let text = r#"[PREDICT:{"content":"user will return tomorrow","confidence":0.6}]"#;
 
-        let errors = process_task_output(&mut stack, text, "test-task", Timescale::Cycle);
+        let new_errors = process_task_output(&mut stack, text, "test-task", Timescale::Cycle);
 
-        assert!(errors.is_empty());
+        assert_eq!(new_errors, 0);
         assert_eq!(stack.predictions.len(), 1);
         assert_eq!(stack.predictions[0].content, "user will return tomorrow");
     }
@@ -470,11 +482,12 @@ mod tests {
         let text = format!(
             r#"[RESOLVE:{{"id":"{id}","outcome":"it rained instead","surprise":0.7,"direction":"misdirected","insight":"completely wrong about weather"}}]"#
         );
-        let errors = process_task_output(&mut stack, &text, "test-task", Timescale::Cycle);
+        let new_errors = process_task_output(&mut stack, &text, "test-task", Timescale::Cycle);
 
-        assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].surprise, 0.7);
-        assert_eq!(errors[0].direction, ErrorDirection::Misdirected);
+        assert_eq!(new_errors, 1);
+        assert_eq!(stack.errors.len(), 1);
+        assert_eq!(stack.errors[0].surprise, 0.7);
+        assert_eq!(stack.errors[0].direction, ErrorDirection::Misdirected);
     }
 
     #[test]
@@ -488,12 +501,13 @@ mod tests {
         let text = format!(
             r#"[PREDICT:{{"content":"new prediction","confidence":0.7}}] some text [RESOLVE:{{"id":"{id}","outcome":"happened","surprise":0.8,"direction":"novel","insight":"wow"}}]"#
         );
-        let errors = process_task_output(&mut stack, &text, "test-task", Timescale::Session);
+        let new_errors = process_task_output(&mut stack, &text, "test-task", Timescale::Session);
 
         // Should have the old prediction (now resolved) + the new one
         assert_eq!(stack.predictions.len(), 2);
-        assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].surprise, 0.8);
+        assert_eq!(new_errors, 1);
+        assert_eq!(stack.errors.len(), 1);
+        assert_eq!(stack.errors[0].surprise, 0.8);
 
         // New prediction should have the default timescale
         let new_pred = &stack.predictions[1];
@@ -504,14 +518,14 @@ mod tests {
     #[test]
     fn process_task_output_no_markers_is_noop() {
         let mut stack = PredictionStack::new();
-        let errors = process_task_output(
+        let new_errors = process_task_output(
             &mut stack,
             "just regular text",
             "test-task",
             Timescale::Cycle,
         );
 
-        assert!(errors.is_empty());
+        assert_eq!(new_errors, 0);
         assert!(stack.predictions.is_empty());
     }
 
@@ -526,9 +540,9 @@ mod tests {
         let text = format!(
             r#"[RESOLVE:{{"id":"{id}","outcome":"as expected","surprise":0.1,"direction":"underconfident"}}]"#
         );
-        let errors = process_task_output(&mut stack, &text, "test-task", Timescale::Cycle);
+        let new_errors = process_task_output(&mut stack, &text, "test-task", Timescale::Cycle);
 
-        assert!(errors.is_empty());
+        assert_eq!(new_errors, 0);
         assert!(stack.predictions[0].resolution.is_some());
     }
 
@@ -547,8 +561,8 @@ mod tests {
         let text = format!(
             r#"[RESOLVE:{{"id":"{id}","outcome":"done","surprise":0.5,"direction":"misdirected"}}]"#
         );
-        let errors = process_task_output(&mut stack, &text, "test", Timescale::Cycle);
-        assert!(errors.is_empty());
+        let new_errors = process_task_output(&mut stack, &text, "test", Timescale::Cycle);
+        assert_eq!(new_errors, 0);
 
         // Same input with threshold = 0.4 produces an error.
         let mut stack2 = PredictionStack::with_config(PredictionConfig {
@@ -562,8 +576,8 @@ mod tests {
         let text2 = format!(
             r#"[RESOLVE:{{"id":"{id2}","outcome":"done","surprise":0.5,"direction":"misdirected"}}]"#
         );
-        let errors2 = process_task_output(&mut stack2, &text2, "test", Timescale::Cycle);
-        assert_eq!(errors2.len(), 1);
+        let new_errors2 = process_task_output(&mut stack2, &text2, "test", Timescale::Cycle);
+        assert_eq!(new_errors2, 1);
     }
 
     #[test]

--- a/src/prediction/store.rs
+++ b/src/prediction/store.rs
@@ -78,7 +78,14 @@ pub fn load(root_dir: &Path, config: PredictionConfig) -> PredictionStack {
 /// Writes to a temporary file first, then renames to the final path.
 /// This prevents partial writes from corrupting the predictions file
 /// if the process is interrupted mid-write.
-pub fn save(root_dir: &Path, stack: &PredictionStack) -> Result<(), Box<dyn std::error::Error>> {
+///
+/// Returns `Box<dyn Error + Send + Sync>` so `save_async` can propagate
+/// the error chain across `spawn_blocking` without stringifying it
+/// (Q-MEDIUM "save error type drops source chain in save_async").
+pub fn save(
+    root_dir: &Path,
+    stack: &PredictionStack,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let path = root_dir.join(PREDICTIONS_FILE);
     let tmp_path = root_dir.join(PREDICTIONS_TMP);
 
@@ -126,17 +133,15 @@ pub async fn load_async(root_dir: PathBuf, config: PredictionConfig) -> Predicti
 }
 
 /// Async wrapper for `save` — offloads file IO to a blocking thread.
+///
+/// The sync `save` now returns `Send + Sync`, so we can pass the error
+/// chain through `spawn_blocking` without stringifying it (M2).
 pub async fn save_async(
     root_dir: PathBuf,
     stack: PredictionStack,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let result =
-        tokio::task::spawn_blocking(move || save(&root_dir, &stack).map_err(|e| e.to_string()))
-            .await;
-
-    match result {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(msg)) => Err(msg.into()),
+    match tokio::task::spawn_blocking(move || save(&root_dir, &stack)).await {
+        Ok(result) => result,
         Err(join_err) => Err(format!("spawn_blocking panicked: {join_err}").into()),
     }
 }

--- a/src/prediction/store.rs
+++ b/src/prediction/store.rs
@@ -96,7 +96,10 @@ pub fn save(
         }
     }
 
-    let content = serde_json::to_string_pretty(stack)?;
+    // Compact JSON: predictions.json is machine-read only (no human
+    // edits expected). Pretty-printing roughly doubled the on-disk size
+    // and added serializer overhead per cycle (PERF-008).
+    let content = serde_json::to_string(stack)?;
     fs::write(&tmp_path, &content)?;
     fs::rename(&tmp_path, &path)?;
 

--- a/src/prediction/store.rs
+++ b/src/prediction/store.rs
@@ -18,7 +18,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::PredictionStack;
+use super::{PredictionStack, PredictionStackSnapshot};
 use crate::config::PredictionConfig;
 
 /// File name for the prediction stack on disk.
@@ -53,14 +53,13 @@ pub fn load(root_dir: &Path, config: PredictionConfig) -> PredictionStack {
         }
     };
 
-    match serde_json::from_str::<PredictionStack>(&content) {
-        Ok(mut stack) => {
+    match serde_json::from_str::<PredictionStackSnapshot>(&content) {
+        Ok(snapshot) => {
             tracing::info!(
                 path = %path.display(),
                 "Loaded prediction stack from disk"
             );
-            stack.config = config;
-            stack
+            snapshot.into_stack(config)
         }
         Err(e) => {
             tracing::warn!(
@@ -99,7 +98,11 @@ pub fn save(
     // Compact JSON: predictions.json is machine-read only (no human
     // edits expected). Pretty-printing roughly doubled the on-disk size
     // and added serializer overhead per cycle (PERF-008).
-    let content = serde_json::to_string(stack)?;
+    //
+    // Serialize via the snapshot view so config (which is rehydrated
+    // from `pulse-null.toml`, not the file) never reaches disk.
+    let snapshot = PredictionStackSnapshot::from_stack(stack);
+    let content = serde_json::to_string(&snapshot)?;
     fs::write(&tmp_path, &content)?;
     fs::rename(&tmp_path, &path)?;
 

--- a/src/prediction/store.rs
+++ b/src/prediction/store.rs
@@ -109,14 +109,19 @@ pub fn save(root_dir: &Path, stack: &PredictionStack) -> Result<(), Box<dyn std:
 /// Synchronous callers running inside `spawn_blocking` (e.g. the prompt
 /// builder pipeline) should call [`load`] directly.
 pub async fn load_async(root_dir: PathBuf, config: PredictionConfig) -> PredictionStack {
+    // Keep a fallback copy outside the closure: if spawn_blocking panics,
+    // the original `config` was already moved in and is unrecoverable.
+    // Without this, the panic path silently returned default thresholds
+    // (Q-MEDIUM "load_async swallows caller config on panic").
+    let config_fallback = config.clone();
     tokio::task::spawn_blocking(move || load(&root_dir, config))
         .await
         .unwrap_or_else(|join_err| {
             tracing::error!(
                 error = %join_err,
-                "spawn_blocking panicked while loading prediction stack; using default"
+                "spawn_blocking panicked while loading prediction stack; using configured fallback"
             );
-            PredictionStack::default()
+            PredictionStack::with_config(config_fallback)
         })
 }
 

--- a/src/scheduler/runner.rs
+++ b/src/scheduler/runner.rs
@@ -846,16 +846,16 @@ async fn post_process_predictions(
     root_dir: &std::path::Path,
     clean_content: &str,
 ) {
-    let new_errors = crate::prediction::resolve::process_task_output(
+    let new_error_count = crate::prediction::resolve::process_task_output(
         &mut stack,
         clean_content,
         &task.id,
         super::tasks::default_timescale_for(&task.id),
     );
-    if !new_errors.is_empty() {
+    if new_error_count > 0 {
         tracing::info!(
             "Prediction errors: {} new (accumulated importance: {:.2})",
-            new_errors.len(),
+            new_error_count,
             stack.accumulated_importance(),
         );
     }


### PR DESCRIPTION
Follow-up to #70 — closes the round-1 audit MEDIUMs that were knowingly deferred when Phase 2 (Hierarchical Predictive Self-Modeling) landed. No behaviour changes; just hygiene and small allocation wins around the prediction module.

## Commits

- **`4aab762` fix(M1)** — `store::load_async` preserves the caller's `PredictionConfig` on a `spawn_blocking` panic. The panic arm previously returned `PredictionStack::default()`, silently dropping configured thresholds.
- **`ef34295` fix(M2)** — Tighten `store::save` return type to `Box<dyn Error + Send + Sync>` so `save_async` propagates the source chain instead of stringifying.
- **`6728836` perf(M3)** — `PredictionStack::prune` rewritten in-place: single stable `sort_by` + count + `truncate` per side, replacing the four `filter().cloned().collect()` passes. Preserves the existing invariants (pending/unprocessed always kept, insertion order within each group).
- **`35db866` perf(M4)** — `process_task_output` consumes parsed marker Vecs by value (moves `content`/`outcome`/`insight`/`actual` into the stack instead of cloning per iteration). Return type changed from `Vec<PredictionError>` (cloned out of the stack) to `usize`; tests inspect `stack.errors` directly.
- **`df88fbd` perf(M5)** — `predictions.json` saved as compact JSON. The file is machine-read only; pretty-printing was doubling on-disk size for no benefit.
- **`7ff944a` fix(M6)** — `recent_errors` sorts by `created_at` descending instead of returning the Vec tail. After a prune the tail wasn't necessarily the time-newest entries.
- **`3ce2bda` refactor(M7)** — Split the on-disk format into `PredictionStackSnapshot` (predictions + errors only, no config). `PredictionStack` drops `Serialize`/`Deserialize` derives so callers physically can't deserialize one without going through `PredictionStackSnapshot::into_stack(config)` — closes the `#[serde(skip)] config` footgun.

## Verification

- `cargo build --release --features discord-text` — green (13m 22s).
- `cargo clippy --features discord-text -- -D warnings` — clean.
- `cargo test -p pulse-null --features discord-text` — **589 passed, 0 failed.**

## Deferred (per round-1 audit, still in Decisions Log)

- Q M5 evaluator NaN debug_assert (INFO-level).
- Q M8 `format_pressure_directive` extraction (aesthetic).
- SEC-004 TOCTOU concurrent writes — needs per-entity mutex, bigger surface.
- PERF-007 `PredictionConfig: Copy` — touches the public `Config` API, separate PR.
- Q-H1 residual: rest of `execute_task` length (non-prediction code) — its own refactor PR.

## Deploy

After merge: `/update-pulse` rebuilds and restarts echo / nova / synth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)