### PR TITLE
chore: fix CI on main — cargo fmt + clippy 1.96 lints

### DIFF
--- a/src/caliber/state.rs
+++ b/src/caliber/state.rs
@@ -50,7 +50,7 @@ impl CaliberState {
             *counts.entry(o.domain.clone()).or_insert(0) += 1;
         }
         let mut result: Vec<_> = counts.into_iter().collect();
-        result.sort_by(|a, b| b.1.cmp(&a.1));
+        result.sort_by_key(|e| std::cmp::Reverse(e.1));
         result
     }
 

--- a/src/caliber/trajectory.rs
+++ b/src/caliber/trajectory.rs
@@ -223,7 +223,7 @@ fn build_domain_reports(outcomes: &[&OutcomeRecord]) -> Vec<DomainReport> {
         .collect();
 
     // Sort by sample size descending for consistent output
-    reports.sort_by(|a, b| b.sample_size.cmp(&a.sample_size));
+    reports.sort_by_key(|r| std::cmp::Reverse(r.sample_size));
     reports
 }
 

--- a/src/chat/banner.rs
+++ b/src/chat/banner.rs
@@ -111,11 +111,9 @@ fn print_doc_bar(name: &str, doc: &DocumentHealth) {
 /// Build a progress bar string.
 fn status_bar(count: usize, hard: usize) -> String {
     let width = 10;
-    let filled = if hard > 0 {
-        (count * width / hard).min(width)
-    } else {
-        0
-    };
+    let filled = (count * width)
+        .checked_div(hard)
+        .map_or(0, |f| f.min(width));
     let empty = width - filled;
     format!("{}{}", "█".repeat(filled), "░".repeat(empty))
 }

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -59,11 +59,9 @@ fn print_doc_status(name: &str, doc: &DocumentHealth) {
 
 fn status_bar(count: usize, hard: usize) -> String {
     let width = 20;
-    let filled = if hard > 0 {
-        (count * width / hard).min(width)
-    } else {
-        0
-    };
+    let filled = (count * width)
+        .checked_div(hard)
+        .map_or(0, |f| f.min(width));
     let empty = width - filled;
     format!("{}{}", "█".repeat(filled), "░".repeat(empty))
 }

--- a/src/context/compact.rs
+++ b/src/context/compact.rs
@@ -96,7 +96,7 @@ fn build_file_reinjection(recent_files: &[RecentFile]) -> Option<String> {
 
     // Sort by access time descending, take most recent
     let mut sorted: Vec<&RecentFile> = recent_files.iter().collect();
-    sorted.sort_by(|a, b| b.accessed_at.cmp(&a.accessed_at));
+    sorted.sort_by_key(|f| std::cmp::Reverse(f.accessed_at));
     let selected: Vec<&RecentFile> = sorted.into_iter().take(MAX_REINJECTION_FILES).collect();
 
     if selected.is_empty() {

--- a/src/praxis/calibrate.rs
+++ b/src/praxis/calibrate.rs
@@ -435,7 +435,7 @@ fn build_outcome_summary(outcomes: &[OutcomeRecord]) -> OutcomeSummary {
         .into_iter()
         .map(|(d, (count, succ))| (d, count, succ as f64 / count as f64))
         .collect();
-    domains.sort_by(|a, b| b.1.cmp(&a.1));
+    domains.sort_by_key(|d| std::cmp::Reverse(d.1));
 
     OutcomeSummary {
         total,

--- a/src/praxis/status.rs
+++ b/src/praxis/status.rs
@@ -11,11 +11,9 @@ const RESET: &str = "\x1b[0m";
 
 fn bar(count: usize, soft: usize, hard: usize) -> String {
     let max_width = 20;
-    let filled = if hard > 0 {
-        (count * max_width / hard).min(max_width)
-    } else {
-        0
-    };
+    let filled = (count * max_width)
+        .checked_div(hard)
+        .map_or(0, |f| f.min(max_width));
     let empty = max_width - filled;
 
     let color = if count >= hard {

--- a/src/prediction/mod.rs
+++ b/src/prediction/mod.rs
@@ -414,7 +414,7 @@ impl PredictionStack {
     #[must_use]
     pub fn recent_errors(&self, count: usize) -> Vec<&PredictionError> {
         let mut by_recency: Vec<&PredictionError> = self.errors.iter().collect();
-        by_recency.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        by_recency.sort_by_key(|e| std::cmp::Reverse(e.created_at));
         by_recency.truncate(count);
         by_recency
     }

--- a/src/prediction/mod.rs
+++ b/src/prediction/mod.rs
@@ -390,12 +390,13 @@ impl PredictionStack {
         if self.errors.len() > max_errors {
             // Unprocessed first (insertion order); processed after (newest
             // first). Same stable-sort trick — preserves order of equal keys.
-            self.errors.sort_by(|a, b| match (a.processed, b.processed) {
-                (false, true) => std::cmp::Ordering::Less,
-                (true, false) => std::cmp::Ordering::Greater,
-                (true, true) => b.created_at.cmp(&a.created_at), // newest first among processed
-                (false, false) => std::cmp::Ordering::Equal,     // preserve insertion order
-            });
+            self.errors
+                .sort_by(|a, b| match (a.processed, b.processed) {
+                    (false, true) => std::cmp::Ordering::Less,
+                    (true, false) => std::cmp::Ordering::Greater,
+                    (true, true) => b.created_at.cmp(&a.created_at), // newest first among processed
+                    (false, false) => std::cmp::Ordering::Equal,     // preserve insertion order
+                });
             let unprocessed_count = self.errors.iter().take_while(|e| !e.processed).count();
             let target = max_errors.max(unprocessed_count);
             self.errors.truncate(target);

--- a/src/tui/screens/wizard.rs
+++ b/src/tui/screens/wizard.rs
@@ -599,10 +599,8 @@ impl Screen for WizardScreen {
                     KeyCode::Up => {
                         self.provider_idx = self.provider_idx.saturating_sub(1);
                     }
-                    KeyCode::Down => {
-                        if self.provider_idx < 2 {
-                            self.provider_idx += 1;
-                        }
+                    KeyCode::Down if self.provider_idx < 2 => {
+                        self.provider_idx += 1;
                     }
                     _ => {}
                 }
@@ -613,10 +611,8 @@ impl Screen for WizardScreen {
                     KeyCode::Up => {
                         self.timezone_idx = self.timezone_idx.saturating_sub(1);
                     }
-                    KeyCode::Down => {
-                        if self.timezone_idx < TIMEZONES.len() - 1 {
-                            self.timezone_idx += 1;
-                        }
+                    KeyCode::Down if self.timezone_idx < TIMEZONES.len() - 1 => {
+                        self.timezone_idx += 1;
                     }
                     _ => {}
                 }

--- a/src/tui/tabs/recall.rs
+++ b/src/tui/tabs/recall.rs
@@ -140,7 +140,7 @@ impl RecallTab {
                 Ok((stats, pipeline)) => {
                     let mut type_counts: Vec<(String, u64)> =
                         stats.entity_type_counts.into_iter().collect();
-                    type_counts.sort_by(|a, b| b.1.cmp(&a.1));
+                    type_counts.sort_by_key(|c| std::cmp::Reverse(c.1));
 
                     let health = GraphHealthData {
                         entity_count: stats.entity_count,


### PR DESCRIPTION
CI has been red on main since #71: the `recent_errors` sort in `src/prediction/mod.rs` wasn't formatted, and CI's `dtolnay/rust-toolchain@stable` now resolves to Rust 1.96, whose clippy introduces lints the code predates.

## Changes
- `cargo fmt` on `src/prediction/mod.rs` (the original format failure)
- 6× `unnecessary_sort_by` → `sort_by_key(Reverse(..))` (caliber/state, caliber/trajectory, context/compact, praxis/calibrate, prediction/mod, tui/recall)
- 3× `manual_checked_ops` → `checked_div().map_or(..)` in the three `status_bar`/`bar` helpers (chat/banner, cli/pipeline, praxis/status)
- 2× `collapsible_match` → match guards in `tui/screens/wizard.rs` (clippy --fix, behavior-preserving)

No logic changes. Verified locally on rustc 1.96.0 against CI's exact gate: fmt clean, `clippy -- -D warnings -A dead_code` green, 580/580 tests pass.