### PR TITLE
Prompt governance & scheduler liveness — make the E2BIG outage class impossible

### DIFF
--- a/src/claude_code_provider.rs
+++ b/src/claude_code_provider.rs
@@ -1,15 +1,26 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use pulse_system_types::llm::{
     ContentBlock, LlmResponse, LlmResult, LmProvider, Message, MessageContent, MessageSource, Role,
     StopReason,
 };
+use tracing::warn;
 
 /// Default timeout for Claude Code subprocess (5 minutes).
 /// Claude Code runs tools and may take longer than a direct API call.
 const SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Timeout for the one-off `--system-prompt-file` support probe.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// What a CLI without the flag prints when it parses `--system-prompt-file`.
+const UNKNOWN_OPTION_MARKER: &str = "unknown option";
+
+use crate::errors::ClaudeCliError;
 use crate::session::strip_system_prefixes;
 use crate::streaming::{self, StreamResult, StreamingProvider};
 
@@ -24,6 +35,158 @@ impl ClaudeCodeProvider {
             .or_else(|| std::env::var("CLAUDE_BIN").ok())
             .unwrap_or_else(|| "claude".into());
         Self { model, claude_bin }
+    }
+}
+
+/// A private on-disk copy of the system prompt for a single CLI invocation.
+///
+/// The prompt is handed to `claude` as `--system-prompt-file <path>` rather
+/// than as an argv string: Linux caps a single argv argument at
+/// `MAX_ARG_STRLEN` (128KB), and an oversized system prompt made every spawn
+/// fail with E2BIG. The file is created with mode 0600 and unlinked when this
+/// guard drops, which covers the success, error, timeout and cancellation
+/// paths alike — every exit from the invocation future drops its locals.
+struct SystemPromptFile {
+    path: PathBuf,
+}
+
+impl SystemPromptFile {
+    /// Write `contents` to a uniquely named private file in the temp dir.
+    fn create(contents: &str) -> Result<Self, ClaudeCliError> {
+        let path = std::env::temp_dir().join(format!(
+            "pulse-null-system-prompt-{}.md",
+            uuid::Uuid::new_v4()
+        ));
+
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        let staged = Self { path };
+        let mut file = options
+            .open(&staged.path)
+            .map_err(|source| staged.error(source))?;
+        {
+            use std::io::Write;
+            file.write_all(contents.as_bytes())
+                .map_err(|source| staged.error(source))?;
+        }
+        Ok(staged)
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn error(&self, source: std::io::Error) -> ClaudeCliError {
+        ClaudeCliError::SystemPromptFile {
+            path: self.path.display().to_string(),
+            source,
+        }
+    }
+}
+
+impl Drop for SystemPromptFile {
+    fn drop(&mut self) {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => warn!(
+                "failed to remove system prompt file '{}': {}",
+                self.path.display(),
+                e
+            ),
+        }
+    }
+}
+
+/// Probe results for `--system-prompt-file`, keyed by resolved binary path.
+fn support_cache() -> &'static Mutex<HashMap<String, bool>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Verify the resolved CLI accepts `--system-prompt-file`, probing at most once
+/// per binary path.
+///
+/// Falling back to `--system-prompt` on argv is not an option: that is the
+/// failure mode this transport exists to remove, so an unsupported CLI is a
+/// hard, named error.
+async fn ensure_system_prompt_file_support(claude_bin: &str) -> Result<(), ClaudeCliError> {
+    let cached = support_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(claude_bin)
+        .copied();
+
+    let supported = match cached {
+        Some(supported) => supported,
+        None => {
+            let supported = probe_system_prompt_file(claude_bin).await?;
+            support_cache()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(claude_bin.to_string(), supported);
+            supported
+        }
+    };
+
+    if supported {
+        Ok(())
+    } else {
+        Err(ClaudeCliError::SystemPromptFileUnsupported {
+            bin: claude_bin.to_string(),
+        })
+    }
+}
+
+/// Run the CLI with `--system-prompt-file` pointed at a path that cannot exist.
+///
+/// A CLI that knows the flag rejects the missing *file*; one that does not
+/// rejects the unknown *option*. Either way the process exits during argument
+/// handling, so the probe never reaches the API.
+async fn probe_system_prompt_file(claude_bin: &str) -> Result<bool, ClaudeCliError> {
+    let absent = std::env::temp_dir().join(format!("pulse-null-probe-{}.md", uuid::Uuid::new_v4()));
+
+    let mut cmd = tokio::process::Command::new(claude_bin);
+    cmd.arg("-p")
+        .arg("--system-prompt-file")
+        .arg(&absent)
+        .env_remove("CLAUDECODE")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.kill_on_drop(true);
+
+    let child = cmd.spawn().map_err(|source| ClaudeCliError::Probe {
+        bin: claude_bin.to_string(),
+        source,
+    })?;
+
+    match tokio::time::timeout(PROBE_TIMEOUT, child.wait_with_output()).await {
+        Ok(Ok(output)) => {
+            let mut combined = String::from_utf8_lossy(&output.stderr).into_owned();
+            combined.push_str(&String::from_utf8_lossy(&output.stdout));
+            Ok(!combined.contains(UNKNOWN_OPTION_MARKER))
+        }
+        Ok(Err(source)) => Err(ClaudeCliError::Probe {
+            bin: claude_bin.to_string(),
+            source,
+        }),
+        Err(_) => {
+            // The flag was accepted by the argument parser — an unknown option
+            // exits immediately — so treat a slow probe as support.
+            warn!(
+                "probe of '{}' for --system-prompt-file timed out after {}s; assuming supported",
+                claude_bin,
+                PROBE_TIMEOUT.as_secs()
+            );
+            Ok(true)
+        }
     }
 }
 
@@ -43,6 +206,11 @@ impl LmProvider for ClaudeCodeProvider {
         Box::pin(async move {
             let prompt = serialize_messages(&messages);
 
+            ensure_system_prompt_file_support(&claude_bin).await?;
+            // Dropped on every exit from this future — success, error, timeout
+            // and cancellation — which unlinks the staged prompt.
+            let system_prompt_file = SystemPromptFile::create(&system_prompt)?;
+
             let mut cmd = tokio::process::Command::new(&claude_bin);
             cmd.arg("-p")
                 .arg("-")
@@ -50,8 +218,8 @@ impl LmProvider for ClaudeCodeProvider {
                 .arg(&model)
                 .arg("--output-format")
                 .arg("json")
-                .arg("--system-prompt")
-                .arg(&system_prompt)
+                .arg("--system-prompt-file")
+                .arg(system_prompt_file.path())
                 .arg("--no-session-persistence")
                 .arg("--dangerously-skip-permissions")
                 .env_remove("CLAUDECODE")
@@ -424,6 +592,242 @@ mod tests {
     fn provider_name() {
         let provider = ClaudeCodeProvider::new("opus".into(), None);
         assert_eq!(provider.name(), "claude-code");
+    }
+
+    // --- PN-75: system prompt off argv ---
+
+    /// A fake `claude` CLI that mimics the parts of the real one this provider
+    /// depends on: it rejects a missing `--system-prompt-file`, records its
+    /// argv and the prompt file it was given, then emits a JSON result.
+    struct MockCli {
+        _dir: tempfile::TempDir,
+        bin: PathBuf,
+        argv_log: PathBuf,
+        prompt_copy: PathBuf,
+        prompt_path_log: PathBuf,
+    }
+
+    impl MockCli {
+        fn new(body: &str) -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let bin = dir.path().join("claude-mock");
+            let argv_log = dir.path().join("argv.log");
+            let prompt_copy = dir.path().join("prompt.copy");
+            let prompt_path_log = dir.path().join("prompt-path.log");
+
+            let script = format!(
+                "#!/bin/sh\n\
+                 spf=\"\"\n\
+                 prev=\"\"\n\
+                 for a in \"$@\"; do\n\
+                 \x20 if [ \"$prev\" = \"--system-prompt-file\" ]; then spf=\"$a\"; fi\n\
+                 \x20 prev=\"$a\"\n\
+                 done\n\
+                 if [ -n \"$spf\" ] && [ ! -f \"$spf\" ]; then\n\
+                 \x20 echo \"Error: System prompt file not found: $spf\" >&2\n\
+                 \x20 exit 1\n\
+                 fi\n\
+                 cat > /dev/null\n\
+                 : > \"{argv}\"\n\
+                 for a in \"$@\"; do printf '%s\\n' \"$a\" >> \"{argv}\"; done\n\
+                 if [ -n \"$spf\" ]; then\n\
+                 \x20 cp \"$spf\" \"{copy}\"\n\
+                 \x20 printf '%s' \"$spf\" > \"{pathlog}\"\n\
+                 fi\n\
+                 {body}\n",
+                argv = argv_log.display(),
+                copy = prompt_copy.display(),
+                pathlog = prompt_path_log.display(),
+                body = body,
+            );
+            std::fs::write(&bin, script).unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+            }
+
+            Self {
+                _dir: dir,
+                bin,
+                argv_log,
+                prompt_copy,
+                prompt_path_log,
+            }
+        }
+
+        /// A mock that succeeds with a fixed JSON result.
+        fn succeeding() -> Self {
+            Self::new("printf '{\"result\":\"mock ok\",\"session_id\":\"mock\"}'")
+        }
+
+        fn provider(&self, model: &str) -> ClaudeCodeProvider {
+            ClaudeCodeProvider::new(model.into(), Some(self.bin.display().to_string()))
+        }
+
+        fn argv(&self) -> Vec<String> {
+            std::fs::read_to_string(&self.argv_log)
+                .unwrap()
+                .lines()
+                .map(str::to_string)
+                .collect()
+        }
+
+        fn captured_prompt(&self) -> String {
+            std::fs::read_to_string(&self.prompt_copy).unwrap()
+        }
+
+        fn captured_prompt_path(&self) -> PathBuf {
+            PathBuf::from(std::fs::read_to_string(&self.prompt_path_log).unwrap())
+        }
+    }
+
+    fn user_message(text: &str) -> Vec<Message> {
+        vec![Message {
+            role: Role::User,
+            content: MessageContent::Text(text.into()),
+            source: None,
+        }]
+    }
+
+    #[tokio::test]
+    async fn system_prompt_goes_to_a_file_not_argv() {
+        let mock = MockCli::succeeding();
+        let provider = mock.provider("opus");
+        let system_prompt = "# Identity\nYou are a test entity.";
+
+        let response = provider
+            .invoke(system_prompt, &user_message("hello"), 1024, None)
+            .await
+            .unwrap();
+        assert_eq!(response.text(), "mock ok");
+
+        let argv = mock.argv();
+        assert!(
+            argv.iter().any(|a| a == "--system-prompt-file"),
+            "expected --system-prompt-file in argv, got {argv:?}"
+        );
+        assert!(
+            !argv.iter().any(|a| a == "--system-prompt"),
+            "system prompt must never ride argv, got {argv:?}"
+        );
+        assert!(
+            !argv.iter().any(|a| a.contains("You are a test entity")),
+            "prompt content leaked into argv: {argv:?}"
+        );
+        assert_eq!(mock.captured_prompt(), system_prompt);
+    }
+
+    #[tokio::test]
+    async fn system_prompt_file_is_removed_after_invocation() {
+        let mock = MockCli::succeeding();
+        let provider = mock.provider("opus");
+
+        provider
+            .invoke("system", &user_message("hello"), 1024, None)
+            .await
+            .unwrap();
+
+        let staged = mock.captured_prompt_path();
+        assert!(
+            !staged.exists(),
+            "staged system prompt {} should be unlinked after the invocation",
+            staged.display()
+        );
+    }
+
+    #[tokio::test]
+    async fn system_prompt_file_is_removed_when_the_cli_fails() {
+        let mock = MockCli::new("echo 'boom' >&2\nexit 2");
+        let provider = mock.provider("opus");
+
+        let err = provider
+            .invoke("system", &user_message("hello"), 1024, None)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("boom"), "got: {err}");
+
+        let staged = mock.captured_prompt_path();
+        assert!(
+            !staged.exists(),
+            "staged system prompt {} should be unlinked after a failed invocation",
+            staged.display()
+        );
+    }
+
+    /// AC1: a system prompt far past the 128KB single-argv kernel limit spawns
+    /// successfully, and argv stays tiny.
+    #[tokio::test]
+    async fn giant_system_prompt_spawns_with_small_argv() {
+        const MEGABYTE: usize = 1024 * 1024;
+
+        let mock = MockCli::succeeding();
+        let provider = mock.provider("opus");
+        let system_prompt = "x".repeat(MEGABYTE);
+
+        let response = provider
+            .invoke(&system_prompt, &user_message("hello"), 1024, None)
+            .await
+            .unwrap();
+        assert_eq!(response.text(), "mock ok");
+
+        let argv = mock.argv();
+        let argv_bytes: usize = argv.iter().map(|a| a.len() + 1).sum();
+        assert!(
+            argv_bytes < 8 * 1024,
+            "argv should carry flags only, got {argv_bytes} bytes: {argv:?}"
+        );
+        assert_eq!(mock.captured_prompt().len(), MEGABYTE);
+    }
+
+    #[tokio::test]
+    async fn unsupported_cli_fails_with_a_named_error() {
+        let mock = MockCli::new("exit 0");
+        // Overwrite the mock with one that rejects the flag outright.
+        std::fs::write(
+            &mock.bin,
+            "#!/bin/sh\necho \"error: unknown option '--system-prompt-file'\" >&2\nexit 1\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&mock.bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let provider = mock.provider("opus");
+        let err = provider
+            .invoke("system", &user_message("hello"), 1024, None)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("does not support --system-prompt-file"),
+            "expected a named unsupported-CLI error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn system_prompt_file_is_private_and_self_cleaning() {
+        let path = {
+            let staged = SystemPromptFile::create("secret prompt").unwrap();
+            assert_eq!(
+                std::fs::read_to_string(staged.path()).unwrap(),
+                "secret prompt"
+            );
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mode = std::fs::metadata(staged.path())
+                    .unwrap()
+                    .permissions()
+                    .mode();
+                assert_eq!(mode & 0o777, 0o600, "staged prompt must be owner-only");
+            }
+            staged.path().to_path_buf()
+        };
+        assert!(!path.exists(), "guard must unlink the file when dropped");
     }
 
     #[test]

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -1,5 +1,10 @@
+use chrono::Utc;
+use console::style;
+
 use crate::config::Config;
 use crate::pidfile;
+use crate::scheduler::health::{self, TaskHealthStore, TaskStatusLevel, TaskStatusView};
+use crate::scheduler::Schedule;
 
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
@@ -49,5 +54,113 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     println!("Status: {}", status);
+
+    print_task_liveness(&config, &root_dir);
     Ok(())
+}
+
+/// Per-task liveness: last-success age, failure streak, staleness marker.
+///
+/// This is the SSH glance that answers "is the entity actually alive?" —
+/// the question that went unanswered for seven weeks.
+fn print_task_liveness(config: &Config, root_dir: &std::path::Path) {
+    // `Schedule::load` seeds a default schedule.json when none exists;
+    // reporting status must not write anything.
+    if !root_dir.join("schedule.json").exists() {
+        println!("Tasks: none scheduled");
+        return;
+    }
+    let schedule = match Schedule::load(root_dir) {
+        Ok(s) => s,
+        Err(e) => {
+            println!("Tasks: unavailable ({e})");
+            return;
+        }
+    };
+    if schedule.tasks.is_empty() {
+        println!("Tasks: none scheduled");
+        return;
+    }
+
+    let store = TaskHealthStore::load(root_dir);
+    let liveness = &config.scheduler.liveness;
+    let now = Utc::now();
+
+    println!();
+    println!("{}", style("Scheduled task liveness").bold());
+
+    let mut enabled = 0usize;
+    let mut problems = 0usize;
+    for task in &schedule.tasks {
+        if task.enabled {
+            enabled += 1;
+        }
+        let view = TaskStatusView {
+            task_id: &task.id,
+            task_name: &task.name,
+            enabled: task.enabled,
+            interval: health::interval_from_cron(&task.cron, now),
+            health: store.get(&task.id),
+        };
+        let level = health::classify(&view, liveness, now);
+        if level.is_problem() {
+            problems += 1;
+        }
+        let line = health::status_line(&view, liveness, now);
+        let styled = match level {
+            TaskStatusLevel::Failing | TaskStatusLevel::Stale => style(line).red(),
+            TaskStatusLevel::Degraded => style(line).yellow(),
+            TaskStatusLevel::Ok => style(line).green(),
+            TaskStatusLevel::Idle => style(line).white(),
+            TaskStatusLevel::Disabled => style(line).dim(),
+        };
+        println!("  {styled}");
+    }
+
+    println!("  {}", global_liveness_line(&store, config, enabled, now));
+    if problems > 0 {
+        println!(
+            "  {}",
+            style(format!("{problems} task(s) need attention")).red()
+        );
+    }
+}
+
+/// The one-line answer: how long since *anything* succeeded.
+fn global_liveness_line(
+    store: &TaskHealthStore,
+    config: &Config,
+    enabled_tasks: usize,
+    now: chrono::DateTime<Utc>,
+) -> String {
+    let liveness = &config.scheduler.liveness;
+    let last = store.last_success_any();
+    let since = last.unwrap_or_else(|| store.created_at());
+    let silent_for = now - since;
+    let threshold = chrono::Duration::hours(liveness.global_silence_alert_hours as i64);
+
+    let summary = if last.is_some() {
+        format!(
+            "Last success on any task: {}",
+            health::format_age(last, now)
+        )
+    } else {
+        format!(
+            "No task has ever succeeded (tracking for {})",
+            health::format_duration(silent_for)
+        )
+    };
+    let verdict = if enabled_tasks == 0 {
+        style("(no tasks enabled)".to_string()).dim()
+    } else if silent_for >= threshold {
+        style(format!(
+            "ALERT: silent past the {}h threshold",
+            liveness.global_silence_alert_hours
+        ))
+        .red()
+        .bold()
+    } else {
+        style("alive".to_string()).green()
+    };
+    format!("{summary} — {verdict}")
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -133,6 +133,8 @@ pub struct SchedulerConfig {
     pub timezone: String,
     #[serde(default)]
     pub output: OutputConfig,
+    #[serde(default)]
+    pub liveness: LivenessConfig,
 }
 
 impl Default for SchedulerConfig {
@@ -141,6 +143,40 @@ impl Default for SchedulerConfig {
             enabled: true,
             timezone: default_timezone(),
             output: OutputConfig::default(),
+            liveness: LivenessConfig::default(),
+        }
+    }
+}
+
+/// Scheduler liveness alarm — turns a silent task outage into a webhook alert.
+///
+/// Per-task streaks alert after `alert_after_consecutive_failures` and then
+/// repeat on a backoff ladder (`alert_backoff_hours`, then 4× that). The
+/// global rule alerts when *no* task has succeeded for
+/// `global_silence_alert_hours` while tasks are enabled — set it above the
+/// longest interval in your schedule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LivenessConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Consecutive failures of one task before the first [ALERT].
+    #[serde(default = "default_alert_after_consecutive_failures")]
+    pub alert_after_consecutive_failures: u32,
+    /// Hours without a success on *any* task before the global [ALERT].
+    #[serde(default = "default_global_silence_alert_hours")]
+    pub global_silence_alert_hours: u64,
+    /// Hours before the first repeat of a still-unresolved alert.
+    #[serde(default = "default_alert_backoff_hours")]
+    pub alert_backoff_hours: u64,
+}
+
+impl Default for LivenessConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            alert_after_consecutive_failures: default_alert_after_consecutive_failures(),
+            global_silence_alert_hours: default_global_silence_alert_hours(),
+            alert_backoff_hours: default_alert_backoff_hours(),
         }
     }
 }
@@ -262,6 +298,18 @@ fn default_archive_max() -> usize {
 
 fn default_timezone() -> String {
     "UTC".to_string()
+}
+
+fn default_alert_after_consecutive_failures() -> u32 {
+    3
+}
+
+fn default_global_silence_alert_hours() -> u64 {
+    6
+}
+
+fn default_alert_backoff_hours() -> u64 {
+    6
 }
 
 // Identity-class session limit defaults

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -772,6 +772,18 @@ pub struct SystemPromptBudgetConfig {
     pub pipeline_health_cap: usize,
     pub cognitive_health_cap: usize,
     pub caliber_cap: usize,
+    /// Hard byte ceiling for THOUGHT_STACK.md content.
+    ///
+    /// The `*_max_bytes` ceilings are safety limits, not budgeting: they are
+    /// enforced even when `enabled` is false. Line counts do not bound bytes —
+    /// a 60-line THOUGHT_STACK of 3KB lines is 180KB — and an oversized prompt
+    /// is what killed every subprocess spawn for seven weeks.
+    pub thought_stack_max_bytes: usize,
+    /// Hard byte ceiling for AWARENESS.md content (API/Ollama providers only).
+    pub awareness_max_bytes: usize,
+    /// Hard byte ceiling for MEMORY.md content, complementing
+    /// `memory.memory_max_lines`.
+    pub memory_max_bytes: usize,
 }
 
 impl Default for SystemPromptBudgetConfig {
@@ -788,6 +800,9 @@ impl Default for SystemPromptBudgetConfig {
             pipeline_health_cap: 500,
             cognitive_health_cap: 300,
             caliber_cap: 200,
+            thought_stack_max_bytes: 48 * 1024,
+            awareness_max_bytes: 16 * 1024,
+            memory_max_bytes: 32 * 1024,
         }
     }
 }

--- a/src/config/validate.rs
+++ b/src/config/validate.rs
@@ -83,5 +83,35 @@ pub fn validate(config: &Config) -> Result<(), ConfigError> {
             "Monitoring window_size must be > 0".into(),
         ));
     }
+    validate_liveness(&config.scheduler.liveness)?;
+    Ok(())
+}
+
+/// Upper bound for liveness hour knobs — a year, which keeps every
+/// `chrono::Duration::hours` conversion far from overflow.
+const MAX_LIVENESS_HOURS: u64 = 8760;
+
+fn validate_liveness(liveness: &super::LivenessConfig) -> Result<(), ConfigError> {
+    if !liveness.enabled {
+        return Ok(());
+    }
+    if liveness.alert_after_consecutive_failures == 0 {
+        return Err(ConfigError::Validation(
+            "Scheduler liveness alert_after_consecutive_failures must be > 0".into(),
+        ));
+    }
+    for (name, hours) in [
+        (
+            "global_silence_alert_hours",
+            liveness.global_silence_alert_hours,
+        ),
+        ("alert_backoff_hours", liveness.alert_backoff_hours),
+    ] {
+        if hours == 0 || hours > MAX_LIVENESS_HOURS {
+            return Err(ConfigError::Validation(format!(
+                "Scheduler liveness {name} must be between 1 and {MAX_LIVENESS_HOURS}"
+            )));
+        }
+    }
     Ok(())
 }

--- a/src/context/micro_compact.rs
+++ b/src/context/micro_compact.rs
@@ -601,11 +601,11 @@ mod tests {
 
     #[test]
     fn micro_compact_strips_resolved_tool_pairs() {
-        let mut messages = Vec::new();
-
-        // Tool use + result pair (old, will be resolved)
-        messages.push(tool_use_msg("t1", "read_file"));
-        messages.push(tool_result_msg("t1", &large_text(100)));
+        let mut messages = vec![
+            // Tool use + result pair (old, will be resolved)
+            tool_use_msg("t1", "read_file"),
+            tool_result_msg("t1", &large_text(100)),
+        ];
 
         // Two assistant messages after (makes the pair "resolved")
         messages.push(text_msg(
@@ -760,10 +760,10 @@ mod tests {
 
     #[test]
     fn micro_compact_result_tracks_all_metrics() {
-        let mut messages = Vec::new();
-
-        // System messages to collapse
-        messages.push(text_msg(Role::User, "sys 1", Some(MessageSource::System)));
+        let mut messages = vec![
+            // System messages to collapse
+            text_msg(Role::User, "sys 1", Some(MessageSource::System)),
+        ];
         messages.push(text_msg(Role::User, "sys 2", Some(MessageSource::System)));
 
         // Tool pair to strip

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -102,6 +102,34 @@ pub enum PromptError {
     Assembly(String),
     #[error("prompt IO error: {0}")]
     Io(#[from] std::io::Error),
+    #[error(
+        "essential system prompt components are {bytes} bytes, over the {limit} byte hard limit — \
+         essential content is never auto-trimmed, so trim CLAUDE.md or the rules directory by hand"
+    )]
+    EssentialTooLarge { bytes: usize, limit: usize },
+}
+
+/// Errors from driving the Claude Code CLI subprocess.
+#[derive(Debug, Error)]
+pub enum ClaudeCliError {
+    #[error(
+        "claude CLI at '{bin}' does not support --system-prompt-file — upgrade the CLI; \
+         pulse-null requires it to keep the system prompt off argv (a single argv argument is \
+         capped at 128KB and an oversized prompt fails every spawn with E2BIG)"
+    )]
+    SystemPromptFileUnsupported { bin: String },
+    #[error("failed to probe claude CLI at '{bin}' for --system-prompt-file support: {source}")]
+    Probe {
+        bin: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to stage the system prompt file at '{path}': {source}")]
+    SystemPromptFile {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 /// Top-level error type for CLI and binary boundaries.

--- a/src/init/templates.rs
+++ b/src/init/templates.rs
@@ -80,6 +80,12 @@ timezone = "{timezone}"
 # share_webhook = "https://discord.com/api/webhooks/..."
 # call_endpoint = "http://localhost:8443/api/call"
 
+[scheduler.liveness]
+enabled = true
+alert_after_consecutive_failures = 3
+global_silence_alert_hours = 6
+alert_backoff_hours = 6
+
 [pipeline]
 enabled = true
 learning_soft = 5

--- a/src/intake_audit.rs
+++ b/src/intake_audit.rs
@@ -16,6 +16,10 @@ use serde::Serialize;
 const AUDIT_FILE: &str = "intake-audit.jsonl";
 #[allow(dead_code)]
 const MAX_AUDIT_LINES: usize = 500;
+/// Byte ceiling for the audit file. A line cap alone bounds nothing: a `detail`
+/// field can be arbitrarily long, so 500 entries can still be megabytes.
+#[allow(dead_code)]
+const MAX_AUDIT_BYTES: usize = 64 * 1024;
 
 /// A single audit entry recording an interaction's pipeline flow.
 #[derive(Debug, Serialize)]
@@ -95,8 +99,8 @@ pub fn entry(
     }
 }
 
-/// Rotate the audit file if it exceeds MAX_AUDIT_LINES.
-/// Keeps the most recent half of entries.
+/// Rotate the audit file if it exceeds MAX_AUDIT_LINES or MAX_AUDIT_BYTES.
+/// Keeps the most recent entries that fit under both ceilings.
 #[allow(dead_code)]
 pub fn rotate_if_needed(root_dir: &Path) {
     let audit_path = root_dir.join(AUDIT_FILE);
@@ -107,12 +111,18 @@ pub fn rotate_if_needed(root_dir: &Path) {
     };
 
     let lines: Vec<&str> = content.lines().collect();
-    if lines.len() <= MAX_AUDIT_LINES {
+    if lines.len() <= MAX_AUDIT_LINES && content.len() <= MAX_AUDIT_BYTES {
         return;
     }
 
-    // Keep the most recent half
-    let keep_from = lines.len() - (MAX_AUDIT_LINES / 2);
+    // Keep the most recent half, then walk forward until the tail fits the
+    // byte ceiling as well.
+    let mut keep_from = lines.len().saturating_sub(MAX_AUDIT_LINES / 2);
+    let mut kept_bytes: usize = lines[keep_from..].iter().map(|l| l.len() + 1).sum();
+    while keep_from < lines.len() && kept_bytes > MAX_AUDIT_BYTES {
+        kept_bytes = kept_bytes.saturating_sub(lines[keep_from].len() + 1);
+        keep_from += 1;
+    }
     let kept: String = lines[keep_from..].join("\n") + "\n";
     if let Err(e) = fs::write(&audit_path, kept) {
         tracing::error!("Failed to rotate audit file: {}", e);
@@ -176,5 +186,37 @@ mod tests {
         assert!(lines.len() <= MAX_AUDIT_LINES / 2 + 1);
         // Should keep the most recent entries
         assert!(lines.last().unwrap().contains("id-599"));
+    }
+
+    /// PN-75: 500 entries say nothing about size — a fat `detail` field can
+    /// make a few dozen lines megabytes.
+    #[test]
+    fn rotate_enforces_the_byte_ceiling() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        let fat = "d".repeat(8 * 1024);
+        let mut content = String::new();
+        for i in 0..40 {
+            content.push_str(&format!(
+                "{{\"interaction_id\":\"id-{i}\",\"detail\":\"{fat}\"}}\n"
+            ));
+        }
+        assert!(content.len() > MAX_AUDIT_BYTES);
+        fs::write(root.join(AUDIT_FILE), &content).unwrap();
+
+        rotate_if_needed(root);
+
+        let after = fs::read_to_string(root.join(AUDIT_FILE)).unwrap();
+        assert!(
+            after.len() <= MAX_AUDIT_BYTES,
+            "audit file still {} bytes",
+            after.len()
+        );
+        let lines: Vec<&str> = after.lines().filter(|l| !l.is_empty()).collect();
+        assert!(lines.last().unwrap().contains("id-39"));
+        for line in lines {
+            serde_json::from_str::<serde_json::Value>(line).unwrap();
+        }
     }
 }

--- a/src/logbook.rs
+++ b/src/logbook.rs
@@ -6,12 +6,34 @@ use chrono::Utc;
 
 /// Maximum lines before rotation triggers.
 const MAX_LINES: usize = 200;
+/// Maximum bytes before rotation triggers. A line cap bounds entry *count*,
+/// not size — one 200KB entry is still one line.
+const MAX_BYTES: usize = 64 * 1024;
 /// Lines to keep from the end after rotation.
 const KEEP_TAIL: usize = 50;
 /// Lines to keep from the start (title/header).
 const KEEP_HEADER: usize = 3;
+/// Byte share of MAX_BYTES the header may claim.
+const HEADER_MAX_BYTES: usize = MAX_BYTES / 4;
+/// Byte allowance reserved for the "rotated" note.
+const ROTATION_NOTE_MAX_BYTES: usize = 128;
 
-/// Rotate LOGBOOK.md when it exceeds MAX_LINES.
+/// Take lines while their total size (including newlines) stays within budget.
+fn take_within_budget<'a>(lines: impl Iterator<Item = &'a str>, budget: usize) -> Vec<&'a str> {
+    let mut kept = Vec::new();
+    let mut used = 0usize;
+    for line in lines {
+        let cost = line.len() + 1;
+        if used + cost > budget {
+            break;
+        }
+        used += cost;
+        kept.push(line);
+    }
+    kept
+}
+
+/// Rotate LOGBOOK.md when it exceeds MAX_LINES or MAX_BYTES.
 /// Archives the full file and keeps header + most recent KEEP_TAIL lines.
 pub fn rotate_if_needed(root_dir: &Path, logbook_path: &Path) {
     let content = match std::fs::read_to_string(logbook_path) {
@@ -20,7 +42,7 @@ pub fn rotate_if_needed(root_dir: &Path, logbook_path: &Path) {
     };
 
     let lines: Vec<&str> = content.lines().collect();
-    if lines.len() <= MAX_LINES {
+    if lines.len() <= MAX_LINES && content.len() <= MAX_BYTES {
         return;
     }
 
@@ -38,17 +60,14 @@ pub fn rotate_if_needed(root_dir: &Path, logbook_path: &Path) {
         return;
     }
 
-    // Keep header + most recent entries
-    let header: Vec<&str> = lines.iter().take(KEEP_HEADER).copied().collect();
-    let tail: Vec<&str> = lines
-        .iter()
-        .rev()
-        .take(KEEP_TAIL)
-        .copied()
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .collect();
+    // Keep header + most recent entries, bounded by lines and by bytes.
+    // The full content is archived above, so anything dropped here is
+    // recoverable from the archive.
+    let header = take_within_budget(lines.iter().take(KEEP_HEADER).copied(), HEADER_MAX_BYTES);
+    let header_bytes: usize = header.iter().map(|l| l.len() + 1).sum();
+    let tail_budget = MAX_BYTES.saturating_sub(header_bytes + ROTATION_NOTE_MAX_BYTES);
+    let mut tail = take_within_budget(lines.iter().rev().take(KEEP_TAIL).copied(), tail_budget);
+    tail.reverse();
 
     let mut rotated = header.join("\n");
     rotated.push_str(&format!(
@@ -63,9 +82,10 @@ pub fn rotate_if_needed(root_dir: &Path, logbook_path: &Path) {
         tracing::error!("Failed to write rotated LOGBOOK: {}", e);
     } else {
         tracing::info!(
-            "LOGBOOK rotated: {} lines → ~{} lines (archived to {})",
+            "LOGBOOK rotated: {} lines / {} bytes → {} lines (archived to {})",
             lines.len(),
-            KEEP_HEADER + KEEP_TAIL + 2,
+            content.len(),
+            header.len() + tail.len() + 2,
             archive_path.display()
         );
     }
@@ -215,4 +235,63 @@ pub fn log_session_end(
         &format!("{}, {} messages", channel, message_count),
         &archive_note,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn logbook_path(root: &Path) -> std::path::PathBuf {
+        let journal = root.join("journal");
+        std::fs::create_dir_all(&journal).unwrap();
+        journal.join("LOGBOOK.md")
+    }
+
+    #[test]
+    fn small_logbook_is_not_rotated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = logbook_path(tmp.path());
+        std::fs::write(&path, "# LOGBOOK\n\n### entry\n").unwrap();
+
+        rotate_if_needed(tmp.path(), &path);
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "# LOGBOOK\n\n### entry\n"
+        );
+        assert!(!tmp.path().join("archives").exists());
+    }
+
+    /// PN-75: 200 lines is not 200 lines' worth of bytes — one runaway entry
+    /// must still trigger rotation.
+    #[test]
+    fn oversized_logbook_rotates_on_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = logbook_path(tmp.path());
+
+        let mut content = String::from("# LOGBOOK\n\n");
+        content.push_str(&"g".repeat(MAX_BYTES + 1024));
+        content.push('\n');
+        std::fs::write(&path, &content).unwrap();
+
+        rotate_if_needed(tmp.path(), &path);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            after.len() <= MAX_BYTES,
+            "rotated LOGBOOK still {} bytes",
+            after.len()
+        );
+        assert!(after.starts_with("# LOGBOOK"));
+        assert!(after.contains("Rotated"));
+
+        // The full content is preserved in the archive.
+        let archives = std::fs::read_dir(tmp.path().join("archives")).unwrap();
+        let archived: Vec<_> = archives.flatten().collect();
+        assert_eq!(archived.len(), 1);
+        assert_eq!(
+            std::fs::read_to_string(archived[0].path()).unwrap(),
+            content
+        );
+    }
 }

--- a/src/praxis/parser.rs
+++ b/src/praxis/parser.rs
@@ -113,17 +113,10 @@ fn extract_date_field(line: &str, field: &str) -> Option<String> {
     let lower = line.to_lowercase();
     let field_lower = field.to_lowercase();
 
-    // Match patterns like "**Last touched**: 2026-02-26" or "Last touched: 2026-02-26"
-    if lower.contains(&field_lower) {
-        // Find a date pattern (YYYY-MM-DD) after the field name
-        let after_field = if let Some(idx) = lower.find(&field_lower) {
-            &line[idx + field.len()..]
-        } else {
-            return None;
-        };
-        return find_date_in_str(after_field);
-    }
-    None
+    // Match patterns like "**Last touched**: 2026-02-26" or "Last touched: 2026-02-26",
+    // then look for a YYYY-MM-DD after the field name.
+    let idx = lower.find(&field_lower)?;
+    find_date_in_str(&line[idx + field.len()..])
 }
 
 /// Find first YYYY-MM-DD pattern in a string.

--- a/src/scheduler/health.rs
+++ b/src/scheduler/health.rs
@@ -1,0 +1,1310 @@
+//! Scheduler liveness: persisted per-task health and the alert state machine.
+//!
+//! Echo's seven scheduled tasks failed every cycle for seven weeks and nothing
+//! escalated: per-error `[ERROR]` webhooks fired, but nothing said "this task
+//! has failed 500 times in a row" or "nothing has succeeded in six weeks".
+//! This module is the missing memory — a small JSON store next to
+//! `predictions.json` / `intents.json` that survives restarts, plus the pure
+//! rules that turn its contents into `[ALERT]` / `[RESOLVED]` messages.
+//!
+//! ## Separation of concerns
+//!
+//! Everything here is pure state and pure decisions: it never talks to the
+//! network and never sleeps. `now` is always an explicit parameter, so the
+//! rules are table-testable without a clock. Delivery of the decisions lives
+//! in [`super::liveness`].
+//!
+//! ## Deliver-then-commit
+//!
+//! [`TaskHealthStore::pending_task_alert`] *decides*; the caller *delivers*;
+//! only then does [`TaskHealthStore::mark_task_alert_delivered`] record that
+//! it went out. A webhook failure therefore leaves the alert pending and the
+//! next watchdog tick retries it (AC7).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::config::LivenessConfig;
+use crate::errors::SchedulerError;
+
+/// Persisted health store, in the entity root alongside `predictions.json`.
+const TASK_HEALTH_FILE: &str = "task_health.json";
+
+/// Temporary file used for the atomic write.
+const TASK_HEALTH_TMP: &str = "task_health.json.tmp";
+
+/// Stored length limit for the last error message of a streak.
+const MAX_ERROR_LEN: usize = 300;
+
+/// A task counts as stale when its last success is older than this multiple
+/// of its own firing interval.
+const STALE_INTERVAL_MULTIPLIER: i32 = 2;
+
+/// Repeat alerts wait `alert_backoff_hours`, then this multiple of it
+/// (6h then 24h with the default config).
+const LATE_BACKOFF_MULTIPLIER: u64 = 4;
+
+// ---------------------------------------------------------------------------
+// Persisted state
+// ---------------------------------------------------------------------------
+
+/// Liveness history for a single scheduled task.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TaskHealth {
+    /// Human-readable task name, refreshed on every recorded outcome.
+    pub task_name: String,
+    /// Failures since the last success. Zero means the task is healthy.
+    pub consecutive_failures: u32,
+    pub last_success: Option<DateTime<Utc>>,
+    pub last_failure: Option<DateTime<Utc>>,
+    /// When the current failure streak began (`None` when healthy).
+    pub first_failure_of_streak: Option<DateTime<Utc>>,
+    /// When the last alert for the current streak was *delivered*.
+    pub last_alert_at: Option<DateTime<Utc>>,
+    /// Alerts delivered for the current streak — drives the backoff ladder.
+    pub alerts_sent_this_streak: u32,
+    /// Most recent failure reason, truncated for storage.
+    pub last_error: Option<String>,
+    /// A recovery that has not been announced yet. Set on the success that
+    /// ends an *alerted* streak, cleared once the `[RESOLVED]` is delivered.
+    pub pending_resolution: Option<Resolution>,
+}
+
+/// A recovery awaiting its `[RESOLVED]` message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Resolution {
+    /// Length of the streak that just ended.
+    pub failures: u32,
+    /// When that streak started.
+    pub streak_started: Option<DateTime<Utc>>,
+    /// When the task succeeded again.
+    pub recovered_at: DateTime<Utc>,
+}
+
+/// Alert bookkeeping for the global "nothing has succeeded" rule.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GlobalHealth {
+    pub last_alert_at: Option<DateTime<Utc>>,
+    pub alerts_sent: u32,
+    /// End of an alerted silence, awaiting its `[RESOLVED]`.
+    pub pending_resolution: Option<GlobalResolution>,
+}
+
+/// The success that ended an alerted global silence.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GlobalResolution {
+    /// Start of the silence that just ended.
+    pub silent_since: DateTime<Utc>,
+    pub recovered_at: DateTime<Utc>,
+    /// Task that broke the silence.
+    pub task_id: String,
+}
+
+/// On-disk shape of `task_health.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+struct TaskHealthFile {
+    /// When the store was first created — the origin for the global silence
+    /// window before any task has ever succeeded.
+    created_at: DateTime<Utc>,
+    tasks: BTreeMap<String, TaskHealth>,
+    global: GlobalHealth,
+}
+
+impl Default for TaskHealthFile {
+    fn default() -> Self {
+        Self {
+            created_at: Utc::now(),
+            tasks: BTreeMap::new(),
+            global: GlobalHealth::default(),
+        }
+    }
+}
+
+/// File-backed liveness store. Every mutation persists immediately with an
+/// atomic write, so a crash can lose at most the outcome being recorded —
+/// never an existing streak.
+#[derive(Debug)]
+pub struct TaskHealthStore {
+    file: TaskHealthFile,
+    path: PathBuf,
+    tmp_path: PathBuf,
+}
+
+impl TaskHealthStore {
+    /// Load the store from `root_dir`, or start an empty one.
+    ///
+    /// A missing or corrupt file never fails the scheduler: liveness
+    /// bookkeeping must not be able to take the entity down.
+    #[must_use]
+    pub fn load(root_dir: &Path) -> Self {
+        let path = root_dir.join(TASK_HEALTH_FILE);
+        let tmp_path = root_dir.join(TASK_HEALTH_TMP);
+
+        let file = match std::fs::read_to_string(&path) {
+            Ok(content) => match serde_json::from_str::<TaskHealthFile>(&content) {
+                Ok(f) => {
+                    // Debug, not info: `pulse-null status` loads this too and
+                    // must stay readable.
+                    tracing::debug!(
+                        tasks = f.tasks.len(),
+                        "Loaded scheduler health store from {}",
+                        path.display()
+                    );
+                    f
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Corrupt {} — starting with empty health store",
+                        TASK_HEALTH_FILE
+                    );
+                    TaskHealthFile::default()
+                }
+            },
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to read {} — starting with empty health store",
+                        TASK_HEALTH_FILE
+                    );
+                }
+                TaskHealthFile::default()
+            }
+        };
+
+        Self {
+            file,
+            path,
+            tmp_path,
+        }
+    }
+
+    /// Record a successful execution.
+    ///
+    /// Ends any failure streak. If that streak had already alerted, a
+    /// `[RESOLVED]` is queued for the next delivery pass. Any success also
+    /// ends the global silence — and if that silence had alerted, queues its
+    /// own `[RESOLVED]` so an escalation never dangles unanswered.
+    pub fn record_success(&mut self, task_id: &str, task_name: &str, now: DateTime<Utc>) {
+        let silence_alerted = self.file.global.alerts_sent > 0;
+        let silent_since = self.last_success_any().unwrap_or(self.file.created_at);
+
+        let health = self.entry(task_id, task_name);
+        if health.alerts_sent_this_streak > 0 {
+            health.pending_resolution = Some(Resolution {
+                failures: health.consecutive_failures,
+                streak_started: health.first_failure_of_streak,
+                recovered_at: now,
+            });
+        }
+        health.consecutive_failures = 0;
+        health.first_failure_of_streak = None;
+        health.last_alert_at = None;
+        health.alerts_sent_this_streak = 0;
+        health.last_success = Some(now);
+
+        self.file.global = GlobalHealth {
+            pending_resolution: silence_alerted.then(|| GlobalResolution {
+                silent_since,
+                recovered_at: now,
+                task_id: task_id.to_string(),
+            }),
+            ..GlobalHealth::default()
+        };
+        self.persist();
+    }
+
+    /// Record a failed execution, extending (or starting) the streak.
+    pub fn record_failure(
+        &mut self,
+        task_id: &str,
+        task_name: &str,
+        error: &str,
+        now: DateTime<Utc>,
+    ) {
+        let health = self.entry(task_id, task_name);
+        if health.consecutive_failures == 0 {
+            health.first_failure_of_streak = Some(now);
+            health.last_alert_at = None;
+            health.alerts_sent_this_streak = 0;
+        }
+        health.consecutive_failures = health.consecutive_failures.saturating_add(1);
+        health.last_failure = Some(now);
+        health.last_error = Some(crate::utils::safe_truncate(error, MAX_ERROR_LEN).to_string());
+        self.persist();
+    }
+
+    /// Health for one task, if it has ever reported an outcome.
+    #[must_use]
+    pub fn get(&self, task_id: &str) -> Option<&TaskHealth> {
+        self.file.tasks.get(task_id)
+    }
+
+    /// Most recent success across every known task.
+    #[must_use]
+    pub fn last_success_any(&self) -> Option<DateTime<Utc>> {
+        self.file
+            .tasks
+            .values()
+            .filter_map(|h| h.last_success)
+            .max()
+    }
+
+    /// When the store started tracking — the origin of the global silence
+    /// window while no task has ever succeeded.
+    #[must_use]
+    pub fn created_at(&self) -> DateTime<Utc> {
+        self.file.created_at
+    }
+
+    /// The alert this task currently owes, if any.
+    ///
+    /// A pending `[RESOLVED]` outranks a new failure alert so the operator
+    /// reads the outage story in order. Returns `None` when the task is
+    /// healthy, below the threshold, or inside its backoff window.
+    #[must_use]
+    pub fn pending_task_alert(
+        &self,
+        task_id: &str,
+        config: &LivenessConfig,
+        now: DateTime<Utc>,
+    ) -> Option<LivenessAlert> {
+        let health = self.file.tasks.get(task_id)?;
+
+        if let Some(resolution) = &health.pending_resolution {
+            return Some(LivenessAlert::TaskRecovered {
+                task_id: task_id.to_string(),
+                task_name: health.task_name.clone(),
+                failures: resolution.failures,
+                streak_started: resolution.streak_started,
+                recovered_at: resolution.recovered_at,
+            });
+        }
+
+        if health.consecutive_failures < config.alert_after_consecutive_failures {
+            return None;
+        }
+        if !alert_due(
+            health.last_alert_at,
+            health.alerts_sent_this_streak,
+            config,
+            now,
+        ) {
+            return None;
+        }
+
+        Some(LivenessAlert::TaskFailing {
+            task_id: task_id.to_string(),
+            task_name: health.task_name.clone(),
+            consecutive_failures: health.consecutive_failures,
+            streak_started: health.first_failure_of_streak,
+            last_error: health.last_error.clone(),
+            repeat: health.alerts_sent_this_streak,
+        })
+    }
+
+    /// Commit a delivered task alert so the backoff clock starts.
+    ///
+    /// Call this only after the alert actually reached the webhook — an
+    /// undelivered alert must stay pending for the next tick.
+    pub fn mark_task_alert_delivered(
+        &mut self,
+        task_id: &str,
+        alert: &LivenessAlert,
+        now: DateTime<Utc>,
+    ) {
+        let Some(health) = self.file.tasks.get_mut(task_id) else {
+            return;
+        };
+        match alert {
+            LivenessAlert::TaskRecovered { .. } => health.pending_resolution = None,
+            LivenessAlert::TaskFailing { .. } => {
+                health.last_alert_at = Some(now);
+                health.alerts_sent_this_streak = health.alerts_sent_this_streak.saturating_add(1);
+            }
+            LivenessAlert::GlobalSilence { .. } | LivenessAlert::GlobalRecovered { .. } => {
+                tracing::warn!("Global alert passed to per-task delivery bookkeeping — ignored");
+                return;
+            }
+        }
+        self.persist();
+    }
+
+    /// The global "nothing is alive" alert (or its all-clear), if one is due.
+    ///
+    /// Fires when at least one task is enabled and no task has succeeded for
+    /// `global_silence_alert_hours`. This is the rule that would have caught
+    /// the seven-week outage on day one. A pending all-clear is returned even
+    /// with no tasks enabled — good news is never withheld.
+    #[must_use]
+    pub fn pending_global_alert(
+        &self,
+        config: &LivenessConfig,
+        enabled_tasks: usize,
+        now: DateTime<Utc>,
+    ) -> Option<LivenessAlert> {
+        if let Some(resolution) = &self.file.global.pending_resolution {
+            return Some(LivenessAlert::GlobalRecovered {
+                since: resolution.silent_since,
+                silent_for: resolution.recovered_at - resolution.silent_since,
+                task_id: resolution.task_id.clone(),
+            });
+        }
+        if enabled_tasks == 0 {
+            return None;
+        }
+        let last_success = self.last_success_any();
+        let since = last_success.unwrap_or(self.file.created_at);
+        let silent_for = now - since;
+        if silent_for < hours(config.global_silence_alert_hours) {
+            return None;
+        }
+        if !alert_due(
+            self.file.global.last_alert_at,
+            self.file.global.alerts_sent,
+            config,
+            now,
+        ) {
+            return None;
+        }
+        Some(LivenessAlert::GlobalSilence {
+            since,
+            silent_for,
+            ever_succeeded: last_success.is_some(),
+            enabled_tasks,
+            repeat: self.file.global.alerts_sent,
+        })
+    }
+
+    /// Commit a delivered global alert so the backoff clock starts.
+    ///
+    /// As with tasks: only call this once the webhook accepted the message.
+    pub fn mark_global_alert_delivered(&mut self, alert: &LivenessAlert, now: DateTime<Utc>) {
+        match alert {
+            LivenessAlert::GlobalRecovered { .. } => self.file.global.pending_resolution = None,
+            LivenessAlert::GlobalSilence { .. } => {
+                self.file.global.last_alert_at = Some(now);
+                self.file.global.alerts_sent = self.file.global.alerts_sent.saturating_add(1);
+            }
+            LivenessAlert::TaskFailing { .. } | LivenessAlert::TaskRecovered { .. } => {
+                tracing::warn!("Task alert passed to global delivery bookkeeping — ignored");
+                return;
+            }
+        }
+        self.persist();
+    }
+
+    fn entry(&mut self, task_id: &str, task_name: &str) -> &mut TaskHealth {
+        let health = self.file.tasks.entry(task_id.to_string()).or_default();
+        if !task_name.is_empty() {
+            health.task_name = task_name.to_string();
+        }
+        health
+    }
+
+    /// Write the store atomically (tmp file + rename), so an interrupted
+    /// write can never leave a half-serialized `task_health.json` behind.
+    fn save(&self) -> Result<(), SchedulerError> {
+        let content = serde_json::to_string_pretty(&self.file)?;
+        std::fs::write(&self.tmp_path, &content)?;
+        std::fs::rename(&self.tmp_path, &self.path)?;
+        Ok(())
+    }
+
+    fn persist(&self) {
+        if let Err(e) = self.save() {
+            tracing::error!(error = %e, "Failed to persist scheduler health store");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Alerts
+// ---------------------------------------------------------------------------
+
+/// A liveness message that owes delivery to the operator.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LivenessAlert {
+    /// One task has crossed the consecutive-failure threshold.
+    TaskFailing {
+        task_id: String,
+        task_name: String,
+        consecutive_failures: u32,
+        streak_started: Option<DateTime<Utc>>,
+        last_error: Option<String>,
+        /// Alerts already sent for this streak (0 = first alert).
+        repeat: u32,
+    },
+    /// A task succeeded again after an alerted streak.
+    TaskRecovered {
+        task_id: String,
+        task_name: String,
+        failures: u32,
+        streak_started: Option<DateTime<Utc>>,
+        recovered_at: DateTime<Utc>,
+    },
+    /// No task at all has succeeded inside the configured window.
+    GlobalSilence {
+        /// Last success across all tasks, or store creation if never.
+        since: DateTime<Utc>,
+        silent_for: Duration,
+        ever_succeeded: bool,
+        enabled_tasks: usize,
+        repeat: u32,
+    },
+    /// Some task succeeded again, ending an alerted global silence.
+    GlobalRecovered {
+        since: DateTime<Utc>,
+        silent_for: Duration,
+        task_id: String,
+    },
+}
+
+impl LivenessAlert {
+    /// Task this alert is about — `None` for the global rules.
+    #[must_use]
+    pub fn task_id(&self) -> Option<&str> {
+        match self {
+            LivenessAlert::TaskFailing { task_id, .. }
+            | LivenessAlert::TaskRecovered { task_id, .. } => Some(task_id),
+            LivenessAlert::GlobalSilence { .. } | LivenessAlert::GlobalRecovered { .. } => None,
+        }
+    }
+
+    /// The webhook body, rendered relative to `now`.
+    #[must_use]
+    pub fn message(&self, now: DateTime<Utc>) -> String {
+        match self {
+            LivenessAlert::TaskFailing {
+                task_id,
+                task_name,
+                consecutive_failures,
+                streak_started,
+                last_error,
+                repeat,
+            } => {
+                let mut msg = format!(
+                    "[ALERT] Scheduled task '{}' ({}) has failed {} time(s) in a row.",
+                    display_name(task_name, task_id),
+                    task_id,
+                    consecutive_failures
+                );
+                msg.push_str(&format!(
+                    "\nStreak started: {}",
+                    format_instant(*streak_started, now)
+                ));
+                if let Some(error) = last_error {
+                    msg.push_str(&format!("\nLast error: {error}"));
+                }
+                if *repeat > 0 {
+                    msg.push_str(&format!("\nStill failing (alert #{}).", repeat + 1));
+                }
+                msg
+            }
+            LivenessAlert::TaskRecovered {
+                task_id,
+                task_name,
+                failures,
+                streak_started,
+                recovered_at,
+            } => {
+                let broken_for = streak_started
+                    .map(|start| format_duration(*recovered_at - start))
+                    .unwrap_or_else(|| "unknown".to_string());
+                format!(
+                    "[RESOLVED] Scheduled task '{}' ({}) succeeded again after {} consecutive failure(s) — broken for {} (since {}).",
+                    display_name(task_name, task_id),
+                    task_id,
+                    failures,
+                    broken_for,
+                    format_instant(*streak_started, now),
+                )
+            }
+            LivenessAlert::GlobalSilence {
+                since,
+                silent_for,
+                ever_succeeded,
+                enabled_tasks,
+                repeat,
+            } => {
+                let head = if *ever_succeeded {
+                    format!(
+                        "[ALERT] LIVENESS: no scheduled task has succeeded in {}. Last success: {}.",
+                        format_duration(*silent_for),
+                        format_instant(Some(*since), now)
+                    )
+                } else {
+                    format!(
+                        "[ALERT] LIVENESS: no scheduled task has EVER succeeded — silent for {} since tracking began ({}).",
+                        format_duration(*silent_for),
+                        format_instant(Some(*since), now)
+                    )
+                };
+                let mut msg = format!(
+                    "{head}\n{enabled_tasks} task(s) enabled. Run `pulse-null status` for per-task detail."
+                );
+                if *repeat > 0 {
+                    msg.push_str(&format!("\nStill silent (alert #{}).", repeat + 1));
+                }
+                msg
+            }
+            LivenessAlert::GlobalRecovered {
+                since,
+                silent_for,
+                task_id,
+            } => format!(
+                "[RESOLVED] LIVENESS: task '{}' succeeded — the schedule is alive again after {} of silence (since {}).",
+                task_id,
+                format_duration(*silent_for),
+                format_instant(Some(*since), now)
+            ),
+        }
+    }
+}
+
+/// Whether an alert is due given when the last one went out.
+///
+/// The first alert of a streak is always due. Repeats wait
+/// `alert_backoff_hours`, then `LATE_BACKOFF_MULTIPLIER` times that.
+fn alert_due(
+    last_alert_at: Option<DateTime<Utc>>,
+    alerts_sent: u32,
+    config: &LivenessConfig,
+    now: DateTime<Utc>,
+) -> bool {
+    match last_alert_at {
+        None => true,
+        Some(sent_at) => now - sent_at >= backoff(alerts_sent, config),
+    }
+}
+
+fn backoff(alerts_sent: u32, config: &LivenessConfig) -> Duration {
+    if alerts_sent <= 1 {
+        hours(config.alert_backoff_hours)
+    } else {
+        hours(
+            config
+                .alert_backoff_hours
+                .saturating_mul(LATE_BACKOFF_MULTIPLIER),
+        )
+    }
+}
+
+/// Config hours as a `Duration`, clamped to a year (config validation
+/// enforces the same bound; this keeps the conversion total regardless).
+fn hours(value: u64) -> Duration {
+    Duration::hours(value.min(8760) as i64)
+}
+
+// ---------------------------------------------------------------------------
+// Status surface
+// ---------------------------------------------------------------------------
+
+/// How a task reads at a glance in `pulse-null status`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskStatusLevel {
+    /// Succeeded recently enough.
+    Ok,
+    /// Enabled but has never reported an outcome.
+    Idle,
+    /// Last success older than twice the task's own interval.
+    Stale,
+    /// Failing, but not yet at the alert threshold.
+    Degraded,
+    /// At or past the alert threshold.
+    Failing,
+    /// Turned off in schedule.json.
+    Disabled,
+}
+
+impl TaskStatusLevel {
+    /// Fixed-width marker so a column of tasks scans vertically.
+    #[must_use]
+    pub fn marker(self) -> &'static str {
+        match self {
+            TaskStatusLevel::Ok => "[ OK  ]",
+            TaskStatusLevel::Idle => "[IDLE ]",
+            TaskStatusLevel::Stale => "[STALE]",
+            TaskStatusLevel::Degraded => "[WARN ]",
+            TaskStatusLevel::Failing => "[FAIL ]",
+            TaskStatusLevel::Disabled => "[ off ]",
+        }
+    }
+
+    /// Whether this level needs the operator's attention.
+    #[must_use]
+    pub fn is_problem(self) -> bool {
+        matches!(
+            self,
+            TaskStatusLevel::Stale | TaskStatusLevel::Degraded | TaskStatusLevel::Failing
+        )
+    }
+}
+
+/// One task as the status command sees it.
+#[derive(Debug, Clone, Copy)]
+pub struct TaskStatusView<'a> {
+    pub task_id: &'a str,
+    pub task_name: &'a str,
+    pub enabled: bool,
+    /// Gap between consecutive firings, derived from the task's cron.
+    pub interval: Option<Duration>,
+    pub health: Option<&'a TaskHealth>,
+}
+
+/// Classify a task for the status surface.
+#[must_use]
+pub fn classify(
+    view: &TaskStatusView<'_>,
+    config: &LivenessConfig,
+    now: DateTime<Utc>,
+) -> TaskStatusLevel {
+    if !view.enabled {
+        return TaskStatusLevel::Disabled;
+    }
+    let Some(health) = view.health else {
+        return TaskStatusLevel::Idle;
+    };
+    if health.consecutive_failures >= config.alert_after_consecutive_failures {
+        return TaskStatusLevel::Failing;
+    }
+    if is_stale(view, now) {
+        return TaskStatusLevel::Stale;
+    }
+    if health.consecutive_failures > 0 {
+        return TaskStatusLevel::Degraded;
+    }
+    match health.last_success {
+        Some(_) => TaskStatusLevel::Ok,
+        None => TaskStatusLevel::Idle,
+    }
+}
+
+/// Whether the last success is older than twice the task's own interval.
+///
+/// A task with no known interval (unparseable cron) or no success yet is not
+/// called stale here — `classify` already surfaces those as `Idle`.
+#[must_use]
+fn is_stale(view: &TaskStatusView<'_>, now: DateTime<Utc>) -> bool {
+    let (Some(interval), Some(health)) = (view.interval, view.health) else {
+        return false;
+    };
+    let Some(last_success) = health.last_success else {
+        return false;
+    };
+    now - last_success > interval * STALE_INTERVAL_MULTIPLIER
+}
+
+/// One plain-text status line: marker, identity, last-success age, streak.
+#[must_use]
+pub fn status_line(
+    view: &TaskStatusView<'_>,
+    config: &LivenessConfig,
+    now: DateTime<Utc>,
+) -> String {
+    let level = classify(view, config, now);
+    let mut line = format!(
+        "{} {} ({}) — last success {}",
+        level.marker(),
+        display_name(view.task_name, view.task_id),
+        view.task_id,
+        format_age(view.health.and_then(|h| h.last_success), now),
+    );
+    if let Some(health) = view.health {
+        if health.consecutive_failures > 0 {
+            line.push_str(&format!(
+                "; {} consecutive failure(s), last {}",
+                health.consecutive_failures,
+                format_age(health.last_failure, now)
+            ));
+        }
+    }
+    if level == TaskStatusLevel::Stale {
+        if let Some(interval) = view.interval {
+            line.push_str(&format!("; STALE (interval {})", format_duration(interval)));
+        }
+    }
+    line
+}
+
+/// Gap between two consecutive firings of a cron expression, measured from
+/// `now`. Used as the staleness yardstick, so irregular schedules are judged
+/// against the interval they are actually in.
+#[must_use]
+pub fn interval_from_cron(cron_expr: &str, now: DateTime<Utc>) -> Option<Duration> {
+    use std::str::FromStr;
+
+    let schedule = cron::Schedule::from_str(&super::normalize_cron(cron_expr)).ok()?;
+    let mut upcoming = schedule.after(&now);
+    let first = upcoming.next()?;
+    let second = upcoming.next()?;
+    Some(second - first)
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+fn display_name<'a>(task_name: &'a str, task_id: &'a str) -> &'a str {
+    if task_name.is_empty() {
+        task_id
+    } else {
+        task_name
+    }
+}
+
+/// Coarse human duration: `3d 4h`, `6h 12m`, `45m`, `30s`.
+#[must_use]
+pub fn format_duration(duration: Duration) -> String {
+    let total = duration.num_seconds().max(0);
+    let days = total / 86_400;
+    let hours = (total % 86_400) / 3_600;
+    let minutes = (total % 3_600) / 60;
+    if days > 0 {
+        format!("{days}d {hours}h")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m")
+    } else {
+        format!("{total}s")
+    }
+}
+
+/// `never` or `3h 2m ago`.
+#[must_use]
+pub fn format_age(timestamp: Option<DateTime<Utc>>, now: DateTime<Utc>) -> String {
+    match timestamp {
+        Some(ts) => format!("{} ago", format_duration(now - ts)),
+        None => "never".to_string(),
+    }
+}
+
+/// Absolute timestamp plus relative age, or `unknown`.
+fn format_instant(timestamp: Option<DateTime<Utc>>, now: DateTime<Utc>) -> String {
+    match timestamp {
+        Some(ts) => format!(
+            "{} ({} ago)",
+            ts.format("%Y-%m-%d %H:%M UTC"),
+            format_duration(now - ts)
+        ),
+        None => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn config() -> LivenessConfig {
+        LivenessConfig::default()
+    }
+
+    fn at(hours_from_epoch: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(hours_from_epoch * 3600, 0).expect("valid timestamp")
+    }
+
+    fn fail_n(store: &mut TaskHealthStore, task: &str, count: u32, start: DateTime<Utc>) {
+        for i in 0..count {
+            store.record_failure(task, "Task", "boom", start + Duration::minutes(i as i64));
+        }
+    }
+
+    // -- store ------------------------------------------------------------
+
+    #[test]
+    fn empty_store_reports_nothing() {
+        let dir = TempDir::new().unwrap();
+        let store = TaskHealthStore::load(dir.path());
+        assert!(store.get("anything").is_none());
+        assert!(store.last_success_any().is_none());
+        assert!(store
+            .pending_task_alert("anything", &config(), at(1))
+            .is_none());
+    }
+
+    #[test]
+    fn failure_starts_streak_and_success_resets_it() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+
+        store.record_failure("t", "Task", "boom", at(1));
+        store.record_failure("t", "Task", "boom again", at(2));
+        let health = store.get("t").unwrap();
+        assert_eq!(health.consecutive_failures, 2);
+        assert_eq!(health.first_failure_of_streak, Some(at(1)));
+        assert_eq!(health.last_failure, Some(at(2)));
+        assert_eq!(health.last_error.as_deref(), Some("boom again"));
+
+        store.record_success("t", "Task", at(3));
+        let health = store.get("t").unwrap();
+        assert_eq!(health.consecutive_failures, 0);
+        assert!(health.first_failure_of_streak.is_none());
+        assert_eq!(health.last_success, Some(at(3)));
+    }
+
+    #[test]
+    fn persistence_round_trip_preserves_streak() {
+        let dir = TempDir::new().unwrap();
+        {
+            let mut store = TaskHealthStore::load(dir.path());
+            fail_n(&mut store, "t", 4, at(1));
+            store.record_success("other", "Other", at(2));
+        }
+        let store = TaskHealthStore::load(dir.path());
+        assert_eq!(store.get("t").unwrap().consecutive_failures, 4);
+        assert_eq!(store.get("t").unwrap().task_name, "Task");
+        assert_eq!(store.last_success_any(), Some(at(2)));
+    }
+
+    #[test]
+    fn crash_mid_update_leaves_last_good_state() {
+        let dir = TempDir::new().unwrap();
+        {
+            let mut store = TaskHealthStore::load(dir.path());
+            fail_n(&mut store, "t", 3, at(1));
+        }
+        // Simulate a crash between the tmp write and the rename.
+        std::fs::write(dir.path().join(TASK_HEALTH_TMP), "{ truncated json").unwrap();
+
+        let store = TaskHealthStore::load(dir.path());
+        assert_eq!(store.get("t").unwrap().consecutive_failures, 3);
+    }
+
+    #[test]
+    fn corrupt_store_starts_empty_instead_of_failing() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join(TASK_HEALTH_FILE), "not json at all").unwrap();
+        let store = TaskHealthStore::load(dir.path());
+        assert!(store.get("t").is_none());
+    }
+
+    // -- per-task alert rules ---------------------------------------------
+
+    #[test]
+    fn no_alert_below_threshold() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        fail_n(&mut store, "t", 2, at(1));
+        assert!(store.pending_task_alert("t", &config(), at(2)).is_none());
+    }
+
+    #[test]
+    fn alert_at_threshold_names_task_count_and_streak_start() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        fail_n(&mut store, "t", 3, at(1));
+
+        let alert = store.pending_task_alert("t", &config(), at(2)).unwrap();
+        let LivenessAlert::TaskFailing {
+            consecutive_failures,
+            streak_started,
+            repeat,
+            ..
+        } = &alert
+        else {
+            panic!("expected TaskFailing, got {alert:?}");
+        };
+        assert_eq!(*consecutive_failures, 3);
+        assert_eq!(*streak_started, Some(at(1)));
+        assert_eq!(*repeat, 0);
+
+        let message = alert.message(at(2));
+        assert!(message.starts_with("[ALERT]"));
+        assert!(message.contains("Task"));
+        assert!(message.contains("3 time(s)"));
+        assert!(message.contains("boom"));
+    }
+
+    #[test]
+    fn alert_fires_once_until_backoff_elapses() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let cfg = config();
+        fail_n(&mut store, "t", 3, at(1));
+
+        let alert = store.pending_task_alert("t", &cfg, at(2)).unwrap();
+        store.mark_task_alert_delivered("t", &alert, at(2));
+
+        // Silent inside the first backoff window (6h).
+        assert!(store.pending_task_alert("t", &cfg, at(3)).is_none());
+        assert!(store.pending_task_alert("t", &cfg, at(7)).is_none());
+
+        // Due at +6h.
+        let repeat = store.pending_task_alert("t", &cfg, at(8)).unwrap();
+        let LivenessAlert::TaskFailing { repeat: n, .. } = &repeat else {
+            panic!("expected TaskFailing");
+        };
+        assert_eq!(*n, 1);
+        assert!(repeat.message(at(8)).contains("alert #2"));
+        store.mark_task_alert_delivered("t", &repeat, at(8));
+
+        // Second window is 24h, not 6h.
+        assert!(store.pending_task_alert("t", &cfg, at(8 + 6)).is_none());
+        assert!(store.pending_task_alert("t", &cfg, at(8 + 23)).is_none());
+        assert!(store.pending_task_alert("t", &cfg, at(8 + 24)).is_some());
+    }
+
+    #[test]
+    fn undelivered_alert_stays_pending_for_the_next_cycle() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let cfg = config();
+        fail_n(&mut store, "t", 3, at(1));
+
+        // Webhook failed: no mark_task_alert_delivered call.
+        let first = store.pending_task_alert("t", &cfg, at(2)).unwrap();
+        let retry = store.pending_task_alert("t", &cfg, at(2)).unwrap();
+        assert_eq!(first, retry);
+
+        // ...and it survives a restart, still pending.
+        let store = TaskHealthStore::load(dir.path());
+        assert!(store.pending_task_alert("t", &cfg, at(2)).is_some());
+    }
+
+    #[test]
+    fn recovery_after_alerted_streak_resolves_once() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let cfg = config();
+        fail_n(&mut store, "t", 3, at(1));
+        let alert = store.pending_task_alert("t", &cfg, at(2)).unwrap();
+        store.mark_task_alert_delivered("t", &alert, at(2));
+
+        store.record_success("t", "Task", at(30));
+        let resolved = store.pending_task_alert("t", &cfg, at(30)).unwrap();
+        let LivenessAlert::TaskRecovered { failures, .. } = &resolved else {
+            panic!("expected TaskRecovered, got {resolved:?}");
+        };
+        assert_eq!(*failures, 3);
+        let message = resolved.message(at(30));
+        assert!(message.starts_with("[RESOLVED]"));
+        assert!(message.contains("broken for 1d 5h"));
+
+        store.mark_task_alert_delivered("t", &resolved, at(30));
+        assert!(store.pending_task_alert("t", &cfg, at(30)).is_none());
+    }
+
+    #[test]
+    fn recovery_without_alert_stays_quiet() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        fail_n(&mut store, "t", 2, at(1));
+        store.record_success("t", "Task", at(2));
+        assert!(store.pending_task_alert("t", &config(), at(2)).is_none());
+    }
+
+    #[test]
+    fn new_streak_after_recovery_alerts_again() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let cfg = config();
+
+        fail_n(&mut store, "t", 3, at(1));
+        let alert = store.pending_task_alert("t", &cfg, at(2)).unwrap();
+        store.mark_task_alert_delivered("t", &alert, at(2));
+        store.record_success("t", "Task", at(3));
+        let resolved = store.pending_task_alert("t", &cfg, at(3)).unwrap();
+        store.mark_task_alert_delivered("t", &resolved, at(3));
+
+        fail_n(&mut store, "t", 3, at(4));
+        let second = store.pending_task_alert("t", &cfg, at(5)).unwrap();
+        let LivenessAlert::TaskFailing {
+            repeat,
+            streak_started,
+            ..
+        } = &second
+        else {
+            panic!("expected TaskFailing");
+        };
+        assert_eq!(*repeat, 0, "backoff resets with the new streak");
+        assert_eq!(*streak_started, Some(at(4)));
+    }
+
+    #[test]
+    fn custom_threshold_is_honoured() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let cfg = LivenessConfig {
+            alert_after_consecutive_failures: 1,
+            ..LivenessConfig::default()
+        };
+        fail_n(&mut store, "t", 1, at(1));
+        assert!(store.pending_task_alert("t", &cfg, at(1)).is_some());
+    }
+
+    // -- global rule -------------------------------------------------------
+
+    #[test]
+    fn global_alert_needs_enabled_tasks() {
+        let dir = TempDir::new().unwrap();
+        let store = TaskHealthStore::load(dir.path());
+        let now = store.created_at() + Duration::hours(48);
+        assert!(store.pending_global_alert(&config(), 0, now).is_none());
+        assert!(store.pending_global_alert(&config(), 3, now).is_some());
+    }
+
+    #[test]
+    fn global_alert_waits_for_the_silence_window() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let cfg = config();
+        store.record_success("t", "Task", at(100));
+
+        assert!(store
+            .pending_global_alert(&cfg, 7, at(100) + Duration::hours(5))
+            .is_none());
+        let alert = store
+            .pending_global_alert(&cfg, 7, at(100) + Duration::hours(6))
+            .unwrap();
+        let message = alert.message(at(100) + Duration::hours(6));
+        assert!(message.contains("[ALERT] LIVENESS"));
+        assert!(message.contains("6h 0m"));
+        assert!(message.contains("7 task(s) enabled"));
+    }
+
+    #[test]
+    fn global_alert_repeats_on_backoff_then_resets_on_any_success() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let cfg = config();
+        store.record_success("t", "Task", at(100));
+
+        let first = store.pending_global_alert(&cfg, 7, at(107)).unwrap();
+        store.mark_global_alert_delivered(&first, at(107));
+        assert!(first.task_id().is_none());
+
+        assert!(store.pending_global_alert(&cfg, 7, at(112)).is_none());
+        let second = store.pending_global_alert(&cfg, 7, at(113)).unwrap();
+        store.mark_global_alert_delivered(&second, at(113));
+        // Second repeat waits 24h.
+        assert!(store.pending_global_alert(&cfg, 7, at(136)).is_none());
+        assert!(store.pending_global_alert(&cfg, 7, at(137)).is_some());
+
+        // Any success ends the silence — and, because it was alerted, says so.
+        store.record_success("other", "Other", at(140));
+        let resolved = store.pending_global_alert(&cfg, 7, at(141)).unwrap();
+        let message = resolved.message(at(141));
+        assert!(message.starts_with("[RESOLVED] LIVENESS"));
+        assert!(message.contains("'other'"));
+        assert!(message.contains("1d 16h of silence"));
+
+        store.mark_global_alert_delivered(&resolved, at(141));
+        assert!(store.pending_global_alert(&cfg, 7, at(141)).is_none());
+    }
+
+    #[test]
+    fn global_recovery_is_only_announced_after_an_alert() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let cfg = config();
+        store.record_success("t", "Task", at(100));
+        // Silent long enough to qualify, but never alerted (no enabled tasks).
+        assert!(store.pending_global_alert(&cfg, 0, at(120)).is_none());
+        store.record_success("t", "Task", at(120));
+        assert!(store.pending_global_alert(&cfg, 7, at(120)).is_none());
+    }
+
+    #[test]
+    fn undelivered_global_alert_stays_pending() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let cfg = config();
+        store.record_success("t", "Task", at(100));
+
+        // Webhook failed: nothing is marked delivered.
+        let first = store.pending_global_alert(&cfg, 7, at(107)).unwrap();
+        assert_eq!(store.pending_global_alert(&cfg, 7, at(107)), Some(first));
+
+        let reloaded = TaskHealthStore::load(dir.path());
+        assert!(reloaded.pending_global_alert(&cfg, 7, at(107)).is_some());
+    }
+
+    #[test]
+    fn global_alert_before_any_success_uses_tracking_start() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let created_at = store.created_at();
+        fail_n(&mut store, "t", 3, created_at);
+        let now = created_at + Duration::hours(7);
+        let alert = store.pending_global_alert(&config(), 1, now).unwrap();
+        assert!(alert.message(now).contains("EVER"));
+    }
+
+    // -- status surface ----------------------------------------------------
+
+    fn view<'a>(
+        task_id: &'a str,
+        enabled: bool,
+        interval: Option<Duration>,
+        health: Option<&'a TaskHealth>,
+    ) -> TaskStatusView<'a> {
+        TaskStatusView {
+            task_id,
+            task_name: "Morning Check",
+            enabled,
+            interval,
+            health,
+        }
+    }
+
+    #[test]
+    fn classify_covers_every_level() {
+        let cfg = config();
+        let now = at(100);
+        let hour = Duration::hours(1);
+
+        let healthy = TaskHealth {
+            last_success: Some(now - Duration::minutes(30)),
+            ..TaskHealth::default()
+        };
+        let stale = TaskHealth {
+            last_success: Some(now - Duration::hours(5)),
+            ..TaskHealth::default()
+        };
+        let degraded = TaskHealth {
+            consecutive_failures: 1,
+            last_success: Some(now - Duration::minutes(30)),
+            last_failure: Some(now),
+            ..TaskHealth::default()
+        };
+        let failing = TaskHealth {
+            consecutive_failures: 42,
+            last_failure: Some(now),
+            ..TaskHealth::default()
+        };
+
+        assert_eq!(
+            classify(&view("t", true, Some(hour), Some(&healthy)), &cfg, now),
+            TaskStatusLevel::Ok
+        );
+        assert_eq!(
+            classify(&view("t", true, Some(hour), Some(&stale)), &cfg, now),
+            TaskStatusLevel::Stale
+        );
+        assert_eq!(
+            classify(&view("t", true, Some(hour), Some(&degraded)), &cfg, now),
+            TaskStatusLevel::Degraded
+        );
+        assert_eq!(
+            classify(&view("t", true, Some(hour), Some(&failing)), &cfg, now),
+            TaskStatusLevel::Failing
+        );
+        assert_eq!(
+            classify(&view("t", true, Some(hour), None), &cfg, now),
+            TaskStatusLevel::Idle
+        );
+        assert_eq!(
+            classify(&view("t", false, Some(hour), Some(&failing)), &cfg, now),
+            TaskStatusLevel::Disabled
+        );
+    }
+
+    #[test]
+    fn stale_needs_more_than_two_intervals() {
+        let cfg = config();
+        let now = at(100);
+        let health = TaskHealth {
+            last_success: Some(now - Duration::hours(2)),
+            ..TaskHealth::default()
+        };
+        // Exactly two intervals is still on time.
+        assert_eq!(
+            classify(
+                &view("t", true, Some(Duration::hours(1)), Some(&health)),
+                &cfg,
+                now
+            ),
+            TaskStatusLevel::Ok
+        );
+        // A minute past two intervals is not.
+        assert_eq!(
+            classify(
+                &view("t", true, Some(Duration::hours(1)), Some(&health)),
+                &cfg,
+                now + Duration::minutes(1)
+            ),
+            TaskStatusLevel::Stale
+        );
+    }
+
+    #[test]
+    fn status_line_shows_age_streak_and_marker() {
+        let cfg = config();
+        let now = at(100);
+        let health = TaskHealth {
+            task_name: "Morning Check".to_string(),
+            consecutive_failures: 42,
+            last_success: Some(now - Duration::hours(50)),
+            last_failure: Some(now - Duration::minutes(12)),
+            ..TaskHealth::default()
+        };
+        let line = status_line(
+            &view("morning", true, Some(Duration::hours(1)), Some(&health)),
+            &cfg,
+            now,
+        );
+        assert!(line.starts_with("[FAIL ]"));
+        assert!(line.contains("Morning Check (morning)"));
+        assert!(line.contains("last success 2d 2h ago"));
+        assert!(line.contains("42 consecutive failure(s), last 12m ago"));
+    }
+
+    #[test]
+    fn status_line_marks_stale_with_interval() {
+        let cfg = config();
+        let now = at(100);
+        let health = TaskHealth {
+            last_success: Some(now - Duration::hours(9)),
+            ..TaskHealth::default()
+        };
+        let line = status_line(
+            &view("t", true, Some(Duration::hours(4)), Some(&health)),
+            &cfg,
+            now,
+        );
+        assert!(line.starts_with("[STALE]"));
+        assert!(line.contains("STALE (interval 4h 0m)"));
+    }
+
+    #[test]
+    fn status_line_for_never_run_task() {
+        let cfg = config();
+        let line = status_line(&view("t", true, None, None), &cfg, at(100));
+        assert!(line.starts_with("[IDLE ]"));
+        assert!(line.contains("last success never"));
+    }
+
+    #[test]
+    fn interval_from_daily_and_hourly_crons() {
+        let now = at(100);
+        assert_eq!(
+            interval_from_cron("0 0 8 * * *", now),
+            Some(Duration::hours(24))
+        );
+        assert_eq!(
+            interval_from_cron("0 0 * * * *", now),
+            Some(Duration::hours(1))
+        );
+        assert!(interval_from_cron("not a cron", now).is_none());
+    }
+
+    #[test]
+    fn duration_formatting_is_coarse_and_readable() {
+        assert_eq!(format_duration(Duration::seconds(30)), "30s");
+        assert_eq!(format_duration(Duration::minutes(45)), "45m");
+        assert_eq!(format_duration(Duration::minutes(372)), "6h 12m");
+        assert_eq!(format_duration(Duration::hours(75)), "3d 3h");
+        assert_eq!(format_duration(Duration::seconds(-10)), "0s");
+        assert_eq!(format_age(None, at(1)), "never");
+        assert_eq!(format_age(Some(at(1)), at(4)), "3h 0m ago");
+    }
+}

--- a/src/scheduler/liveness.rs
+++ b/src/scheduler/liveness.rs
@@ -1,0 +1,163 @@
+//! Runtime side of the liveness alarm: delivery and the watchdog loop.
+//!
+//! [`super::health`] decides *what* should be said; this module says it and
+//! records that it was said. The split keeps the alert rules pure and
+//! table-testable while the IO stays in one place.
+//!
+//! Delivery is deliberately deliver-then-commit: the store is only told an
+//! alert went out once the webhook accepted it, so a failed webhook leaves
+//! the alert pending and the next tick retries it (AC7). Nothing in here
+//! propagates an error into task execution — the alarm can never take down
+//! the thing it is watching.
+
+use std::sync::Arc;
+use std::time::Duration as StdDuration;
+
+use chrono::Utc;
+use tokio::sync::RwLock;
+
+use super::health::{LivenessAlert, TaskHealthStore};
+use super::output;
+use super::Schedule;
+use crate::server::AppState;
+
+/// How often the watchdog re-checks global silence and retries alerts that
+/// failed to deliver. Well under the smallest sensible silence window, so an
+/// outage is reported promptly without polling noise.
+const WATCHDOG_INTERVAL: StdDuration = StdDuration::from_secs(15 * 60);
+
+/// Shared handle to the liveness store.
+pub type SharedTaskHealth = Arc<RwLock<TaskHealthStore>>;
+
+/// Outcome of one scheduled-task execution, as liveness sees it.
+///
+/// This is an observation only: nothing here changes how a task runs.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TaskOutcome {
+    Success,
+    Failure(String),
+}
+
+/// Record one task outcome and deliver whatever alert it triggers.
+pub async fn record_outcome(
+    health: &SharedTaskHealth,
+    state: &Arc<AppState>,
+    task_id: &str,
+    task_name: &str,
+    outcome: TaskOutcome,
+) {
+    if !state.config.scheduler.liveness.enabled {
+        return;
+    }
+    let now = Utc::now();
+    {
+        let mut store = health.write().await;
+        match outcome {
+            TaskOutcome::Success => store.record_success(task_id, task_name, now),
+            TaskOutcome::Failure(ref reason) => {
+                store.record_failure(task_id, task_name, reason, now)
+            }
+        }
+    }
+    deliver_task_alert(health, state, task_id).await;
+}
+
+/// Deliver the alert this task currently owes, if any.
+async fn deliver_task_alert(health: &SharedTaskHealth, state: &Arc<AppState>, task_id: &str) {
+    let now = Utc::now();
+    let config = &state.config.scheduler.liveness;
+
+    let pending = {
+        let store = health.read().await;
+        store.pending_task_alert(task_id, config, now)
+    };
+    let Some(alert) = pending else {
+        return;
+    };
+
+    if deliver(&alert, state).await {
+        health
+            .write()
+            .await
+            .mark_task_alert_delivered(task_id, &alert, Utc::now());
+    }
+}
+
+/// Periodic check: global silence, plus retries for alerts whose webhook
+/// failed earlier. Runs until the process stops.
+pub async fn watchdog_loop(
+    state: Arc<AppState>,
+    schedule: Arc<RwLock<Schedule>>,
+    health: SharedTaskHealth,
+) {
+    tracing::info!(
+        "Scheduler liveness watchdog started (global silence threshold: {}h)",
+        state.config.scheduler.liveness.global_silence_alert_hours
+    );
+    loop {
+        tokio::time::sleep(WATCHDOG_INTERVAL).await;
+        watchdog_tick(&state, &schedule, &health).await;
+    }
+}
+
+/// One watchdog pass. Only currently-enabled tasks are considered, so
+/// disabling a broken task also silences its alerts.
+async fn watchdog_tick(
+    state: &Arc<AppState>,
+    schedule: &Arc<RwLock<Schedule>>,
+    health: &SharedTaskHealth,
+) {
+    let enabled_task_ids: Vec<String> = {
+        let sched = schedule.read().await;
+        sched
+            .tasks
+            .iter()
+            .filter(|t| t.enabled)
+            .map(|t| t.id.clone())
+            .collect()
+    };
+
+    for task_id in &enabled_task_ids {
+        deliver_task_alert(health, state, task_id).await;
+    }
+
+    let pending = {
+        let store = health.read().await;
+        store.pending_global_alert(
+            &state.config.scheduler.liveness,
+            enabled_task_ids.len(),
+            Utc::now(),
+        )
+    };
+    let Some(alert) = pending else {
+        return;
+    };
+    if deliver(&alert, state).await {
+        health
+            .write()
+            .await
+            .mark_global_alert_delivered(&alert, Utc::now());
+    }
+}
+
+/// Send one alert. Returns whether it may be marked as delivered.
+async fn deliver(alert: &LivenessAlert, state: &Arc<AppState>) -> bool {
+    let message = alert.message(Utc::now());
+    let webhook = state.config.scheduler.output.share_webhook.as_deref();
+    let subject = alert.task_id().unwrap_or("scheduler");
+    match output::deliver_liveness_alert(&message, webhook).await {
+        Ok(()) => {
+            tracing::warn!(subject, "Liveness alert delivered: {}", message);
+            true
+        }
+        Err(e) => {
+            tracing::error!(
+                subject,
+                error = %e,
+                "Liveness alert delivery failed — retrying next watchdog tick: {}",
+                message
+            );
+            false
+        }
+    }
+}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -3,7 +3,9 @@ pub mod digest;
 pub mod dynamic;
 pub mod evaluator;
 pub mod executor;
+pub mod health;
 pub mod intent;
+pub mod liveness;
 pub mod output;
 pub mod runner;
 pub mod tasks;
@@ -121,16 +123,33 @@ pub async fn start(
 
     let mut handles = Vec::new();
 
+    // Liveness store: one shared handle for every task loop and the
+    // watchdog, so a failure streak is visible across tasks and restarts.
+    let health: liveness::SharedTaskHealth =
+        Arc::new(RwLock::new(health::TaskHealthStore::load(&state.root_dir)));
+
     for task in enabled_tasks {
         let state = Arc::clone(&state);
         let schedule = Arc::clone(&schedule);
         let queue = Arc::clone(&intent_queue);
+        let task_health = Arc::clone(&health);
 
         let handle = tokio::spawn(async move {
-            runner::run_task_loop(task, state, schedule, queue, tz).await;
+            runner::run_task_loop(task, state, schedule, queue, task_health, tz).await;
         });
 
         handles.push(handle);
+    }
+
+    if state.config.scheduler.liveness.enabled {
+        let watchdog_state = Arc::clone(&state);
+        let watchdog_schedule = Arc::clone(&schedule);
+        let watchdog_health = Arc::clone(&health);
+        handles.push(tokio::spawn(async move {
+            liveness::watchdog_loop(watchdog_state, watchdog_schedule, watchdog_health).await;
+        }));
+    } else {
+        tracing::warn!("Scheduler liveness alarm disabled in config — task outages will be silent");
     }
 
     // Start the intent drain loop

--- a/src/scheduler/output.rs
+++ b/src/scheduler/output.rs
@@ -201,6 +201,41 @@ pub async fn route_error(error: &str, error_kind: &str, task_name: &str, config:
     }
 }
 
+/// Deliver a liveness `[ALERT]` / `[RESOLVED]` message via the share webhook.
+///
+/// Unlike the fire-and-forget routers above, this reports delivery: the
+/// scheduler only commits an alert as sent when this returns `Ok`, so a
+/// failing webhook leaves the alert pending for the next watchdog tick
+/// instead of losing it (AC7).
+///
+/// With no webhook configured there is nothing to retry — the alert is
+/// logged at `error` level and reported as delivered so the backoff ladder
+/// still applies.
+///
+/// Takes the URL rather than the whole `Config` because that is all it
+/// needs, which also makes the delivery contract testable on its own.
+pub async fn deliver_liveness_alert(content: &str, webhook: Option<&str>) -> Result<(), String> {
+    let webhook_url = match webhook {
+        Some(url) if !url.is_empty() => url,
+        _ => {
+            tracing::error!("Liveness alert (no webhook configured): {}", content);
+            return Ok(());
+        }
+    };
+
+    let client = reqwest::Client::builder()
+        .timeout(WEBHOOK_TIMEOUT)
+        .build()
+        .map_err(|e| format!("client build failed: {e}"))?;
+    let body = serde_json::json!({ "content": content });
+
+    match client.post(webhook_url).json(&body).send().await {
+        Ok(res) if res.status().is_success() => Ok(()),
+        Ok(res) => Err(format!("webhook returned {}", res.status())),
+        Err(e) => Err(format!("webhook request failed: {e}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -273,6 +308,27 @@ mod tests {
         assert_eq!(parsed.chain_requests.len(), 1);
         assert!(parsed.chain_requests[0].contains("Reflect"));
         assert!(!parsed.clean_content.contains("[CHAIN:"));
+    }
+
+    #[tokio::test]
+    async fn liveness_alert_without_webhook_counts_as_delivered() {
+        // Nothing to retry against, so the caller must be free to start the
+        // backoff clock instead of looping on an impossible delivery.
+        assert!(deliver_liveness_alert("[ALERT] test", None).await.is_ok());
+        assert!(deliver_liveness_alert("[ALERT] test", Some(""))
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn liveness_alert_reports_transport_failure() {
+        // Port 1 on loopback refuses instantly — the failure must surface as
+        // Err so the alert stays pending for the next watchdog tick.
+        let result = deliver_liveness_alert("[ALERT] test", Some("http://127.0.0.1:1/hook")).await;
+        assert!(
+            result.is_err(),
+            "expected transport failure, got {result:?}"
+        );
     }
 
     #[test]

--- a/src/scheduler/runner.rs
+++ b/src/scheduler/runner.rs
@@ -8,6 +8,7 @@ use tokio::sync::RwLock;
 use super::evaluator::{resolve_docs_dir, resolve_task_evaluator, EvalDecision, SchedulerState};
 use super::executor::{self, ExecutionConfig};
 use super::intent::{self, IntentQueue, IntentSource};
+use super::liveness::{self, SharedTaskHealth, TaskOutcome};
 use super::output;
 use super::{Schedule, ScheduledTask};
 use crate::events::EntityEvent;
@@ -22,6 +23,7 @@ pub async fn run_task_loop(
     state: Arc<AppState>,
     schedule: Arc<RwLock<Schedule>>,
     intent_queue: Arc<RwLock<IntentQueue>>,
+    health: SharedTaskHealth,
     tz: chrono_tz::Tz,
 ) {
     let normalized_cron = super::normalize_cron(&task.cron);
@@ -117,10 +119,13 @@ pub async fn run_task_loop(
 
         // Check for built-in deterministic handlers first
         if run_builtin_handler(&task, &state, &root_dir).await {
+            liveness::record_outcome(&health, &state, &task.id, &task.name, TaskOutcome::Success)
+                .await;
             continue;
         }
 
-        execute_task(&task, &state, &schedule, &intent_queue, &mut eval_state).await;
+        let outcome = execute_task(&task, &state, &schedule, &intent_queue, &mut eval_state).await;
+        liveness::record_outcome(&health, &state, &task.id, &task.name, outcome).await;
     }
 }
 
@@ -163,13 +168,16 @@ async fn run_builtin_handler(
 }
 
 /// Execute a scheduled task: build prompt, call LLM (with tools if autonomy enabled), route output.
+///
+/// Returns what the liveness alarm should record. Execution semantics are
+/// unchanged — the outcome is an observation, not a control signal.
 async fn execute_task(
     task: &ScheduledTask,
     state: &Arc<AppState>,
     schedule: &Arc<RwLock<Schedule>>,
     intent_queue: &Arc<RwLock<IntentQueue>>,
     eval_state: &mut SchedulerState,
-) {
+) -> TaskOutcome {
     // Use cached root_dir from AppState
     let root_dir = state.root_dir.clone();
 
@@ -185,7 +193,7 @@ async fn execute_task(
         Ok(p) => p,
         Err(e) => {
             tracing::error!("Cannot build system prompt for task '{}': {}", task.id, e);
-            return;
+            return TaskOutcome::Failure(format!("system prompt build failed: {e}"));
         }
     };
 
@@ -273,7 +281,7 @@ async fn execute_task(
                     error_msg
                 );
                 handle_provider_error(state, &task.id, &error_msg).await;
-                return;
+                return TaskOutcome::Failure(error_msg);
             }
         }
     } else {
@@ -319,7 +327,7 @@ async fn execute_task(
                     error_msg
                 );
                 handle_provider_error(state, &task.id, &error_msg).await;
-                return;
+                return TaskOutcome::Failure(error_msg);
             }
         }
     };
@@ -642,6 +650,8 @@ async fn execute_task(
     if state.config.graph.enabled {
         crate::session::graph_sync_vigil(&root_dir).await;
     }
+
+    TaskOutcome::Success
 }
 
 /// Handle a provider error: classify, update status, emit event, send notification.

--- a/src/server/prompt.rs
+++ b/src/server/prompt.rs
@@ -35,6 +35,39 @@ fn truncate_to_token_cap(text: &str, token_cap: usize) -> String {
     )
 }
 
+/// Truncate text to a hard byte ceiling, preserving the beginning.
+///
+/// Line counts do not bound bytes: a 60-line file of 3KB lines is 180KB. Every
+/// line-capped component gets one of these ceilings so a single runaway
+/// document cannot blow up the assembled prompt.
+///
+/// The result is at most `max_bytes` bytes, including the truncation marker
+/// (unless `max_bytes` is smaller than the marker itself). Truncation happens
+/// on a char boundary, so the output is always valid UTF-8.
+fn truncate_to_byte_cap(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let marker = format!("\n[truncated — exceeded {} byte ceiling]", max_bytes);
+    let content_budget = max_bytes.saturating_sub(marker.len());
+    format!(
+        "{}{}",
+        crate::utils::safe_truncate(text, content_budget),
+        marker
+    )
+}
+
+/// Line cap for THOUGHT_STACK.md. The entity is instructed to keep it under
+/// 50 lines; this is the safety margin on top of that.
+const THOUGHT_STACK_MAX_LINES: usize = 60;
+
+/// Hard byte ceiling for the Essential tier as a whole.
+///
+/// Essential components are never trimmed, so if they alone exceed this the
+/// prompt is unshippable and assembly fails loudly rather than handing a
+/// doomed prompt to the provider.
+const ESSENTIAL_MAX_BYTES: usize = 64 * 1024;
+
 /// Priority tier for a system prompt component.
 /// Lower number = higher priority = trimmed last.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -219,7 +252,8 @@ pub fn build_system_prompt_budgeted(
         if awareness_path.exists() {
             let content = std::fs::read_to_string(&awareness_path)?;
             if !content.trim().is_empty() {
-                let wrapped = format!("<platform>\n{}\n</platform>", content);
+                let bounded = truncate_to_byte_cap(&content, budget_cfg.awareness_max_bytes);
+                let wrapped = format!("<platform>\n{}\n</platform>", bounded);
                 let tokens = estimate_tokens(&wrapped);
                 components.push(PromptComponent {
                     name: "AWARENESS.md",
@@ -241,7 +275,8 @@ pub fn build_system_prompt_budgeted(
             .take(config.memory.memory_max_lines)
             .collect::<Vec<_>>()
             .join("\n");
-        let wrapped = format!("<memory>\n{}\n</memory>", limited);
+        let bounded = truncate_to_byte_cap(&limited, budget_cfg.memory_max_bytes);
+        let wrapped = format!("<memory>\n{}\n</memory>", bounded);
         let capped = if budget_enabled && budget_cfg.memory_cap > 0 {
             truncate_to_token_cap(&wrapped, budget_cfg.memory_cap)
         } else {
@@ -299,22 +334,15 @@ pub fn build_system_prompt_budgeted(
     });
 
     // --- Tier 1 (High): THOUGHT_STACK.md ---
-    let thought_stack_path = root_dir.join("THOUGHT_STACK.md");
-    if thought_stack_path.exists() {
-        let content = std::fs::read_to_string(&thought_stack_path)?;
-        if !content.trim().is_empty() {
-            // Hard cap at 60 lines (entity is instructed to keep under 50; this is the safety margin)
-            let limited: String = content.lines().take(60).collect::<Vec<_>>().join("\n");
-            let wrapped = format!("<thought-stack>\n{}\n</thought-stack>", limited);
-            let tokens = estimate_tokens(&wrapped);
-            components.push(PromptComponent {
-                name: "THOUGHT_STACK.md",
-                content: wrapped,
-                tokens,
-                tier: PromptTier::High,
-                cap: 0,
-            });
-        }
+    if let Some(wrapped) = load_thought_stack(root_dir, budget_cfg.thought_stack_max_bytes)? {
+        let tokens = estimate_tokens(&wrapped);
+        components.push(PromptComponent {
+            name: "THOUGHT_STACK.md",
+            content: wrapped,
+            tokens,
+            tier: PromptTier::High,
+            cap: 0,
+        });
     }
 
     // --- Tier 2 (Low): EPHEMERAL.md ---
@@ -504,7 +532,28 @@ pub fn build_system_prompt_budgeted(
         }
     }
 
-    // --- Budget enforcement ---
+    enforce_budget_and_assemble(components, budget_cfg, "chat")
+}
+
+/// Apply the budget passes to a component set and render the final prompt.
+///
+/// Shared by the chat and scheduled-task assembly paths so both are governed by
+/// the same tiers, the same passes and the same metrics.
+///
+/// Passes, in order:
+/// 1. Compress Low-tier components to one-line summaries.
+/// 2. Drop Low-tier components entirely.
+/// 3. Hard-truncate High-tier components down to whatever the Essential tier
+///    leaves of the budget.
+///
+/// Essential components are never trimmed; they are instead verified against
+/// [`ESSENTIAL_MAX_BYTES`] and reported as an error when they exceed it.
+fn enforce_budget_and_assemble(
+    mut components: Vec<PromptComponent>,
+    budget_cfg: &crate::config::SystemPromptBudgetConfig,
+    profile: &str,
+) -> Result<SystemPromptResult, crate::errors::PromptError> {
+    let budget_enabled = budget_cfg.enabled;
     let total_before: usize = components.iter().map(|c| c.tokens).sum();
     let mut was_trimmed = false;
     let mut dropped_components = Vec::new();
@@ -568,15 +617,56 @@ pub fn build_system_prompt_budgeted(
             }
         }
 
-        // Pass 3: Truncate High-tier components if STILL over budget (rare, means
-        // essential + high alone exceed the budget — log a warning).
+        // Pass 3: Hard-truncate High-tier components if STILL over budget.
+        // Essential is untouchable, so High shares whatever the budget has left
+        // after Essential. Earlier components keep their allowance first.
         if current_total > budget {
+            let essential_tokens: usize = components
+                .iter()
+                .filter(|c| c.tier == PromptTier::Essential)
+                .map(|c| c.tokens)
+                .sum();
             warn!(
                 "[system-prompt-budget] essential + high-priority components ({} tokens) exceed \
-                 budget ({} tokens) — core documents may be too large",
+                 budget ({} tokens) — truncating high-priority content to fit",
                 current_total, budget
             );
+
+            let mut allowance = budget.saturating_sub(essential_tokens);
+            for component in components
+                .iter_mut()
+                .filter(|c| c.tier == PromptTier::High && !c.content.is_empty())
+            {
+                if component.tokens <= allowance {
+                    allowance -= component.tokens;
+                    continue;
+                }
+                let original_tokens = component.tokens;
+                let truncated = truncate_to_token_cap(&component.content, allowance);
+                component.tokens = estimate_tokens(&truncated);
+                component.content = truncated;
+                allowance = 0;
+                was_trimmed = true;
+                info!(
+                    "[system-prompt-budget] truncated {} from ~{} to ~{} tokens",
+                    component.name, original_tokens, component.tokens
+                );
+            }
         }
+    }
+
+    // Essential is never trimmed, so it is the one tier that can still push the
+    // prompt past what a subprocess can carry. Verify it before shipping.
+    let essential_bytes: usize = components
+        .iter()
+        .filter(|c| c.tier == PromptTier::Essential)
+        .map(|c| c.content.len())
+        .sum();
+    if essential_bytes > ESSENTIAL_MAX_BYTES {
+        return Err(crate::errors::PromptError::EssentialTooLarge {
+            bytes: essential_bytes,
+            limit: ESSENTIAL_MAX_BYTES,
+        });
     }
 
     // Assemble final prompt from non-empty components (preserving original order)
@@ -588,15 +678,17 @@ pub fn build_system_prompt_budgeted(
     let prompt = parts.join("\n\n");
     let estimated_tokens = estimate_tokens(&prompt);
 
-    if budget_enabled {
-        info!(
-            "[system-prompt-budget] assembled {} tokens (budget: {}, trimmed: {}, dropped: {})",
-            estimated_tokens,
-            budget_cfg.token_budget,
-            was_trimmed,
-            dropped_components.len()
-        );
-    }
+    info!(
+        "[system-prompt-budget] {} prompt assembled: {} tokens, {} bytes \
+         (budget: {}, enabled: {}, trimmed: {}, dropped: {})",
+        profile,
+        estimated_tokens,
+        prompt.len(),
+        budget_cfg.token_budget,
+        budget_enabled,
+        was_trimmed,
+        dropped_components.len()
+    );
 
     Ok(SystemPromptResult {
         prompt,
@@ -678,24 +770,68 @@ pub fn build_task_system_prompt(
     root_dir: &Path,
     config: &Config,
 ) -> Result<String, crate::errors::PromptError> {
-    let mut parts = Vec::new();
+    Ok(build_task_system_prompt_budgeted(root_dir, config)?.prompt)
+}
 
-    // CLAUDE.md — behavioral instructions (core identity)
+/// Build the scheduled-task system prompt with full budget metrics returned.
+///
+/// Same tiers, caps and passes as the chat path — a task prompt that outgrows
+/// the budget is exactly as fatal as a chat prompt that does.
+pub fn build_task_system_prompt_budgeted(
+    root_dir: &Path,
+    config: &Config,
+) -> Result<SystemPromptResult, crate::errors::PromptError> {
+    let budget_cfg = &config.system_prompt_budget;
+    let budget_enabled = budget_cfg.enabled;
+    let mut components = Vec::new();
+
+    // --- Tier 0 (Essential): CLAUDE.md — behavioral instructions ---
     let claude_path = root_dir.join("CLAUDE.md");
     if claude_path.exists() {
         let content = std::fs::read_to_string(&claude_path)?;
-        parts.push(content);
+        let capped = if budget_enabled && budget_cfg.claude_md_cap > 0 {
+            truncate_to_token_cap(&content, budget_cfg.claude_md_cap)
+        } else {
+            content
+        };
+        let tokens = estimate_tokens(&capped);
+        components.push(PromptComponent {
+            name: "CLAUDE.md",
+            content: capped,
+            tokens,
+            tier: PromptTier::Essential,
+            cap: budget_cfg.claude_md_cap,
+        });
     }
 
-    // Shared rule/protocol files
+    // --- Tier 0 (Essential): Shared rule/protocol files ---
     if let Some(ref rules_dir) = config.entity.rules_dir {
         match load_rule_files(rules_dir) {
             Ok(rules) => {
+                let mut rules_text = String::new();
                 for (name, content) in rules {
-                    parts.push(format!(
+                    if !rules_text.is_empty() {
+                        rules_text.push_str("\n\n");
+                    }
+                    rules_text.push_str(&format!(
                         "<protocol name=\"{}\">\n{}\n</protocol>",
                         name, content
                     ));
+                }
+                if !rules_text.is_empty() {
+                    let capped = if budget_enabled && budget_cfg.rules_cap > 0 {
+                        truncate_to_token_cap(&rules_text, budget_cfg.rules_cap)
+                    } else {
+                        rules_text
+                    };
+                    let tokens = estimate_tokens(&capped);
+                    components.push(PromptComponent {
+                        name: "rules",
+                        content: capped,
+                        tokens,
+                        tier: PromptTier::Essential,
+                        cap: budget_cfg.rules_cap,
+                    });
                 }
             }
             Err(e) => {
@@ -704,27 +840,43 @@ pub fn build_task_system_prompt(
         }
     }
 
-    // SELF.md — identity
+    // --- Tier 1 (High): SELF.md — identity ---
     let self_path = root_dir.join("SELF.md");
     if self_path.exists() {
         let content = std::fs::read_to_string(&self_path)?;
-        parts.push(format!("<identity>\n{}\n</identity>", content));
+        let wrapped = format!("<identity>\n{}\n</identity>", content);
+        let capped = if budget_enabled && budget_cfg.self_md_cap > 0 {
+            truncate_to_token_cap(&wrapped, budget_cfg.self_md_cap)
+        } else {
+            wrapped
+        };
+        let tokens = estimate_tokens(&capped);
+        components.push(PromptComponent {
+            name: "SELF.md",
+            content: capped,
+            tokens,
+            tier: PromptTier::High,
+            cap: budget_cfg.self_md_cap,
+        });
     }
 
-    // THOUGHT_STACK.md — working memory for continuous thinking
-    let thought_stack_path = root_dir.join("THOUGHT_STACK.md");
-    if thought_stack_path.exists() {
-        let content = std::fs::read_to_string(&thought_stack_path)?;
-        if !content.trim().is_empty() {
-            let limited: String = content.lines().take(60).collect::<Vec<_>>().join("\n");
-            parts.push(format!("<thought-stack>\n{}\n</thought-stack>", limited));
-        }
+    // --- Tier 1 (High): THOUGHT_STACK.md — working memory ---
+    if let Some(wrapped) = load_thought_stack(root_dir, budget_cfg.thought_stack_max_bytes)? {
+        let tokens = estimate_tokens(&wrapped);
+        components.push(PromptComponent {
+            name: "THOUGHT_STACK.md",
+            content: wrapped,
+            tokens,
+            tier: PromptTier::High,
+            cap: 0,
+        });
     }
 
-    // Metacognitive context — vigil health + calibration data for autonomous goal generation
+    // --- Tier 2 (Low): Metacognitive context ---
+    // Vigil health + calibration data for autonomous goal generation.
     let metacog = build_metacognitive_context(root_dir);
     if !metacog.is_empty() {
-        parts.push(format!(
+        let wrapped = format!(
             "<metacognitive-state>\n\
             This is your current cognitive health assessment. Use this to guide your \
             autonomous thinking. If you notice patterns — declining signals, calibration \
@@ -732,12 +884,21 @@ pub fn build_task_system_prompt(
             {}\n\
             </metacognitive-state>",
             metacog
-        ));
+        );
+        let tokens = estimate_tokens(&wrapped);
+        components.push(PromptComponent {
+            name: "metacognitive-state",
+            content: wrapped,
+            tokens,
+            tier: PromptTier::Low,
+            cap: 0,
+        });
     }
 
-    // Task isolation notice + autonomous hallucination guard (Layer 1b)
-    parts.push(
-        "<task-context>\n\
+    // --- Tier 0 (Essential): Task isolation notice + hallucination guard ---
+    // Essential because dropping it is how autonomous runs start inventing
+    // user turns (Layer 1b).
+    let task_context = "<task-context>\n\
         This is an autonomous scheduled task execution. There is no human user in this \
         conversation. You are executing a task prompt independently.\n\n\
         CRITICAL RULES:\n\
@@ -749,10 +910,46 @@ pub fn build_task_system_prompt(
         EPHEMERAL.md, or monitoring data). Focus on the task prompt. Do not reference \
         memory or session context that is not present in this context window.\n\
         </task-context>"
-            .to_string(),
-    );
+        .to_string();
+    let tokens = estimate_tokens(&task_context);
+    components.push(PromptComponent {
+        name: "task-context",
+        content: task_context,
+        tokens,
+        tier: PromptTier::Essential,
+        cap: 0,
+    });
 
-    Ok(parts.join("\n\n"))
+    enforce_budget_and_assemble(components, budget_cfg, "task")
+}
+
+/// Load THOUGHT_STACK.md bounded by both line count and bytes, wrapped for the
+/// prompt. Returns `None` when the file is missing or blank.
+///
+/// The line cap is the entity-facing rule (it is instructed to stay under 50);
+/// the byte ceiling is the safety net, because 60 lines say nothing about size.
+fn load_thought_stack(
+    root_dir: &Path,
+    max_bytes: usize,
+) -> Result<Option<String>, crate::errors::PromptError> {
+    let path = root_dir.join("THOUGHT_STACK.md");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(&path)?;
+    if content.trim().is_empty() {
+        return Ok(None);
+    }
+    let limited: String = content
+        .lines()
+        .take(THOUGHT_STACK_MAX_LINES)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let bounded = truncate_to_byte_cap(&limited, max_bytes);
+    Ok(Some(format!(
+        "<thought-stack>\n{}\n</thought-stack>",
+        bounded
+    )))
 }
 
 /// Build metacognitive context for autonomous tasks — vigil health summary
@@ -1510,21 +1707,23 @@ mod tests {
     }
 
     #[test]
-    fn budget_disabled_loads_everything() {
+    fn budget_disabled_skips_token_caps() {
         let dir = tempfile::tempdir().unwrap();
         let mut config = minimal_config();
         config.system_prompt_budget.enabled = false;
 
-        // Write large files
-        std::fs::write(dir.path().join("CLAUDE.md"), "x".repeat(80_000)).unwrap();
+        // Large, but each component stays under its byte ceiling.
+        std::fs::write(dir.path().join("CLAUDE.md"), "x".repeat(60_000)).unwrap();
         std::fs::create_dir_all(dir.path().join("memory")).unwrap();
-        std::fs::write(dir.path().join("memory/MEMORY.md"), "y".repeat(40_000)).unwrap();
+        std::fs::write(dir.path().join("memory/MEMORY.md"), "y".repeat(30_000)).unwrap();
 
         let result = build_system_prompt_budgeted(dir.path(), &config, None, None).unwrap();
 
-        // Everything loaded, no trimming
+        // Everything loaded, no trimming — token caps are budgeting, and
+        // budgeting is off.
         assert!(!result.was_trimmed);
-        assert!(result.estimated_tokens > 25_000);
+        assert!(!result.prompt.contains("[truncated"));
+        assert!(result.estimated_tokens > 22_000);
     }
 
     #[test]
@@ -1669,6 +1868,246 @@ mod tests {
         assert_eq!(cfg.pipeline_health_cap, 500);
         assert_eq!(cfg.cognitive_health_cap, 300);
         assert_eq!(cfg.caliber_cap, 200);
+        assert_eq!(cfg.thought_stack_max_bytes, 48 * 1024);
+        assert_eq!(cfg.awareness_max_bytes, 16 * 1024);
+        assert_eq!(cfg.memory_max_bytes, 32 * 1024);
+    }
+
+    // --- PN-75: byte ceilings and task-path budgeting ---
+
+    fn write_giant_line(path: &std::path::Path, bytes: usize) {
+        std::fs::write(path, "z".repeat(bytes)).unwrap();
+    }
+
+    #[test]
+    fn truncate_to_byte_cap_noop_when_under() {
+        let text = "short text";
+        assert_eq!(truncate_to_byte_cap(text, 1024), text);
+    }
+
+    #[test]
+    fn truncate_to_byte_cap_bounds_a_single_giant_line() {
+        let text = "a".repeat(200_000);
+        let result = truncate_to_byte_cap(&text, 4096);
+        assert!(result.len() <= 4096, "got {} bytes", result.len());
+        assert!(result.contains("[truncated"));
+        assert!(result.contains("4096 byte ceiling"));
+    }
+
+    #[test]
+    fn truncate_to_byte_cap_respects_char_boundaries() {
+        // Each emoji is 4 bytes — an odd cap must not split one.
+        let text = "\u{1F600}".repeat(1000);
+        let result = truncate_to_byte_cap(&text, 101);
+        assert!(result.len() <= 101);
+        assert!(result.starts_with('\u{1F600}'));
+    }
+
+    #[test]
+    fn thought_stack_enforces_byte_ceiling() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = minimal_config();
+
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Entity").unwrap();
+        write_giant_line(&dir.path().join("THOUGHT_STACK.md"), 200_000);
+
+        let result = build_system_prompt_budgeted(dir.path(), &config, None, None).unwrap();
+
+        assert!(result.prompt.contains("<thought-stack>"));
+        assert!(result.prompt.contains("byte ceiling"));
+        assert!(
+            result.prompt.len() < 64 * 1024,
+            "prompt should be bounded by the thought stack ceiling, got {} bytes",
+            result.prompt.len()
+        );
+    }
+
+    #[test]
+    fn memory_enforces_byte_ceiling() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = minimal_config();
+        // Generous token cap so the byte ceiling is the binding constraint.
+        config.system_prompt_budget.memory_cap = 100_000;
+        config.system_prompt_budget.token_budget = 1_000_000;
+
+        std::fs::create_dir_all(dir.path().join("memory")).unwrap();
+        write_giant_line(&dir.path().join("memory/MEMORY.md"), 200_000);
+
+        let result = build_system_prompt_budgeted(dir.path(), &config, None, None).unwrap();
+
+        assert!(result.prompt.contains("<memory>"));
+        assert!(result.prompt.contains("byte ceiling"));
+        assert!(result.prompt.len() < 64 * 1024);
+    }
+
+    #[test]
+    fn awareness_enforces_byte_ceiling() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = minimal_config();
+        config.system_prompt_budget.token_budget = 1_000_000;
+
+        write_giant_line(&dir.path().join("AWARENESS.md"), 200_000);
+
+        let result = build_system_prompt_budgeted(dir.path(), &config, None, None).unwrap();
+
+        assert!(result.prompt.contains("<platform>"));
+        assert!(result.prompt.contains("byte ceiling"));
+        assert!(result.prompt.len() < 32 * 1024);
+    }
+
+    /// AC6: the byte ceilings are safety, not budgeting — they survive
+    /// `system_prompt_budget.enabled = false`.
+    #[test]
+    fn byte_ceilings_hold_with_budget_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = minimal_config();
+        config.system_prompt_budget.enabled = false;
+
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Entity").unwrap();
+        write_giant_line(&dir.path().join("THOUGHT_STACK.md"), 500_000);
+        write_giant_line(&dir.path().join("AWARENESS.md"), 500_000);
+        std::fs::create_dir_all(dir.path().join("memory")).unwrap();
+        write_giant_line(&dir.path().join("memory/MEMORY.md"), 500_000);
+
+        let chat = build_system_prompt_budgeted(dir.path(), &config, None, None).unwrap();
+        assert!(
+            chat.prompt.len() < 128 * 1024,
+            "chat prompt unbounded with budget disabled: {} bytes",
+            chat.prompt.len()
+        );
+        assert_eq!(chat.prompt.matches("byte ceiling").count(), 3);
+
+        let task = build_task_system_prompt_budgeted(dir.path(), &config).unwrap();
+        assert!(
+            task.prompt.len() < 64 * 1024,
+            "task prompt unbounded with budget disabled: {} bytes",
+            task.prompt.len()
+        );
+        assert!(task.prompt.contains("byte ceiling"));
+    }
+
+    /// AC1 (prompt side): a 10MB THOUGHT_STACK of 4KB lines still assembles
+    /// into a prompt small enough to hand to a subprocess.
+    #[test]
+    fn giant_thought_stack_yields_a_bounded_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = minimal_config();
+
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Entity").unwrap();
+        let line = "t".repeat(4096);
+        let stack: String = std::iter::repeat(line.as_str())
+            .take(2560)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(stack.len() > 10 * 1024 * 1024);
+        std::fs::write(dir.path().join("THOUGHT_STACK.md"), &stack).unwrap();
+
+        let result = build_system_prompt_budgeted(dir.path(), &config, None, None).unwrap();
+        assert!(
+            result.prompt.len() < 64 * 1024,
+            "assembled prompt was {} bytes",
+            result.prompt.len()
+        );
+    }
+
+    #[test]
+    fn essential_over_hard_byte_limit_fails_loudly() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = minimal_config();
+        // Token caps off — only the essential hard limit should speak here.
+        config.system_prompt_budget.enabled = false;
+
+        std::fs::write(dir.path().join("CLAUDE.md"), "c".repeat(70 * 1024)).unwrap();
+
+        let err = build_system_prompt_budgeted(dir.path(), &config, None, None).unwrap_err();
+        assert!(
+            matches!(err, crate::errors::PromptError::EssentialTooLarge { .. }),
+            "expected EssentialTooLarge, got: {err}"
+        );
+        assert!(err.to_string().contains("never auto-trimmed"));
+    }
+
+    #[test]
+    fn pass_three_hard_truncates_high_tier() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = minimal_config();
+        config.system_prompt_budget.enabled = true;
+        // Essential (~100 tokens of static blocks) plus a High-tier SELF.md
+        // that alone blows the budget. Low tiers are absent, so only Pass 3
+        // can bring this back under.
+        config.system_prompt_budget.token_budget = 800;
+        config.system_prompt_budget.self_md_cap = 0;
+
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Entity").unwrap();
+        std::fs::write(dir.path().join("SELF.md"), "s".repeat(40_000)).unwrap();
+
+        let result = build_system_prompt_budgeted(dir.path(), &config, None, None).unwrap();
+
+        assert!(result.was_trimmed, "Pass 3 must trim, not just warn");
+        assert!(result.prompt.contains("token cap"));
+        assert!(
+            result.estimated_tokens <= 900,
+            "prompt still over budget: {} tokens",
+            result.estimated_tokens
+        );
+        // Essential survives untouched.
+        assert!(result.prompt.contains("# Entity"));
+        assert!(result.prompt.contains("memory-curation"));
+    }
+
+    // --- Task path ---
+
+    #[test]
+    fn task_prompt_keeps_its_content_and_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = minimal_config();
+
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Entity\nBehave.").unwrap();
+        std::fs::write(dir.path().join("SELF.md"), "I am a test.").unwrap();
+        std::fs::write(dir.path().join("THOUGHT_STACK.md"), "- thinking").unwrap();
+
+        let prompt = build_task_system_prompt(dir.path(), &config).unwrap();
+
+        let claude = prompt.find("# Entity").unwrap();
+        let identity = prompt.find("<identity>").unwrap();
+        let stack = prompt.find("<thought-stack>").unwrap();
+        let task = prompt.find("<task-context>").unwrap();
+        assert!(claude < identity && identity < stack && stack < task);
+
+        // Chat-only components stay out of the task prompt.
+        assert!(!prompt.contains("<memory>"));
+        assert!(!prompt.contains("<last-session>"));
+        assert!(!prompt.contains("memory-curation"));
+    }
+
+    #[test]
+    fn task_prompt_reports_budget_metrics() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = minimal_config();
+
+        std::fs::write(dir.path().join("CLAUDE.md"), "# Entity").unwrap();
+
+        let result = build_task_system_prompt_budgeted(dir.path(), &config).unwrap();
+
+        assert!(result.estimated_tokens > 0);
+        assert!(!result.was_trimmed);
+        assert!(result.dropped_components.is_empty());
+        assert!(result.prompt.contains("<task-context>"));
+    }
+
+    #[test]
+    fn task_prompt_applies_component_caps() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = minimal_config();
+        config.system_prompt_budget.claude_md_cap = 50;
+
+        std::fs::write(dir.path().join("CLAUDE.md"), "x".repeat(4_000)).unwrap();
+
+        let result = build_task_system_prompt_budgeted(dir.path(), &config).unwrap();
+
+        assert!(result.prompt.contains("[truncated"));
+        // The hallucination guard is essential and always survives.
+        assert!(result.prompt.contains("Do NOT generate user messages"));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -655,6 +655,42 @@ pub fn count_recent_conversations(root_dir: &Path, days: i64) -> u32 {
     count
 }
 
+/// Size at which `pipeline-changes.jsonl` rotates. Append-only journals with
+/// no rotation are how a disk fills up quietly.
+const PIPELINE_JOURNAL_MAX_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Rotate an append-only journal once it passes `max_bytes`.
+///
+/// Keep-newest semantics: the live file is renamed to `<name>.1` (replacing any
+/// previous generation) and the next append starts a fresh file. Readers that
+/// open the live path always see valid JSON lines — never a half-truncated one —
+/// and only ever lose visibility of entries older than the last rotation.
+fn rotate_journal_if_over(path: &Path, max_bytes: u64) {
+    let size = match fs::metadata(path) {
+        Ok(meta) => meta.len(),
+        Err(_) => return,
+    };
+    if size <= max_bytes {
+        return;
+    }
+
+    let file_name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(name) => name.to_string(),
+        None => return,
+    };
+    let rotated = path.with_file_name(format!("{}.1", file_name));
+
+    match fs::rename(path, &rotated) {
+        Ok(()) => tracing::info!(
+            "Rotated {} ({} bytes) to {}",
+            path.display(),
+            size,
+            rotated.display()
+        ),
+        Err(e) => tracing::error!("Failed to rotate {}: {}", path.display(), e),
+    }
+}
+
 /// Log a pipeline state change to the pipeline change journal.
 /// Each entry records the old and new counts along with what changed.
 pub fn log_pipeline_change(
@@ -669,6 +705,7 @@ pub fn log_pipeline_change(
     }
 
     let journal_path = root_dir.join("pipeline-changes.jsonl");
+    rotate_journal_if_over(&journal_path, PIPELINE_JOURNAL_MAX_BYTES);
 
     let mut changes = Vec::new();
     if old_counts.learning != new_counts.learning {
@@ -1048,5 +1085,66 @@ mod tests {
     fn count_recent_conversations_no_index() {
         let tmp = tempfile::tempdir().unwrap();
         assert_eq!(count_recent_conversations(tmp.path(), 7), 0);
+    }
+
+    // --- PN-75: journal rotation ---
+
+    #[test]
+    fn journal_under_the_limit_is_left_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("pipeline-changes.jsonl");
+        fs::write(&path, "{\"a\":1}\n").unwrap();
+
+        rotate_journal_if_over(&path, 1024);
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{\"a\":1}\n");
+        assert!(!tmp.path().join("pipeline-changes.jsonl.1").exists());
+    }
+
+    /// AC8: rotation keeps the newest entries readable and leaves whole JSON
+    /// lines behind — no reader sees a truncated record.
+    #[test]
+    fn journal_rotation_keeps_newest_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let path = root.join("pipeline-changes.jsonl");
+        let rotated = root.join("pipeline-changes.jsonl.1");
+
+        let old_entries = "{\"old\":true}\n".repeat(200);
+        fs::write(&path, &old_entries).unwrap();
+
+        rotate_journal_if_over(&path, 128);
+
+        assert!(!path.exists(), "live journal restarts empty after rotation");
+        assert_eq!(fs::read_to_string(&rotated).unwrap(), old_entries);
+
+        // A subsequent append starts a fresh, fully parseable journal.
+        let old_counts = pulse_system_types::monitoring::DocumentCounts::default();
+        let mut new_counts = old_counts.clone();
+        new_counts.learning += 1;
+        log_pipeline_change(root, &old_counts, &new_counts, "test");
+
+        let live = fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = live.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines.len(), 1);
+        for line in lines {
+            serde_json::from_str::<serde_json::Value>(line).unwrap();
+        }
+    }
+
+    #[test]
+    fn journal_rotation_replaces_the_previous_generation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("pipeline-changes.jsonl");
+        let rotated = tmp.path().join("pipeline-changes.jsonl.1");
+
+        fs::write(&rotated, "{\"generation\":0}\n").unwrap();
+        fs::write(&path, "{\"generation\":1}\n".repeat(100)).unwrap();
+
+        rotate_journal_if_over(&path, 64);
+
+        let kept = fs::read_to_string(&rotated).unwrap();
+        assert!(kept.contains("\"generation\":1"));
+        assert!(!kept.contains("\"generation\":0"));
     }
 }


### PR DESCRIPTION
Echo died silently for seven weeks (2026-06-14 → 08-03). Two independent failures compounded: the system prompt outgrew Linux's 128KB per-argument limit because every cap counted lines rather than bytes, and 500+ consecutive task failures escalated nothing distinguishable from noise. This fixes both classes.

## Prompt transport (AC1)

The system prompt now travels in a 0600 temp file via `--system-prompt-file`; argv carries flags only, so the kernel limit stops being reachable. Cleanup is an RAII guard, so it survives every exit path including the timeout branch and outright future cancellation. Support is probed per binary by pointing the flag at a path that cannot exist — an unaware CLI rejects the *option*, an aware one rejects the *file* — and an unsupported CLI is a hard named error, never a silent fall back to argv.

## Byte governance (AC2, AC3, AC6, AC8)

Every line-counted cap gained a byte ceiling, enforced regardless of `budget.enabled` because these are safety rather than budgeting: THOUGHT_STACK 48KB (the component that caused the outage — it bites the live file today by ~4KB, which is the point), AWARENESS 16KB, MEMORY 32KB, intake-audit and LOGBOOK 64KB, and `pipeline-changes.jsonl` rotates at 8MB. Budget Pass 3 now hard-truncates the High tier instead of only warning, and the Essential tier gets a 64KB check that fails loudly. `build_task_system_prompt` — the path every scheduled task used, which had no budget at all — is rebuilt on the shared budgeted assembly with identical ordering and text.

One contract change worth naming: `budget_disabled_loads_everything` asserted that disabling the budget loads oversized files untouched. AC6 deliberately reverses that, so it is now `budget_disabled_skips_token_caps` — token caps still off, byte ceilings still on.

## Liveness (AC4, AC5, AC7)

A persisted per-task health store drives alerts: `[ALERT]` after 3 consecutive failures naming the task, the count and the streak start; re-alerts on a backoff ladder so it can never go quiet; `[RESOLVED]` on recovery naming how long it was broken; and a global alert when no task has succeeded in 6h while tasks are enabled — the rule that would have caught this outage on day one. `pulse-null status` shows per-task last-success age, streak and a staleness marker. Webhook failures log and retry next cycle; alert state advances only on successful delivery.

## Deploy

Ships via `/update-pulse`. **Echo's seven scheduled tasks stay disabled** — re-enabling is a separate, explicit decision after the deploy is verified.

633 tests, clippy -D warnings clean. Refs #75