### PR TITLE
feat: quiet the error channel, and let a task pick its own model

### DIFF
--- a/src/cli/schedule.rs
+++ b/src/cli/schedule.rs
@@ -4,7 +4,15 @@ use console::style;
 use cron::Schedule as CronSchedule;
 
 use crate::config::Config;
-use crate::scheduler::{OutputRouting, Schedule, ScheduledTask, TaskCreator};
+use crate::scheduler::{OutputRouting, Schedule, ScheduleEntry, ScheduledTask, TaskCreator};
+
+/// How a task's model reads in `schedule list`: its own, or the inherited one.
+fn model_line(entry: &ScheduleEntry, default_model: &str) -> String {
+    match entry.model_override() {
+        Some(model) => format!("{model} (override)"),
+        None => format!("{default_model} (from [llm] model)"),
+    }
+}
 
 pub async fn list() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
@@ -20,7 +28,8 @@ pub async fn list() -> Result<(), Box<dyn std::error::Error>> {
     println!("  {}", style("Scheduled Tasks").bold());
     println!();
 
-    for task in &schedule.tasks {
+    for entry in &schedule.tasks {
+        let task = &entry.task;
         let status = if task.enabled {
             style("enabled").green()
         } else {
@@ -48,6 +57,7 @@ pub async fn list() -> Result<(), Box<dyn std::error::Error>> {
             task.cron,
         );
         println!("    Next: {}", next);
+        println!("    Model: {}", model_line(entry, &config.llm.model));
         println!();
     }
 
@@ -85,7 +95,7 @@ pub async fn add(
         evaluator: None,
     };
 
-    schedule.add_task(task);
+    schedule.add_task(ScheduleEntry::from(task));
     schedule.save(&root_dir)?;
 
     println!("  Task '{}' added (id: {})", style(&name).cyan(), id);
@@ -112,8 +122,8 @@ pub async fn enable(id: String) -> Result<(), Box<dyn std::error::Error>> {
     let root_dir = config.root_dir()?;
     let mut schedule = Schedule::load(&root_dir)?;
 
-    if let Some(task) = schedule.find_task_mut(&id) {
-        task.enabled = true;
+    if let Some(entry) = schedule.find_task_mut(&id) {
+        entry.task.enabled = true;
         schedule.save(&root_dir)?;
         println!("  Task '{}' enabled.", style(&id).green());
     } else {
@@ -128,13 +138,53 @@ pub async fn disable(id: String) -> Result<(), Box<dyn std::error::Error>> {
     let root_dir = config.root_dir()?;
     let mut schedule = Schedule::load(&root_dir)?;
 
-    if let Some(task) = schedule.find_task_mut(&id) {
-        task.enabled = false;
+    if let Some(entry) = schedule.find_task_mut(&id) {
+        entry.task.enabled = false;
         schedule.save(&root_dir)?;
         println!("  Task '{}' disabled.", style(&id).yellow());
     } else {
         println!("  Task '{}' not found.", style(&id).red());
     }
 
+    Ok(())
+}
+
+/// Pin one task to a model, or clear the pin so it follows `[llm] model`.
+///
+/// Editing schedule.json by hand does not work while the entity is running —
+/// the process rewrites the file — so the override needs a command of its own,
+/// exactly like `enable` / `disable`.
+pub async fn set_model(
+    id: String,
+    model: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+    let root_dir = config.root_dir()?;
+    let mut schedule = Schedule::load(&root_dir)?;
+
+    let Some(entry) = schedule.find_task_mut(&id) else {
+        println!("  Task '{}' not found.", style(&id).red());
+        return Ok(());
+    };
+
+    let model = model
+        .map(|m| m.trim().to_string())
+        .filter(|m| !m.is_empty());
+    entry.model.clone_from(&model);
+    schedule.save(&root_dir)?;
+
+    match model {
+        Some(model) => println!(
+            "  Task '{}' pinned to model {}.",
+            style(&id).cyan(),
+            style(&model).cyan()
+        ),
+        None => println!(
+            "  Task '{}' now follows [llm] model ({}).",
+            style(&id).cyan(),
+            style(&config.llm.model).cyan()
+        ),
+    }
+    println!("  Restart the entity for a running scheduler to pick this up.");
     Ok(())
 }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -94,7 +94,8 @@ fn print_task_liveness(config: &Config, root_dir: &std::path::Path) {
 
     let mut enabled = 0usize;
     let mut problems = 0usize;
-    for task in &schedule.tasks {
+    for entry in &schedule.tasks {
+        let task = &entry.task;
         if task.enabled {
             enabled += 1;
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -225,6 +225,19 @@ pub struct OutputConfig {
     /// Endpoint for [CALL:] output (voice plugin)
     #[serde(default)]
     pub call_endpoint: Option<String>,
+    /// Webhook URL for per-failure task diagnostics (`[task-error]` lines).
+    ///
+    /// These carry the full error text at the moment of failure and exist to
+    /// *diagnose*, not to alarm — the alarm is
+    /// [`LivenessConfig`]'s `[ALERT]` / `[RESOLVED]`. Point this at a
+    /// different channel than `share_webhook` so the alarm channel contains
+    /// nothing that looks like an alarm.
+    ///
+    /// Unset falls back to `share_webhook` with plain, un-alarming framing —
+    /// silence would lose the only full error text there is. See
+    /// [`crate::scheduler::diagnostics`].
+    #[serde(default)]
+    pub diagnostics_webhook: Option<String>,
 }
 
 impl Default for MemoryConfig {
@@ -516,7 +529,11 @@ pub struct EventsConfig {
     /// Queue investigation when conversations archive but pipeline docs don't update
     #[serde(default = "default_true")]
     pub pipeline_conversion_low: bool,
-    /// Send notification when LLM provider fails
+    /// Send a `[task-error]` diagnostic when a scheduled task fails.
+    ///
+    /// The diagnostic is state-aware: one per failure streak plus one per
+    /// change of error text. Turning this off leaves the liveness alarm as
+    /// the only failure signal.
     pub provider_error: bool,
 }
 
@@ -922,6 +939,55 @@ impl Default for PulseConfig {
         Self {
             enabled: true,
             max_outcomes: 200,
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test_support {
+    use super::*;
+
+    /// A `Config` with every required field filled in and everything else at
+    /// its default — the starting point for tests that need to vary one knob.
+    pub fn minimal_config() -> Config {
+        Config {
+            entity: EntityConfig {
+                name: "Test".into(),
+                owner_name: "Owner".into(),
+                owner_alias: "O".into(),
+                rules_dir: None,
+            },
+            server: ServerConfig::default(),
+            llm: LlmConfig {
+                provider: default_provider(),
+                api_key: Some("test-key".into()),
+                model: default_model(),
+                max_tokens: default_max_tokens(),
+                base_url: None,
+                claude_bin: None,
+                context_budget: 0,
+            },
+            security: SecurityConfig {
+                secret: None,
+                injection_detection: true,
+            },
+            trust: TrustConfig::default(),
+            owner: OwnerConfig::default(),
+            memory: MemoryConfig::default(),
+            scheduler: SchedulerConfig::default(),
+            pipeline: PipelineConfig::default(),
+            monitoring: MonitoringConfig::default(),
+            autonomy: AutonomyConfig::default(),
+            pulse: PulseConfig::default(),
+            graph: GraphConfig::default(),
+            prediction: PredictionConfig::default(),
+            sessions: SessionConfig::default(),
+            context_buffer: crate::context_buffer::ContextBufferConfig::default(),
+            session_health: crate::session_health::SessionHealthConfig::default(),
+            platform: PlatformConfig::default(),
+            system_prompt_budget: SystemPromptBudgetConfig::default(),
+            peers: HashMap::new(),
+            plugins: HashMap::new(),
         }
     }
 }

--- a/src/init/templates.rs
+++ b/src/init/templates.rs
@@ -79,6 +79,11 @@ timezone = "{timezone}"
 [scheduler.output]
 # share_webhook = "https://discord.com/api/webhooks/..."
 # call_endpoint = "http://localhost:8443/api/call"
+# Per-failure diagnostics ([task-error] lines with the full error text).
+# Point this at a channel of its own: the liveness [ALERT] below can only be
+# read as an alarm if nothing else in its channel looks like one. Unset falls
+# back to share_webhook with plain framing.
+# diagnostics_webhook = "https://discord.com/api/webhooks/..."
 
 [scheduler.liveness]
 enabled = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,17 @@ enum ScheduleAction {
         /// Task ID
         id: String,
     },
+    /// Pin a task to a specific model, overriding [llm] model for that task
+    Model {
+        /// Task ID
+        id: String,
+        /// Model name (omit with --clear to follow [llm] model again)
+        #[arg(required_unless_present = "clear", conflicts_with = "clear")]
+        model: Option<String>,
+        /// Remove the override so the task follows [llm] model
+        #[arg(long)]
+        clear: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -321,6 +332,9 @@ async fn main() {
                 ScheduleAction::Remove { id } => cli::schedule::remove(id).await,
                 ScheduleAction::Enable { id } => cli::schedule::enable(id).await,
                 ScheduleAction::Disable { id } => cli::schedule::disable(id).await,
+                ScheduleAction::Model { id, model, clear } => {
+                    cli::schedule::set_model(id, if clear { None } else { model }).await
+                }
             };
             if let Err(e) = result {
                 eprintln!("Error: {e}");

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -69,3 +69,75 @@ pub fn create_streaming_provider(
 pub fn create_provider_arc(config: &Config) -> Result<Arc<Box<dyn LmProvider>>, ProviderError> {
     Ok(Arc::new(create_provider(config)?))
 }
+
+/// Create a provider that talks to `model` instead of `[llm] model`.
+///
+/// The [`LmProvider`](pulse_system_types::llm::LmProvider) contract has no
+/// per-invocation model parameter — a provider *is* its model — so overriding
+/// one call means building a provider for it. That is cheap for every backend
+/// here (a subprocess spawner or an HTTP client), and a scheduled task fires
+/// minutes apart, so it is built per execution rather than cached.
+pub fn create_provider_with_model(
+    config: &Config,
+    model: &str,
+) -> Result<Box<dyn LmProvider>, ProviderError> {
+    create_provider(&with_model(config, model))
+}
+
+/// The same configuration, pointed at a different model.
+///
+/// Split out from [`create_provider_with_model`] so the substitution can be
+/// tested on its own: everything but the model must survive, and the caller's
+/// configuration must not be touched.
+fn with_model(config: &Config, model: &str) -> Config {
+    let mut overridden = config.clone();
+    overridden.llm.model = model.to_string();
+    overridden
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::LlmConfig;
+
+    fn config() -> Config {
+        let mut config = crate::config::test_support::minimal_config();
+        config.llm = LlmConfig {
+            provider: "claude-code".into(),
+            api_key: Some("key".into()),
+            model: "fable-5".into(),
+            max_tokens: 8192,
+            base_url: None,
+            claude_bin: Some("/usr/bin/claude".into()),
+            context_budget: 4096,
+        };
+        config
+    }
+
+    #[test]
+    fn only_the_model_changes() {
+        let original = config();
+        let overridden = with_model(&original, "claude-opus-4-8");
+
+        assert_eq!(overridden.llm.model, "claude-opus-4-8");
+        assert_eq!(overridden.llm.provider, original.llm.provider);
+        assert_eq!(overridden.llm.api_key, original.llm.api_key);
+        assert_eq!(overridden.llm.max_tokens, original.llm.max_tokens);
+        assert_eq!(overridden.llm.claude_bin, original.llm.claude_bin);
+        assert_eq!(overridden.llm.context_budget, original.llm.context_budget);
+    }
+
+    #[test]
+    fn the_callers_config_is_left_alone() {
+        let original = config();
+        let _ = with_model(&original, "claude-opus-4-8");
+        assert_eq!(original.llm.model, "fable-5");
+    }
+
+    #[test]
+    fn an_unknown_provider_is_an_error_not_a_silent_default() {
+        let mut config = config();
+        config.llm.provider = "nonesuch".into();
+        assert!(create_provider_with_model(&config, "claude-opus-4-8").is_err());
+    }
+}

--- a/src/scheduler/diagnostics.rs
+++ b/src/scheduler/diagnostics.rs
@@ -1,0 +1,435 @@
+//! Per-failure task diagnostics: the `[task-error]` line.
+//!
+//! # Why this is not an alarm
+//!
+//! Every scheduled-task failure used to post a bold "⚠️ Provider Error" to the
+//! same webhook as `[SHARE:]` output and the liveness `[ALERT]` / `[RESOLVED]`
+//! alarm, with no dedupe and no backoff. A failing task therefore produced one
+//! alarm-shaped message per cycle forever, which taught the operator to stop
+//! reading the channel — and that is how a seven-week total outage hid in
+//! plain sight. **An alarm only works if nothing else in the channel looks
+//! like an alarm.**
+//!
+//! So this module keeps the information and drops the theatre:
+//!
+//! * **A separate destination.** `diagnostics_webhook` when set; otherwise the
+//!   share webhook, in plain framing (see [`destination`]).
+//! * **A separate voice.** Lowercase `[task-error]`, no emoji, no bold — it
+//!   reads as a log line, because that is what it is. `[ALERT]` and
+//!   `[RESOLVED]` stay reserved for [`super::health`].
+//! * **State-awareness.** Only failures that are *news* are posted: the first
+//!   of a streak, and any change of error text. See
+//!   [`super::health::failure_is_news_for`].
+//!
+//! # Why it is not deleted
+//!
+//! These lines carry the only full error text at the moment of failure — the
+//! alarm carries one truncated `last_error` on a six-hour ladder, which is
+//! enough to know and not enough to diagnose. They are also a stateless
+//! fallback for a misconfigured or wrong alarm, which is exactly the failure
+//! mode that cost seven weeks.
+//!
+//! # Degradation
+//!
+//! The state-awareness reads [`super::health::TaskHealthStore`], which is only
+//! written while `[scheduler.liveness] enabled = true`. With the alarm off the
+//! store never advances, every failure reads as the first of a streak, and
+//! every failure is posted — the pre-existing behaviour, which is the right
+//! fallback when this is the only failure signal left.
+
+use std::sync::Arc;
+
+use crate::config::OutputConfig;
+use crate::provider_status;
+use crate::server::AppState;
+
+use super::liveness::SharedTaskHealth;
+use super::output;
+use super::ScheduleEntry;
+
+/// Longest error text carried into a webhook message.
+///
+/// Discord rejects bodies over 2000 characters; a diagnostic that 400s
+/// delivers nothing at all. The untruncated text is always written to the
+/// journal at `error` level, so nothing is actually lost.
+const MAX_WEBHOOK_ERROR_LEN: usize = 1500;
+
+/// Where a diagnostic goes.
+///
+/// Naming the fallback rather than folding it into an `Option` keeps the
+/// distinction visible: a dedicated channel is the configuration this feature
+/// exists to encourage, and sharing the alarm channel is a compromise the
+/// operator should be able to see in the logs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Destination<'a> {
+    /// `diagnostics_webhook` — a channel of its own.
+    Dedicated(&'a str),
+    /// No diagnostics webhook, so the share webhook carries it instead.
+    ///
+    /// Plain framing, deliberately: the point of the fallback is to keep the
+    /// full error text reaching a human, not to add a second alarm shape to
+    /// the channel that already holds one.
+    SharedChannel(&'a str),
+    /// No webhook at all — the journal is the only channel there is.
+    LogOnly,
+}
+
+/// Resolve where diagnostics go for this configuration.
+///
+/// Falling back to the share webhook rather than going silent is deliberate:
+/// an operator who upgrades and configures nothing would otherwise lose the
+/// only full error text the system produces, which is the regression that cost
+/// seven weeks. The volume problem the fallback used to cause is solved by
+/// state-awareness instead — a 500-cycle streak posts once, not 500 times.
+#[must_use]
+pub fn destination(output: &OutputConfig) -> Destination<'_> {
+    if let Some(url) = non_empty(output.diagnostics_webhook.as_deref()) {
+        return Destination::Dedicated(url);
+    }
+    match non_empty(output.share_webhook.as_deref()) {
+        Some(url) => Destination::SharedChannel(url),
+        None => Destination::LogOnly,
+    }
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|url| !url.is_empty())
+}
+
+/// One rendered failure, ready for a channel a human reads.
+#[derive(Debug, Clone, Copy)]
+pub struct Diagnostic<'a> {
+    pub task_id: &'a str,
+    pub task_name: &'a str,
+    /// Classified error kind (`auth`, `rate_limit`, …).
+    pub error_kind: &'a str,
+    pub error: &'a str,
+    /// Model the task ran on — the effective one, override included. A task
+    /// pinned to a model is usually pinned *because* of how a model behaves,
+    /// so which one produced the failure is part of the failure.
+    pub model: &'a str,
+    /// Failures already recorded in this streak, *not* counting this one.
+    pub prior_failures: u32,
+}
+
+impl Diagnostic<'_> {
+    /// The message body: one identifying line, then the error.
+    ///
+    /// Deliberately unformatted. No emoji, no bold, no `[ALERT]` — anything
+    /// that reads as an alarm here devalues the one in the same channel.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let name = if self.task_name.is_empty() {
+            self.task_id
+        } else {
+            self.task_name
+        };
+        format!(
+            "[task-error] {} ({}) — failure #{}, {}; kind={}; model={}\n{}",
+            name,
+            self.task_id,
+            self.prior_failures + 1,
+            self.reason(),
+            self.error_kind,
+            self.model,
+            self.truncated_error(),
+        )
+    }
+
+    /// Why this failure was worth a message. Derived, not stored: a failure is
+    /// only reported when it is news, and news with no prior failures in the
+    /// streak can only be the streak starting.
+    fn reason(&self) -> &'static str {
+        if self.prior_failures == 0 {
+            "first of a new streak"
+        } else {
+            "new error text for this streak"
+        }
+    }
+
+    fn truncated_error(&self) -> String {
+        let kept = crate::utils::safe_truncate(self.error, MAX_WEBHOOK_ERROR_LEN);
+        if kept.len() == self.error.len() {
+            kept.to_string()
+        } else {
+            format!("{kept}… (truncated; full text in the journal)")
+        }
+    }
+}
+
+/// Report one task failure: always to the journal, to a channel only when the
+/// failure is news.
+///
+/// Called before the outcome is recorded, so the health store still describes
+/// the task as of the previous cycle — which is exactly the comparison
+/// "is this new?" needs.
+///
+/// Never fails and never propagates: diagnostics cannot be allowed to take
+/// down the task they are reporting on.
+pub async fn report_failure(
+    health: &SharedTaskHealth,
+    state: &Arc<AppState>,
+    entry: &ScheduleEntry,
+    error: &str,
+) {
+    let task = &entry.task;
+    let error_kind = provider_status::classify_error(error).to_string();
+    let model = entry.effective_model(&state.config.llm.model);
+
+    // The journal keeps everything, whatever the channel policy is.
+    tracing::error!(
+        task_id = %task.id,
+        error_kind = %error_kind,
+        model = %model,
+        "Scheduled task '{}' failed: {}",
+        task.name,
+        error
+    );
+
+    if !state.config.autonomy.events.provider_error {
+        return;
+    }
+
+    let (is_news, prior_failures) = {
+        let store = health.read().await;
+        (
+            store.failure_is_news(&task.id, error),
+            store.consecutive_failures(&task.id),
+        )
+    };
+    if !is_news {
+        tracing::debug!(
+            task_id = %task.id,
+            prior_failures,
+            "Repeat of a known failure — journal only; the liveness alarm owns escalation"
+        );
+        return;
+    }
+
+    let diagnostic = Diagnostic {
+        task_id: &task.id,
+        task_name: &task.name,
+        error_kind: &error_kind,
+        error,
+        model,
+        prior_failures,
+    };
+    let message = diagnostic.render();
+
+    match destination(&state.config.scheduler.output) {
+        Destination::Dedicated(url) => output::deliver_diagnostic(&message, url).await,
+        Destination::SharedChannel(url) => {
+            tracing::debug!(
+                task_id = %task.id,
+                "No diagnostics_webhook configured — using the share webhook"
+            );
+            output::deliver_diagnostic(&message, url).await;
+        }
+        Destination::LogOnly => {
+            tracing::warn!(task_id = %task.id, "No webhook configured for task diagnostics");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scheduler::health::{failure_is_news_for, TaskHealth, TaskHealthStore};
+    use chrono::{DateTime, Duration, Utc};
+    use tempfile::TempDir;
+
+    fn output_config(diagnostics: Option<&str>, share: Option<&str>) -> OutputConfig {
+        OutputConfig {
+            share_webhook: share.map(str::to_string),
+            call_endpoint: None,
+            diagnostics_webhook: diagnostics.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn dedicated_webhook_wins() {
+        let config = output_config(Some("https://diag"), Some("https://share"));
+        assert_eq!(destination(&config), Destination::Dedicated("https://diag"));
+    }
+
+    #[test]
+    fn falls_back_to_share_webhook_rather_than_going_silent() {
+        let config = output_config(None, Some("https://share"));
+        assert_eq!(
+            destination(&config),
+            Destination::SharedChannel("https://share")
+        );
+    }
+
+    #[test]
+    fn blank_webhooks_do_not_count_as_configured() {
+        let config = output_config(Some("   "), Some(""));
+        assert_eq!(destination(&config), Destination::LogOnly);
+    }
+
+    #[test]
+    fn no_webhook_at_all_is_log_only() {
+        assert_eq!(
+            destination(&output_config(None, None)),
+            Destination::LogOnly
+        );
+        assert_eq!(destination(&OutputConfig::default()), Destination::LogOnly);
+    }
+
+    /// The whole point: a diagnostic must not be mistakable for the alarm that
+    /// shares its channel.
+    #[test]
+    fn rendered_message_carries_no_alarm_framing() {
+        let message = Diagnostic {
+            task_id: "thinking-loop",
+            task_name: "Thinking Loop",
+            error_kind: "auth",
+            error: "401 Unauthorized: invalid x-api-key",
+            model: "claude-opus-4-8",
+            prior_failures: 0,
+        }
+        .render();
+
+        assert!(message.starts_with("[task-error] "), "got: {message}");
+        assert!(!message.contains("[ALERT]"), "got: {message}");
+        assert!(!message.contains("[RESOLVED]"), "got: {message}");
+        assert!(!message.contains('\u{26a0}'), "got: {message}");
+        assert!(!message.contains("**"), "got: {message}");
+    }
+
+    #[test]
+    fn rendered_message_states_the_failure_number_reason_and_model() {
+        let first = Diagnostic {
+            task_id: "thinking-loop",
+            task_name: "Thinking Loop",
+            error_kind: "auth",
+            error: "401",
+            model: "claude-opus-4-8",
+            prior_failures: 0,
+        }
+        .render();
+        assert!(
+            first.contains("failure #1, first of a new streak"),
+            "{first}"
+        );
+        assert!(first.contains("kind=auth"), "{first}");
+        assert!(first.contains("model=claude-opus-4-8"), "{first}");
+        assert!(first.contains("401"), "{first}");
+
+        let changed = Diagnostic {
+            task_id: "thinking-loop",
+            task_name: "Thinking Loop",
+            error_kind: "timeout",
+            error: "deadline exceeded",
+            model: "fable-5",
+            prior_failures: 3,
+        }
+        .render();
+        assert!(
+            changed.contains("failure #4, new error text for this streak"),
+            "{changed}"
+        );
+    }
+
+    #[test]
+    fn nameless_task_falls_back_to_its_id() {
+        let message = Diagnostic {
+            task_id: "thinking-loop",
+            task_name: "",
+            error_kind: "unknown",
+            error: "boom",
+            model: "fable-5",
+            prior_failures: 0,
+        }
+        .render();
+        assert!(message.starts_with("[task-error] thinking-loop (thinking-loop)"));
+    }
+
+    /// Discord rejects bodies over 2000 characters, and a rejected diagnostic
+    /// delivers nothing at all.
+    #[test]
+    fn oversized_error_is_truncated_and_says_so() {
+        let error = "x".repeat(10_000);
+        let message = Diagnostic {
+            task_id: "t",
+            task_name: "T",
+            error_kind: "unknown",
+            error: &error,
+            model: "fable-5",
+            prior_failures: 0,
+        }
+        .render();
+        assert!(message.len() < 2000, "message was {} bytes", message.len());
+        assert!(message.contains("(truncated; full text in the journal)"));
+    }
+
+    fn at(minutes: i64) -> DateTime<Utc> {
+        DateTime::<Utc>::MIN_UTC + Duration::days(365 * 100) + Duration::minutes(minutes)
+    }
+
+    /// The routing rule, end to end over the store the alarm already keeps:
+    /// post once per streak, again when the error changes, and again after a
+    /// success re-arms it.
+    #[test]
+    fn news_only_once_per_streak_until_something_changes() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        let (id, name) = ("thinking-loop", "Thinking Loop");
+
+        // First failure of a streak: news.
+        assert!(store.failure_is_news(id, "rate limited"));
+        store.record_failure(id, name, "rate limited", at(0));
+
+        // Same error again: not news — the alarm owns escalation from here.
+        assert!(!store.failure_is_news(id, "rate limited"));
+        store.record_failure(id, name, "rate limited", at(20));
+        assert!(!store.failure_is_news(id, "rate limited"));
+
+        // A different failure mode is news even mid-streak.
+        assert!(store.failure_is_news(id, "401 unauthorized"));
+        store.record_failure(id, name, "401 unauthorized", at(40));
+        assert!(!store.failure_is_news(id, "401 unauthorized"));
+
+        // ...and the old error becomes news again, because it is a change.
+        assert!(store.failure_is_news(id, "rate limited"));
+
+        // A success resets the streak, so the next failure re-arms.
+        store.record_success(id, name, at(60));
+        assert!(store.failure_is_news(id, "401 unauthorized"));
+    }
+
+    /// The failure number printed in the message counts the failure being
+    /// reported, which has not been recorded yet.
+    #[test]
+    fn prior_failure_count_excludes_the_unrecorded_failure() {
+        let dir = TempDir::new().unwrap();
+        let mut store = TaskHealthStore::load(dir.path());
+        assert_eq!(store.consecutive_failures("thinking-loop"), 0);
+
+        store.record_failure("thinking-loop", "Thinking Loop", "boom", at(0));
+        assert_eq!(store.consecutive_failures("thinking-loop"), 1);
+
+        store.record_success("thinking-loop", "Thinking Loop", at(10));
+        assert_eq!(store.consecutive_failures("thinking-loop"), 0);
+    }
+
+    /// An unknown task — first cycle after a restart, or liveness disabled so
+    /// the store never advances — always reports.
+    #[test]
+    fn unknown_task_is_always_news() {
+        assert!(failure_is_news_for(None, "anything"));
+    }
+
+    /// Two errors the store cannot tell apart must not be reported as
+    /// different, or a long error with a varying tail would post every cycle.
+    #[test]
+    fn errors_differing_only_past_the_stored_length_are_not_news() {
+        let long = "e".repeat(400);
+        let health = TaskHealth {
+            consecutive_failures: 2,
+            last_error: Some(crate::utils::safe_truncate(&long, 300).to_string()),
+            ..TaskHealth::default()
+        };
+        assert!(!failure_is_news_for(Some(&health), &format!("{long}-tail")));
+    }
+}

--- a/src/scheduler/health.rs
+++ b/src/scheduler/health.rs
@@ -274,9 +274,31 @@ impl TaskHealthStore {
         }
         health.consecutive_failures = health.consecutive_failures.saturating_add(1);
         health.last_failure = Some(now);
-        health.last_error = Some(crate::utils::safe_truncate(error, MAX_ERROR_LEN).to_string());
+        health.last_error = Some(stored_error(error));
         push_outcome(health, now, false);
         self.persist();
+    }
+
+    /// Whether a failure that has **not yet been recorded** tells the operator
+    /// something the store does not already hold.
+    ///
+    /// Ask this before [`record_failure`](Self::record_failure) — it compares
+    /// the incoming failure against the state as of the previous cycle.
+    ///
+    /// See [`failure_is_news_for`] for the rule.
+    #[must_use]
+    pub fn failure_is_news(&self, task_id: &str, error: &str) -> bool {
+        failure_is_news_for(self.file.tasks.get(task_id), error)
+    }
+
+    /// Failures recorded in the current streak, not counting one that has not
+    /// been recorded yet. Zero when the task is healthy or unknown.
+    #[must_use]
+    pub fn consecutive_failures(&self, task_id: &str) -> u32 {
+        self.file
+            .tasks
+            .get(task_id)
+            .map_or(0, |h| h.consecutive_failures)
     }
 
     /// Health for one task, if it has ever reported an outcome.
@@ -481,6 +503,37 @@ impl TaskHealthStore {
     fn persist(&self) {
         if let Err(e) = self.save() {
             tracing::error!(error = %e, "Failed to persist scheduler health store");
+        }
+    }
+}
+
+/// The stored form of an error message: what `last_error` holds, and so what
+/// any comparison against it must be made against.
+fn stored_error(error: &str) -> String {
+    crate::utils::safe_truncate(error, MAX_ERROR_LEN).to_string()
+}
+
+/// Whether an unrecorded failure is news, given the task's health so far.
+///
+/// News means one of two things, and nothing else:
+///
+/// * **A streak started.** `consecutive_failures == 0` — the previous cycle
+///   passed (or the task is unknown), so this failure is a new event.
+/// * **The error text changed.** The task is already failing, but for a
+///   different reason than last time: a new failure mode is new information.
+///
+/// A repeat of the same error inside a streak is not news. That is the case
+/// the liveness alarm exists for, and reporting it per-cycle is what turns a
+/// channel into noise.
+///
+/// Comparison is against the *stored* (truncated) form, so two errors that the
+/// store cannot tell apart are not treated as different.
+#[must_use]
+pub fn failure_is_news_for(health: Option<&TaskHealth>, error: &str) -> bool {
+    match health {
+        None => true,
+        Some(health) => {
+            health.consecutive_failures == 0 || health.last_error != Some(stored_error(error))
         }
     }
 }

--- a/src/scheduler/liveness.rs
+++ b/src/scheduler/liveness.rs
@@ -112,8 +112,8 @@ async fn watchdog_tick(
         sched
             .tasks
             .iter()
-            .filter(|t| t.enabled)
-            .map(|t| t.id.clone())
+            .filter(|t| t.task.enabled)
+            .map(|t| t.task.id.clone())
             .collect()
     };
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -1,4 +1,5 @@
 pub mod alerts;
+pub mod diagnostics;
 pub mod digest;
 pub mod dynamic;
 pub mod evaluator;
@@ -21,10 +22,64 @@ use crate::server::AppState;
 // Re-export shared types from pulse-system-types
 pub use pulse_system_types::{OutputRouting, ScheduledTask, TaskCreator};
 
+/// One line of `schedule.json`: a task definition plus the overrides that
+/// belong to this host rather than to the shared plugin contract.
+///
+/// [`ScheduledTask`] is the cross-crate contract (`pulse-system-types`) that
+/// plugins also build, so host-only knobs cannot live on it. They live here
+/// and are flattened into the same JSON object, which keeps the file shape
+/// operators edit unchanged:
+///
+/// ```json
+/// { "id": "research-session", "cron": "0 0 10 * * *", "model": "claude-opus-4-8", ... }
+/// ```
+///
+/// Absent overrides are omitted on write, so a schedule.json that has never
+/// used one round-trips byte-identically through the running process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduleEntry {
+    #[serde(flatten)]
+    pub task: ScheduledTask,
+    /// Model this task runs on, overriding `[llm] model` for this task only.
+    ///
+    /// Exists because a safety layer can refuse a whole *class* of task while
+    /// leaving chat untouched: pinning the entity globally to work around one
+    /// refusing task costs every other caller the model they wanted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+impl ScheduleEntry {
+    /// The model this task should run on, given the configured default.
+    ///
+    /// Precedence: the task's own `model`, else `[llm] model`. A blank or
+    /// whitespace-only override counts as absent — an empty string in
+    /// schedule.json is a typo, not a request for a nameless model.
+    #[must_use]
+    pub fn effective_model<'a>(&'a self, default_model: &'a str) -> &'a str {
+        self.model_override().unwrap_or(default_model)
+    }
+
+    /// The override itself, normalized: `None` unless it names something.
+    #[must_use]
+    pub fn model_override(&self) -> Option<&str> {
+        self.model
+            .as_deref()
+            .map(str::trim)
+            .filter(|m| !m.is_empty())
+    }
+}
+
+impl From<ScheduledTask> for ScheduleEntry {
+    fn from(task: ScheduledTask) -> Self {
+        Self { task, model: None }
+    }
+}
+
 /// The full schedule — loaded from and persisted to schedule.json
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Schedule {
-    pub tasks: Vec<ScheduledTask>,
+    pub tasks: Vec<ScheduleEntry>,
 }
 
 impl Schedule {
@@ -42,7 +97,7 @@ impl Schedule {
         let schedule: Schedule = match serde_json::from_str::<Schedule>(&content) {
             Ok(s) => s,
             Err(_) => {
-                let tasks: Vec<ScheduledTask> = serde_json::from_str(&content)?;
+                let tasks: Vec<ScheduleEntry> = serde_json::from_str(&content)?;
                 Schedule { tasks }
             }
         };
@@ -60,33 +115,43 @@ impl Schedule {
     /// Create a schedule with default tasks
     pub fn with_defaults() -> Self {
         Self {
-            tasks: tasks::default_tasks(),
+            tasks: tasks::default_tasks().into_iter().map(Into::into).collect(),
         }
     }
 
     /// Find a task by id
-    pub fn find_task(&self, id: &str) -> Option<&ScheduledTask> {
-        self.tasks.iter().find(|t| t.id == id)
+    pub fn find_task(&self, id: &str) -> Option<&ScheduleEntry> {
+        self.tasks.iter().find(|t| t.task.id == id)
     }
 
     /// Find a task by id (mutable)
-    pub fn find_task_mut(&mut self, id: &str) -> Option<&mut ScheduledTask> {
-        self.tasks.iter_mut().find(|t| t.id == id)
+    pub fn find_task_mut(&mut self, id: &str) -> Option<&mut ScheduleEntry> {
+        self.tasks.iter_mut().find(|t| t.task.id == id)
     }
 
-    /// Add a task (replaces if same id exists)
-    pub fn add_task(&mut self, task: ScheduledTask) {
-        if let Some(existing) = self.find_task_mut(&task.id) {
-            *existing = task;
+    /// Add a task (replaces if same id exists).
+    ///
+    /// A replacement that carries no model override inherits the one it
+    /// replaces. The override is operator policy about *how* a task runs;
+    /// the definition is content, and the entity rewrites its own content
+    /// via `[SCHEDULE:]`. Dropping the override on rewrite would silently
+    /// move a task back onto the model it was moved off.
+    pub fn add_task(&mut self, task: impl Into<ScheduleEntry>) {
+        let mut entry = task.into();
+        if let Some(existing) = self.find_task_mut(&entry.task.id) {
+            if entry.model.is_none() {
+                entry.model.clone_from(&existing.model);
+            }
+            *existing = entry;
         } else {
-            self.tasks.push(task);
+            self.tasks.push(entry);
         }
     }
 
     /// Remove a task by id, returns true if found
     pub fn remove_task(&mut self, id: &str) -> bool {
         let len_before = self.tasks.len();
-        self.tasks.retain(|t| t.id != id);
+        self.tasks.retain(|t| t.task.id != id);
         self.tasks.len() < len_before
     }
 }
@@ -111,8 +176,12 @@ pub async fn start(
     })?;
 
     let tasks = schedule.read().await;
-    let enabled_tasks: Vec<ScheduledTask> =
-        tasks.tasks.iter().filter(|t| t.enabled).cloned().collect();
+    let enabled_tasks: Vec<ScheduleEntry> = tasks
+        .tasks
+        .iter()
+        .filter(|t| t.task.enabled)
+        .cloned()
+        .collect();
     drop(tasks);
 
     tracing::info!(
@@ -128,14 +197,14 @@ pub async fn start(
     let health: liveness::SharedTaskHealth =
         Arc::new(RwLock::new(health::TaskHealthStore::load(&state.root_dir)));
 
-    for task in enabled_tasks {
+    for entry in enabled_tasks {
         let state = Arc::clone(&state);
         let schedule = Arc::clone(&schedule);
         let queue = Arc::clone(&intent_queue);
         let task_health = Arc::clone(&health);
 
         let handle = tokio::spawn(async move {
-            runner::run_task_loop(task, state, schedule, queue, task_health, tz).await;
+            runner::run_task_loop(entry, state, schedule, queue, task_health, tz).await;
         });
 
         handles.push(handle);
@@ -191,6 +260,176 @@ pub fn normalize_cron(expr: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    /// Two tasks, one pinned to a model and one not — the shape an operator
+    /// actually ends up with.
+    const SCHEDULE_JSON: &str = r#"{
+      "tasks": [
+        {
+          "id": "research-session",
+          "name": "Research Session",
+          "cron": "0 0 10 * * *",
+          "channel": "system",
+          "prompt": "Go deep.",
+          "model": "claude-opus-4-8"
+        },
+        {
+          "id": "night-reflection",
+          "name": "Night Reflection",
+          "cron": "0 30 23 * * *",
+          "channel": "system",
+          "prompt": "Look back on today."
+        }
+      ]
+    }"#;
+
+    fn write_schedule(dir: &TempDir, json: &str) {
+        std::fs::write(dir.path().join("schedule.json"), json).unwrap();
+    }
+
+    fn entry(id: &str, model: Option<&str>) -> ScheduleEntry {
+        ScheduleEntry {
+            task: ScheduledTask {
+                id: id.to_string(),
+                name: id.to_string(),
+                cron: "0 0 10 * * *".to_string(),
+                channel: "system".to_string(),
+                prompt: "Do it.".to_string(),
+                output_routing: OutputRouting::Silent,
+                enabled: true,
+                created_by: TaskCreator::System,
+                evaluator: None,
+            },
+            model: model.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn model_override_parses_alongside_the_task_definition() {
+        let schedule: Schedule = serde_json::from_str(SCHEDULE_JSON).unwrap();
+        let pinned = schedule.find_task("research-session").unwrap();
+        assert_eq!(pinned.model_override(), Some("claude-opus-4-8"));
+        assert_eq!(pinned.task.cron, "0 0 10 * * *");
+        assert_eq!(schedule.find_task("night-reflection").unwrap().model, None);
+    }
+
+    /// The running process rewrites schedule.json (dynamic `[SCHEDULE:]`
+    /// tasks, enable/disable). The override has to come back out of that
+    /// rewrite, and the task that never had one must not grow a null.
+    #[test]
+    fn override_survives_a_load_save_load_cycle() {
+        let dir = TempDir::new().unwrap();
+        write_schedule(&dir, SCHEDULE_JSON);
+
+        let loaded = Schedule::load(dir.path()).unwrap();
+        loaded.save(dir.path()).unwrap();
+
+        let written = std::fs::read_to_string(dir.path().join("schedule.json")).unwrap();
+        assert_eq!(
+            written.matches("\"model\"").count(),
+            1,
+            "only the pinned task should carry a model key:\n{written}"
+        );
+
+        let reloaded = Schedule::load(dir.path()).unwrap();
+        assert_eq!(
+            reloaded
+                .find_task("research-session")
+                .unwrap()
+                .model_override(),
+            Some("claude-opus-4-8")
+        );
+        assert_eq!(reloaded.find_task("night-reflection").unwrap().model, None);
+    }
+
+    /// A bare `[...]` schedule.json is still accepted, overrides included.
+    #[test]
+    fn bare_array_schedule_keeps_overrides() {
+        let dir = TempDir::new().unwrap();
+        write_schedule(
+            &dir,
+            r#"[{"id":"t","name":"T","cron":"0 0 10 * * *","channel":"system","prompt":"p","model":"m"}]"#,
+        );
+        let schedule = Schedule::load(dir.path()).unwrap();
+        assert_eq!(schedule.find_task("t").unwrap().model_override(), Some("m"));
+    }
+
+    /// The entity rewrites its own tasks via `[SCHEDULE:]`. Losing the
+    /// override there would silently move a task back onto the model it was
+    /// deliberately moved off.
+    #[test]
+    fn replacing_a_task_inherits_the_override_it_replaces() {
+        let mut schedule = Schedule {
+            tasks: vec![entry("research-session", Some("claude-opus-4-8"))],
+        };
+
+        let mut rewritten = entry("research-session", None);
+        rewritten.task.prompt = "New prompt.".to_string();
+        schedule.add_task(rewritten);
+
+        let stored = schedule.find_task("research-session").unwrap();
+        assert_eq!(stored.model_override(), Some("claude-opus-4-8"));
+        assert_eq!(stored.task.prompt, "New prompt.");
+        assert_eq!(schedule.tasks.len(), 1);
+    }
+
+    #[test]
+    fn an_explicit_override_replaces_the_previous_one() {
+        let mut schedule = Schedule {
+            tasks: vec![entry("t", Some("old-model"))],
+        };
+        schedule.add_task(entry("t", Some("new-model")));
+        assert_eq!(
+            schedule.find_task("t").unwrap().model_override(),
+            Some("new-model")
+        );
+    }
+
+    #[test]
+    fn plain_scheduled_tasks_still_add_without_an_override() {
+        let mut schedule = Schedule { tasks: Vec::new() };
+        schedule.add_task(entry("t", None).task);
+        assert_eq!(schedule.find_task("t").unwrap().model, None);
+    }
+
+    #[test]
+    fn effective_model_prefers_the_task_over_the_config_default() {
+        assert_eq!(
+            entry("t", Some("claude-opus-4-8")).effective_model("fable-5"),
+            "claude-opus-4-8"
+        );
+        assert_eq!(entry("t", None).effective_model("fable-5"), "fable-5");
+    }
+
+    /// An empty or whitespace-only `model` is a typo, not a request for a
+    /// nameless model — it must not reach the provider factory.
+    #[test]
+    fn blank_override_falls_back_to_the_config_default() {
+        assert_eq!(entry("t", Some("")).effective_model("fable-5"), "fable-5");
+        assert_eq!(
+            entry("t", Some("   ")).effective_model("fable-5"),
+            "fable-5"
+        );
+        assert_eq!(entry("t", Some("   ")).model_override(), None);
+    }
+
+    /// Surrounding whitespace is trimmed rather than passed through to the CLI.
+    #[test]
+    fn override_is_trimmed() {
+        assert_eq!(
+            entry("t", Some("  claude-opus-4-8 ")).effective_model("fable-5"),
+            "claude-opus-4-8"
+        );
+    }
+
+    #[test]
+    fn defaults_carry_no_overrides() {
+        assert!(Schedule::with_defaults()
+            .tasks
+            .iter()
+            .all(|t| t.model.is_none()));
+    }
 
     #[test]
     fn normalize_sunday_zero_to_seven() {

--- a/src/scheduler/output.rs
+++ b/src/scheduler/output.rs
@@ -159,44 +159,35 @@ pub async fn route_call(content: &str, config: &Config, task_name: &str) {
     }
 }
 
-/// Send a provider error notification via the share webhook.
-/// Called directly on LLM failure — does not go through the intent system
-/// because the provider is likely down.
-pub async fn route_error(error: &str, error_kind: &str, task_name: &str, config: &Config) {
-    let webhook_url = match &config.scheduler.output.share_webhook {
-        Some(url) if !url.is_empty() => url,
-        _ => {
-            tracing::warn!(
-                "[ERROR] Provider failure in '{}' ({}) but no webhook configured: {}",
-                task_name,
-                error_kind,
-                error
-            );
+/// Deliver one `[task-error]` diagnostic to `webhook`.
+///
+/// Deliberately dumber than [`deliver_liveness_alert`]: a diagnostic that
+/// misses is gone, not queued. It reports one moment in time, and the moment
+/// has a successor a cycle later; the alarm is what must never be lost.
+///
+/// Failure is logged and swallowed — the diagnostics path can never take down
+/// the task it is reporting on. The message body has already been rendered
+/// and logged in full by [`super::diagnostics`], so nothing is lost that the
+/// journal does not already hold.
+pub async fn deliver_diagnostic(content: &str, webhook: &str) {
+    let client = match reqwest::Client::builder().timeout(WEBHOOK_TIMEOUT).build() {
+        Ok(client) => client,
+        Err(e) => {
+            tracing::error!(error = %e, "Diagnostics client build failed");
             return;
         }
     };
-
-    let content = format!(
-        "\u{26a0}\u{fe0f} **Provider Error** in `{}`\n**Type:** {}\n**Error:** {}",
-        task_name, error_kind, error
-    );
-
-    let client = reqwest::Client::new();
     let body = serde_json::json!({ "content": content });
 
-    match client.post(webhook_url).json(&body).send().await {
+    match client.post(webhook).json(&body).send().await {
         Ok(res) if res.status().is_success() => {
-            tracing::info!("[ERROR] notification delivered for task '{}'", task_name);
+            tracing::debug!("Task diagnostic delivered");
         }
         Ok(res) => {
-            tracing::warn!(
-                "[ERROR] webhook returned {}: {}",
-                res.status(),
-                res.text().await.unwrap_or_default()
-            );
+            tracing::warn!(status = %res.status(), "Diagnostics webhook rejected the message");
         }
         Err(e) => {
-            tracing::error!("[ERROR] webhook failed: {}", e);
+            tracing::warn!(error = %e, "Diagnostics webhook failed");
         }
     }
 }
@@ -329,6 +320,14 @@ mod tests {
             result.is_err(),
             "expected transport failure, got {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn diagnostic_delivery_failure_is_swallowed() {
+        // Port 1 on loopback refuses instantly. Unlike an alert, a diagnostic
+        // is not retried and must never surface an error into the task loop —
+        // the journal already holds the full text.
+        deliver_diagnostic("[task-error] t (t) — failure #1", "http://127.0.0.1:1/hook").await;
     }
 
     #[test]

--- a/src/scheduler/runner.rs
+++ b/src/scheduler/runner.rs
@@ -5,12 +5,13 @@ use chrono::Utc;
 use cron::Schedule as CronSchedule;
 use tokio::sync::RwLock;
 
+use super::diagnostics;
 use super::evaluator::{resolve_docs_dir, resolve_task_evaluator, EvalDecision, SchedulerState};
 use super::executor::{self, ExecutionConfig};
 use super::intent::{self, IntentQueue, IntentSource};
 use super::liveness::{self, SharedTaskHealth, TaskOutcome};
 use super::output;
-use super::{Schedule, ScheduledTask};
+use super::{Schedule, ScheduleEntry, ScheduledTask};
 use crate::events::EntityEvent;
 use crate::interaction::{InteractionMetadata, InteractionRecord};
 use crate::provider_status;
@@ -19,13 +20,14 @@ use crate::server::AppState;
 
 /// Run a single task in a loop: calculate next fire time → sleep → execute → repeat.
 pub async fn run_task_loop(
-    task: ScheduledTask,
+    entry: ScheduleEntry,
     state: Arc<AppState>,
     schedule: Arc<RwLock<Schedule>>,
     intent_queue: Arc<RwLock<IntentQueue>>,
     health: SharedTaskHealth,
     tz: chrono_tz::Tz,
 ) {
+    let task = &entry.task;
     let normalized_cron = super::normalize_cron(&task.cron);
     let cron_expr = match CronSchedule::from_str(&normalized_cron) {
         Ok(c) => c,
@@ -35,7 +37,12 @@ pub async fn run_task_loop(
         }
     };
 
-    tracing::info!("Scheduled task '{}' ({})", task.name, task.cron);
+    tracing::info!(
+        model = %entry.effective_model(&state.config.llm.model),
+        "Scheduled task '{}' ({})",
+        task.name,
+        task.cron
+    );
 
     // Use cached root_dir from AppState (avoids re-walking filesystem every task execution)
     let root_dir = state.root_dir.clone();
@@ -67,7 +74,7 @@ pub async fn run_task_loop(
         {
             let sched = schedule.read().await;
             if let Some(t) = sched.find_task(&task.id) {
-                if !t.enabled {
+                if !t.task.enabled {
                     tracing::info!("Task '{}' disabled, stopping loop", task.id);
                     return;
                 }
@@ -115,16 +122,27 @@ pub async fn run_task_loop(
             }
         }
 
-        tracing::info!("Executing scheduled task: {}", task.name);
+        tracing::info!(
+            model = %entry.effective_model(&state.config.llm.model),
+            "Executing scheduled task: {}",
+            task.name
+        );
 
         // Check for built-in deterministic handlers first
-        if run_builtin_handler(&task, &state, &root_dir).await {
+        if run_builtin_handler(task, &state, &root_dir).await {
             liveness::record_outcome(&health, &state, &task.id, &task.name, TaskOutcome::Success)
                 .await;
             continue;
         }
 
-        let outcome = execute_task(&task, &state, &schedule, &intent_queue, &mut eval_state).await;
+        let outcome = execute_task(&entry, &state, &schedule, &intent_queue, &mut eval_state).await;
+        // Diagnostics before the outcome is recorded: the store must still
+        // describe the previous cycle for "is this failure news?" to mean
+        // anything. Every failure path converges here, so a failure that never
+        // reached the provider is reported like any other.
+        if let TaskOutcome::Failure(ref error) = outcome {
+            diagnostics::report_failure(&health, &state, &entry, error).await;
+        }
         liveness::record_outcome(&health, &state, &task.id, &task.name, outcome).await;
     }
 }
@@ -172,14 +190,27 @@ async fn run_builtin_handler(
 /// Returns what the liveness alarm should record. Execution semantics are
 /// unchanged — the outcome is an observation, not a control signal.
 async fn execute_task(
-    task: &ScheduledTask,
+    entry: &ScheduleEntry,
     state: &Arc<AppState>,
     schedule: &Arc<RwLock<Schedule>>,
     intent_queue: &Arc<RwLock<IntentQueue>>,
     eval_state: &mut SchedulerState,
 ) -> TaskOutcome {
+    let task = &entry.task;
     // Use cached root_dir from AppState
     let root_dir = state.root_dir.clone();
+
+    // A model override means a provider of its own; without one this is the
+    // shared provider, byte for byte the previous behaviour.
+    let overridden = match resolve_provider_override(entry, state) {
+        Ok(provider) => provider,
+        Err(failure) => return failure,
+    };
+    let provider: &dyn pulse_system_types::llm::LmProvider = match overridden {
+        Some(ref boxed) => boxed.as_ref(),
+        None => state.provider.as_ref(),
+    };
+    let model = entry.effective_model(&state.config.llm.model);
 
     // Phase 5: Use minimal task system prompt (identity only, no MEMORY.md
     // or monitoring data). This keeps the task context small and focused,
@@ -254,7 +285,7 @@ async fn execute_task(
         match crate::task_context::scope(
             Some(task.id.clone()),
             executor::execute_with_tools(
-                state.provider.as_ref(),
+                provider,
                 &system_prompt,
                 &user_message,
                 &state.tools,
@@ -295,8 +326,7 @@ async fn execute_task(
             }),
         }];
 
-        match state
-            .provider
+        match provider
             .invoke(&system_prompt, &messages, state.config.llm.max_tokens, None)
             .await
         {
@@ -362,8 +392,10 @@ async fn execute_task(
         String::new()
     };
     tracing::info!(
-        "Task '{}' completed ({} tokens in, {} tokens out{})",
+        model = %model,
+        "Task '{}' completed on {} ({} tokens in, {} tokens out{})",
         task.id,
+        model,
         input_tokens,
         output_tokens,
         tool_info,
@@ -654,7 +686,40 @@ async fn execute_task(
     TaskOutcome::Success
 }
 
-/// Handle a provider error: classify, update status, emit event, send notification.
+/// Build this task's own provider, if it overrides `[llm] model`.
+///
+/// `Ok(None)` means "use the shared provider" — the unconfigured, unchanged
+/// path. An override that cannot be built fails the task rather than quietly
+/// running the default model: the reason to pin a task to a model is that the
+/// other model *refuses* it, and a refusal returns as a normal, successful
+/// response. A loud failure is recoverable; a silent wrong model is not.
+fn resolve_provider_override(
+    entry: &ScheduleEntry,
+    state: &Arc<AppState>,
+) -> Result<Option<Box<dyn pulse_system_types::llm::LmProvider>>, TaskOutcome> {
+    let Some(model) = entry.model_override() else {
+        return Ok(None);
+    };
+    match crate::providers::create_provider_with_model(&state.config, model) {
+        Ok(provider) => Ok(Some(provider)),
+        Err(e) => {
+            let message = format!("model override '{model}' could not be applied: {e}");
+            tracing::error!(
+                task_id = %entry.task.id,
+                model,
+                "Refusing to run task on the default model: {}",
+                message
+            );
+            Err(TaskOutcome::Failure(message))
+        }
+    }
+}
+
+/// Handle a provider error: classify, update status, emit event.
+///
+/// The operator-facing notification is not sent here — every failure path,
+/// including the ones that never reach the provider, is reported once from
+/// [`run_task_loop`] via [`diagnostics::report_failure`].
 async fn handle_provider_error(state: &Arc<AppState>, task_id: &str, error_msg: &str) {
     let kind = provider_status::classify_error(error_msg);
     let kind_str = kind.to_string();
@@ -668,14 +733,9 @@ async fn handle_provider_error(state: &Arc<AppState>, task_id: &str, error_msg: 
     // Emit event
     state.event_bus.emit(EntityEvent::ProviderError {
         error: error_msg.to_string(),
-        error_kind: kind_str.clone(),
+        error_kind: kind_str,
         task_id: task_id.to_string(),
     });
-
-    // Send direct webhook notification (bypass intent system — provider is down)
-    if state.config.autonomy.events.provider_error {
-        output::route_error(error_msg, &kind_str, task_id, &state.config).await;
-    }
 }
 
 /// Route parsed output markers to their respective handlers.

--- a/src/tui/tabs/entity.rs
+++ b/src/tui/tabs/entity.rs
@@ -109,12 +109,12 @@ impl EntityTab {
 
             // Schedule
             let (schedule_summary, schedule_tasks) = if let Ok(schedule) = Schedule::load(&root) {
-                let enabled = schedule.tasks.iter().filter(|t| t.enabled).count();
+                let enabled = schedule.tasks.iter().filter(|t| t.task.enabled).count();
                 let total = schedule.tasks.len();
                 let task_names: Vec<(String, bool)> = schedule
                     .tasks
                     .iter()
-                    .map(|t| (t.name.clone(), t.enabled))
+                    .map(|t| (t.task.name.clone(), t.task.enabled))
                     .collect();
                 let summary = ScheduleSummary {
                     enabled,
@@ -125,12 +125,12 @@ impl EntityTab {
                     .tasks
                     .iter()
                     .map(|t| ScheduleTaskEntry {
-                        id: t.id.clone(),
-                        name: t.name.clone(),
-                        cron_display: cron_to_human(&t.cron),
-                        enabled: t.enabled,
-                        created_by: t.created_by.clone(),
-                        prompt: t.prompt.clone(),
+                        id: t.task.id.clone(),
+                        name: t.task.name.clone(),
+                        cron_display: cron_to_human(&t.task.cron),
+                        enabled: t.task.enabled,
+                        created_by: t.task.created_by.clone(),
+                        prompt: t.task.prompt.clone(),
                     })
                     .collect();
                 (Some(summary), tasks)
@@ -175,8 +175,8 @@ impl EntityTab {
             return;
         };
         if let Ok(mut schedule) = Schedule::load(root) {
-            if let Some(st) = schedule.find_task_mut(&task.id) {
-                st.enabled = task.enabled;
+            if let Some(entry) = schedule.find_task_mut(&task.id) {
+                entry.task.enabled = task.enabled;
             }
             let _ = schedule.save(root);
         }


### PR DESCRIPTION
## Diagnostics

Every task failure posted a bold warning to the **same webhook** as SHARE output and the liveness ALERT, with no dedupe and no backoff. That is what trained us to stop reading the channel — which is how a seven-week outage hid in plain sight, and how a task failing half its cycles yesterday was spotted by eye rather than by the system. An alarm only works if nothing else in the channel looks like an alarm.

They are **not deleted** — they carry the only full error text at the moment of failure, and they are a stateless fallback if the alarm itself is misconfigured, which is precisely the failure mode that cost seven weeks. Instead they are posted only when the failure is *news*: the first of a streak, or a change in the error text. Repeats are journal-only. A 500-cycle streak now posts once. No new state — it reads consecutive_failures and last_error from the store the alarm already keeps.

Destination is an optional diagnostics_webhook, falling back to the share webhook in plain framing rather than going silent — silence-by-default would delete the only full error text for anyone who upgrades and sets nothing.

**Two latent bugs fixed on the way:** the webhook client had no timeout, so a hung endpoint blocked the task loop indefinitely; and error text was unbounded, which Discord rejects past 2000 chars. The trigger also widened from provider-error to task-failure — a system-prompt-build failure previously told nobody at all.

## Per-task model

Echo has been pinned to opus-4-8 globally since June because fable-5 refuses the autonomous research tasks that read its oversight-failure journal. Chat never needed that workaround. A scheduled task may now carry its own model, so chat can return to fable-5 while those tasks stay on opus.

ScheduledTask lives in an external crate, so the field rides a flattened ScheduleEntry — JSON shape unchanged, and a schedule with no overrides serialises identically. **Verified against the real binary through three load/save cycles**, since the running process rewrites schedule.json and a unit test would not have caught a drop.

add_task inherits an existing override when a replacement carries none — otherwise the entity rescheduling its own task would silently move it back onto the model that refuses it. A failed per-task provider fails the task **loudly** rather than falling back: a refusal returns as a successful response, so a silently wrong model is unrecoverable where a loud failure is not.

New CLI: pulse-null schedule model ID MODEL, and --clear.

673 tests, clippy clean.