### PR TITLE
feat(PN-80): coordinator — leases, fail-open faculties, isolation mode, farming (stages 0-3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,11 @@ Open an [issue](https://github.com/dnacenta/pulse-null/issues). Use a clear titl
 ## Making changes
 
 1. Fork the repo
-2. Create a branch from `development` (see naming below)
+2. Create a branch from `main` (see naming below)
 3. Make your changes
-4. Open a PR targeting `development`
+4. Open a PR targeting `main`
 
-`main` is protected. All changes go through `development` first.
+`main` is protected — all changes land through a PR.
 
 ## Branch naming
 
@@ -76,4 +76,4 @@ docs(#3): expand configuration reference
 
 ## Release workflow
 
-Releases go from `development` to `main` via merge commit (not squash). Feature PRs to `development` use squash merge.
+Feature PRs target `main` and use squash merge.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,7 +2631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -3909,6 +3924,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3984,6 +4018,7 @@ dependencies = [
  "globset",
  "libc",
  "owo-colors",
+ "proptest",
  "pulse-system-types 0.6.3",
  "ratatui",
  "recall-echo",
@@ -4043,6 +4078,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -4214,6 +4255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4278,7 +4328,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -4801,6 +4851,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5691,7 +5753,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -6208,6 +6270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6422,6 +6490,15 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ discord-text = ["dep:discord-echo"]
 all-plugins = ["voice", "discord-text"]
 
 [dev-dependencies]
+proptest = "1"
 tempfile = "3"
 tower = { version = "0.5.3", features = ["util"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pulse-null"
 version = "0.30.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.89"
 license = "AGPL-3.0-only"
 description = "One binary. One command. Your own AI entity."
 repository = "https://github.com/dnacenta/pulse-null"

--- a/src/claude_code_provider.rs
+++ b/src/claude_code_provider.rs
@@ -45,6 +45,11 @@ use crate::streaming::{self, StreamResult, StreamingProvider};
 pub struct ClaudeCodeProvider {
     model: String,
     claude_bin: String,
+    /// Entity root consulted per-invocation for the isolation marker. While
+    /// isolated, the spawned CLI is restricted to read-only tools — the
+    /// in-process tool registry swap cannot reach a subprocess that brings
+    /// its own tools (and normally runs with permission prompts disabled).
+    isolation_root: Option<PathBuf>,
 }
 
 impl ClaudeCodeProvider {
@@ -52,8 +57,51 @@ impl ClaudeCodeProvider {
         let claude_bin = claude_bin
             .or_else(|| std::env::var("CLAUDE_BIN").ok())
             .unwrap_or_else(|| "claude".into());
-        Self { model, claude_bin }
+        Self {
+            model,
+            claude_bin,
+            isolation_root: None,
+        }
     }
+
+    /// Enable per-invocation isolation awareness (coordinator spec, Stage 2).
+    #[must_use]
+    pub fn with_isolation_root(mut self, root: PathBuf) -> Self {
+        self.isolation_root = Some(root);
+        self
+    }
+}
+
+/// Tools denied to the CLI subprocess while isolated: everything that writes,
+/// executes, or leaves the box. Camel-case flag per the Claude Code CLI. If a
+/// future CLI rejects the flag the invocation fails — closed, not open.
+const ISOLATION_DISALLOWED_TOOLS: &str =
+    "Write,Edit,MultiEdit,NotebookEdit,Bash,WebFetch,WebSearch,Task";
+
+/// Argv for one CLI invocation, factored out so tests can pin the
+/// isolation-restricted shape without spawning anything.
+fn invoke_args(
+    model: &str,
+    system_prompt_file: &std::path::Path,
+    restricted: bool,
+) -> Vec<std::ffi::OsString> {
+    let mut args: Vec<std::ffi::OsString> = vec![
+        "-p".into(),
+        "-".into(),
+        "--model".into(),
+        model.into(),
+        "--output-format".into(),
+        "json".into(),
+        "--system-prompt-file".into(),
+        system_prompt_file.into(),
+        "--no-session-persistence".into(),
+        "--dangerously-skip-permissions".into(),
+    ];
+    if restricted {
+        args.push("--disallowedTools".into());
+        args.push(ISOLATION_DISALLOWED_TOOLS.into());
+    }
+    args
 }
 
 /// A private on-disk copy of the system prompt for a single CLI invocation.
@@ -220,6 +268,10 @@ impl LmProvider for ClaudeCodeProvider {
         let messages = messages.to_vec();
         let model = self.model.clone();
         let claude_bin = self.claude_bin.clone();
+        let restricted = self
+            .isolation_root
+            .as_deref()
+            .is_some_and(crate::server::isolation::is_active);
 
         Box::pin(async move {
             let prompt = serialize_messages(&messages);
@@ -230,16 +282,7 @@ impl LmProvider for ClaudeCodeProvider {
             let system_prompt_file = SystemPromptFile::create(&system_prompt)?;
 
             let mut cmd = tokio::process::Command::new(&claude_bin);
-            cmd.arg("-p")
-                .arg("-")
-                .arg("--model")
-                .arg(&model)
-                .arg("--output-format")
-                .arg("json")
-                .arg("--system-prompt-file")
-                .arg(system_prompt_file.path())
-                .arg("--no-session-persistence")
-                .arg("--dangerously-skip-permissions")
+            cmd.args(invoke_args(&model, system_prompt_file.path(), restricted))
                 .env_remove("CLAUDECODE")
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
@@ -432,6 +475,36 @@ fn parse_response(
 
 fn truncate(s: &str, max: usize) -> &str {
     crate::utils::safe_truncate(s, max)
+}
+
+#[cfg(test)]
+mod isolation_argv_tests {
+    use super::*;
+
+    #[test]
+    fn isolated_argv_denies_writing_tools() {
+        let args = invoke_args("m", std::path::Path::new("/tmp/x"), true);
+        let strs: Vec<String> = args
+            .iter()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let pos = strs
+            .iter()
+            .position(|a| a == "--disallowedTools")
+            .expect("isolated argv must carry --disallowedTools");
+        let denied = &strs[pos + 1];
+        for tool in ["Write", "Edit", "Bash", "WebFetch", "WebSearch", "Task"] {
+            assert!(denied.contains(tool), "{tool} missing from deny list");
+        }
+    }
+
+    #[test]
+    fn normal_argv_is_unrestricted() {
+        let args = invoke_args("m", std::path::Path::new("/tmp/x"), false);
+        assert!(!args
+            .iter()
+            .any(|a| a.to_string_lossy().contains("disallowedTools")));
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/intent.rs
+++ b/src/cli/intent.rs
@@ -57,7 +57,6 @@ pub async fn add(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
     let root_dir = config.root_dir()?;
-    let mut queue = IntentQueue::load(&root_dir);
 
     let priority = match priority.as_str() {
         "low" => IntentPriority::Low,
@@ -81,8 +80,9 @@ pub async fn add(
     };
 
     let max_size = config.autonomy.max_queue_size;
-    if queue.push(intent, max_size) {
-        queue.save()?;
+    let mut pushed = false;
+    IntentQueue::save_delta(&root_dir, |q| pushed = q.push(intent, max_size))?;
+    if pushed {
         println!(
             "  Intent '{}' added (id: {})",
             style(&description).cyan(),
@@ -98,10 +98,10 @@ pub async fn add(
 pub async fn remove(id: String) -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
     let root_dir = config.root_dir()?;
-    let mut queue = IntentQueue::load(&root_dir);
 
-    if queue.remove(&id) {
-        queue.save()?;
+    let mut removed = false;
+    IntentQueue::save_delta(&root_dir, |q| removed = q.remove(&id))?;
+    if removed {
         println!("  Intent '{}' removed.", style(&id).cyan());
     } else {
         println!("  Intent '{}' not found.", style(&id).red());
@@ -113,11 +113,12 @@ pub async fn remove(id: String) -> Result<(), Box<dyn std::error::Error>> {
 pub async fn clear() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
     let root_dir = config.root_dir()?;
-    let mut queue = IntentQueue::load(&root_dir);
 
-    let count = queue.len();
-    queue.clear();
-    queue.save()?;
+    let mut count = 0;
+    IntentQueue::save_delta(&root_dir, |q| {
+        count = q.len();
+        q.clear();
+    })?;
 
     println!("  Cleared {} intent(s).", count);
     Ok(())

--- a/src/cli/isolate.rs
+++ b/src/cli/isolate.rs
@@ -1,0 +1,63 @@
+//! `pulse-null isolate` — enter/exit/inspect Isolation Mode from the shell.
+//!
+//! Writes the marker file directly, so it works with the server down, the
+//! coordinator wedged, or anything in between (coordinator spec, decision 5:
+//! the trigger must not route through the thing that might be wedged). A
+//! running server notices the marker on the next request — no restart needed.
+
+use console::style;
+
+use crate::config::Config;
+use crate::server::isolation;
+
+pub async fn on(reason: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+    let root_dir = config.root_dir()?;
+    let already = isolation::is_active(&root_dir);
+    let marker = isolation::enter(&root_dir, "cli", reason)?;
+    if already {
+        println!(
+            "  {} already active (entered {} by {}).",
+            style("ISOLATION").red().bold(),
+            marker.entered_at.format("%Y-%m-%d %H:%M:%SZ"),
+            marker.by
+        );
+    } else {
+        println!(
+            "  {} entered. Minimal core only — the running entity sheds the \
+             coordinator, scheduler, and all state writes at its next turn.",
+            style("ISOLATION").red().bold()
+        );
+        println!("  Exit with: pulse-null isolate off  (or /resume over chat)");
+    }
+    Ok(())
+}
+
+pub async fn off() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+    let root_dir = config.root_dir()?;
+    if isolation::exit(&root_dir)? {
+        println!("  {}", style(isolation::BACK_TO_NORMAL).green());
+    } else {
+        println!("  Not in isolation mode — nothing to resume.");
+    }
+    Ok(())
+}
+
+pub async fn status() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+    let root_dir = config.root_dir()?;
+    match isolation::status(&root_dir) {
+        Some(marker) => {
+            println!(
+                "  {} active — entered {} by {}{}",
+                style("ISOLATION").red().bold(),
+                marker.entered_at.format("%Y-%m-%d %H:%M:%SZ"),
+                marker.by,
+                marker.reason.map(|r| format!(" ({r})")).unwrap_or_default()
+            );
+        }
+        None => println!("  Normal operation — not isolated."),
+    }
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod chat;
 pub mod down;
 pub mod init;
 pub mod intent;
+pub mod isolate;
 pub mod pipeline;
 pub mod plugin;
 pub mod praxis;

--- a/src/cli/schedule.rs
+++ b/src/cli/schedule.rs
@@ -17,7 +17,7 @@ fn model_line(entry: &ScheduleEntry, default_model: &str) -> String {
 pub async fn list() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
     let root_dir = config.root_dir()?;
-    let schedule = Schedule::load(&root_dir)?;
+    let schedule = Schedule::load_or_init(&root_dir)?;
 
     if schedule.tasks.is_empty() {
         println!("  No scheduled tasks.");
@@ -75,7 +75,7 @@ pub async fn add(
 
     let config = Config::load()?;
     let root_dir = config.root_dir()?;
-    let mut schedule = Schedule::load(&root_dir)?;
+    Schedule::load_or_init(&root_dir)?;
 
     let id = name
         .to_lowercase()
@@ -95,8 +95,7 @@ pub async fn add(
         evaluator: None,
     };
 
-    schedule.add_task(ScheduleEntry::from(task));
-    schedule.save(&root_dir)?;
+    Schedule::save_delta(&root_dir, |s| s.add_task(ScheduleEntry::from(task)))?;
 
     println!("  Task '{}' added (id: {})", style(&name).cyan(), id);
     Ok(())
@@ -105,10 +104,9 @@ pub async fn add(
 pub async fn remove(id: String) -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
     let root_dir = config.root_dir()?;
-    let mut schedule = Schedule::load(&root_dir)?;
-
-    if schedule.remove_task(&id) {
-        schedule.save(&root_dir)?;
+    let mut found = false;
+    Schedule::save_delta(&root_dir, |s| found = s.remove_task(&id))?;
+    if found {
         println!("  Task '{}' removed.", style(&id).cyan());
     } else {
         println!("  Task '{}' not found.", style(&id).red());
@@ -120,11 +118,14 @@ pub async fn remove(id: String) -> Result<(), Box<dyn std::error::Error>> {
 pub async fn enable(id: String) -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
     let root_dir = config.root_dir()?;
-    let mut schedule = Schedule::load(&root_dir)?;
-
-    if let Some(entry) = schedule.find_task_mut(&id) {
-        entry.task.enabled = true;
-        schedule.save(&root_dir)?;
+    let mut found = false;
+    Schedule::save_delta(&root_dir, |s| {
+        if let Some(entry) = s.find_task_mut(&id) {
+            entry.task.enabled = true;
+            found = true;
+        }
+    })?;
+    if found {
         println!("  Task '{}' enabled.", style(&id).green());
     } else {
         println!("  Task '{}' not found.", style(&id).red());
@@ -136,11 +137,14 @@ pub async fn enable(id: String) -> Result<(), Box<dyn std::error::Error>> {
 pub async fn disable(id: String) -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
     let root_dir = config.root_dir()?;
-    let mut schedule = Schedule::load(&root_dir)?;
-
-    if let Some(entry) = schedule.find_task_mut(&id) {
-        entry.task.enabled = false;
-        schedule.save(&root_dir)?;
+    let mut found = false;
+    Schedule::save_delta(&root_dir, |s| {
+        if let Some(entry) = s.find_task_mut(&id) {
+            entry.task.enabled = false;
+            found = true;
+        }
+    })?;
+    if found {
         println!("  Task '{}' disabled.", style(&id).yellow());
     } else {
         println!("  Task '{}' not found.", style(&id).red());
@@ -160,18 +164,20 @@ pub async fn set_model(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::load()?;
     let root_dir = config.root_dir()?;
-    let mut schedule = Schedule::load(&root_dir)?;
-
-    let Some(entry) = schedule.find_task_mut(&id) else {
-        println!("  Task '{}' not found.", style(&id).red());
-        return Ok(());
-    };
-
     let model = model
         .map(|m| m.trim().to_string())
         .filter(|m| !m.is_empty());
-    entry.model.clone_from(&model);
-    schedule.save(&root_dir)?;
+    let mut found = false;
+    Schedule::save_delta(&root_dir, |s| {
+        if let Some(entry) = s.find_task_mut(&id) {
+            entry.model.clone_from(&model);
+            found = true;
+        }
+    })?;
+    if !found {
+        println!("  Task '{}' not found.", style(&id).red());
+        return Ok(());
+    }
 
     match model {
         Some(model) => println!(
@@ -185,6 +191,6 @@ pub async fn set_model(
             style(&config.llm.model).cyan()
         ),
     }
-    println!("  Restart the entity for a running scheduler to pick this up.");
+    println!("  A running scheduler picks this up at the task's next fire.");
     Ok(())
 }

--- a/src/cli/up.rs
+++ b/src/cli/up.rs
@@ -97,7 +97,7 @@ async fn run_multi_entity(
                         config: entity.config,
                         port: booted.actual_port,
                         server_handle: booted.server_handle,
-                        scheduler_handles: booted.scheduler_handles,
+                        coordinator: booted.coordinator,
                         event_bus: booted.event_bus,
                         persist_coordinator: booted.persist_coordinator,
                     });

--- a/src/context/compact.rs
+++ b/src/context/compact.rs
@@ -926,6 +926,7 @@ mod tests {
             wal: crate::session_store::WalState::default(),
             health: crate::session_store::HealthCounters::default(),
             compaction: crate::session_store::CompactionMetrics::default(),
+            isolation_ephemeral_from: None,
         }
     }
 

--- a/src/coordinator/control.rs
+++ b/src/coordinator/control.rs
@@ -100,6 +100,16 @@ impl Coordinator {
         }
     }
 
+    /// Simulate a coordinator wedge/crash: the leadership loop dies without
+    /// releasing the lease or stopping anything. Fail-open tests use this to
+    /// prove the data plane doesn't care.
+    #[cfg(test)]
+    pub(crate) fn wedge_for_test(&self) {
+        if let Some(handle) = &self.handle {
+            handle.abort();
+        }
+    }
+
     /// Abort the scheduler tasks and release the lease. Bounded: gives the
     /// loop 10s to wind down before letting go.
     pub async fn shutdown(self) {

--- a/src/coordinator/control.rs
+++ b/src/coordinator/control.rs
@@ -45,6 +45,30 @@ const LEASE_TTL: Duration = Duration::from_secs(90);
 const RENEW_INTERVAL: Duration = Duration::from_secs(30);
 const RETRY_BACKOFF: Duration = Duration::from_secs(15);
 
+/// The process-wide lease table. One WAL lock per process, so every consumer
+/// (leadership loop, task loops, intent drain) shares this handle.
+pub type SharedLeases = Arc<tokio::sync::Mutex<DurableLeaseTable>>;
+
+/// Sanitize an arbitrary string into the lease id charset.
+pub(crate) fn lease_safe(input: &str) -> String {
+    let sanitized: String = input
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .take(64)
+        .collect();
+    if sanitized.is_empty() {
+        "unnamed".to_string()
+    } else {
+        sanitized
+    }
+}
+
 /// Handle to the coordinator's leadership loop.
 pub struct Coordinator {
     shutdown_tx: watch::Sender<bool>,
@@ -106,24 +130,8 @@ async fn wait_or_shutdown(shutdown_rx: &mut watch::Receiver<bool>, dur: Duration
 
 /// Lease holder id: entity name (sanitized to the lease id charset) + pid,
 /// so concurrent processes are distinguishable in the lease WAL.
-fn holder_id(entity_name: &str) -> String {
-    let sanitized: String = entity_name
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
-                c
-            } else {
-                '-'
-            }
-        })
-        .take(64)
-        .collect();
-    let base = if sanitized.is_empty() {
-        "entity".to_string()
-    } else {
-        sanitized
-    };
-    format!("{base}-{}", std::process::id())
+pub(crate) fn holder_id(entity_name: &str) -> String {
+    format!("{}-{}", lease_safe(entity_name), std::process::id())
 }
 
 async fn leadership_loop(
@@ -141,8 +149,9 @@ async fn leadership_loop(
         }
         // Opening takes the WAL's exclusive file lock — held for as long as
         // this table lives, so it spans tenures and re-acquire attempts.
-        let mut table = match DurableLeaseTable::open(&dir) {
-            Ok(t) => t,
+        // Shared: task loops and the intent drain claim their leases here too.
+        let leases: SharedLeases = match DurableLeaseTable::open(&dir) {
+            Ok(t) => Arc::new(tokio::sync::Mutex::new(t)),
             Err(e) => {
                 tracing::warn!(
                     "coordinator: lease table unavailable ({e}); retrying in {RETRY_BACKOFF:?}"
@@ -158,8 +167,13 @@ async fn leadership_loop(
             if *shutdown_rx.borrow() {
                 return;
             }
-            let lease = match table.acquire(CONTROL_PLANE_RESOURCE, &holder, LEASE_TTL, Utc::now())
-            {
+            let acquired = {
+                leases
+                    .lock()
+                    .await
+                    .acquire(CONTROL_PLANE_RESOURCE, &holder, LEASE_TTL, Utc::now())
+            };
+            let lease = match acquired {
                 Ok(lease) => lease,
                 Err(DurableError::Lease(LeaseError::Held {
                     holder_id,
@@ -194,6 +208,7 @@ async fn leadership_loop(
                 Arc::clone(&state),
                 Arc::clone(&schedule),
                 Arc::clone(&intent_queue),
+                Arc::clone(&leases),
             )
             .await
             {
@@ -206,13 +221,16 @@ async fn leadership_loop(
                         "coordinator: scheduler failed to start ({e}); \
                          releasing control plane — interactive faculties unaffected"
                     );
-                    let _ = table.release(CONTROL_PLANE_RESOURCE, &holder, Utc::now());
+                    let _ =
+                        leases
+                            .lock()
+                            .await
+                            .release(CONTROL_PLANE_RESOURCE, &holder, Utc::now());
                     return;
                 }
             };
 
-            let tenure_end =
-                renew_until_lost_or_shutdown(&mut table, &holder, &mut shutdown_rx).await;
+            let tenure_end = renew_until_lost_or_shutdown(&leases, &holder, &mut shutdown_rx).await;
             tracing::info!(
                 "coordinator: ending tenure, aborting {} scheduler task(s)",
                 handles.len()
@@ -223,7 +241,12 @@ async fn leadership_loop(
 
             match tenure_end {
                 TenureEnd::Shutdown => {
-                    if let Err(e) = table.release(CONTROL_PLANE_RESOURCE, &holder, Utc::now()) {
+                    if let Err(e) =
+                        leases
+                            .lock()
+                            .await
+                            .release(CONTROL_PLANE_RESOURCE, &holder, Utc::now())
+                    {
                         tracing::warn!("coordinator: lease release on shutdown failed: {e}");
                     }
                     return;
@@ -237,7 +260,7 @@ async fn leadership_loop(
 }
 
 async fn renew_until_lost_or_shutdown(
-    table: &mut DurableLeaseTable,
+    leases: &SharedLeases,
     holder: &str,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) -> TenureEnd {
@@ -245,7 +268,13 @@ async fn renew_until_lost_or_shutdown(
         if wait_or_shutdown(shutdown_rx, RENEW_INTERVAL).await {
             return TenureEnd::Shutdown;
         }
-        match table.renew(CONTROL_PLANE_RESOURCE, holder, LEASE_TTL, Utc::now()) {
+        let renewed = {
+            leases
+                .lock()
+                .await
+                .renew(CONTROL_PLANE_RESOURCE, holder, LEASE_TTL, Utc::now())
+        };
+        match renewed {
             Ok(_) => {}
             Err(e) => {
                 // Expired (we stalled past ttl), reclaimed by a successor,
@@ -270,6 +299,6 @@ mod tests {
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')));
         assert!(id.starts_with("Echo-Prime--v2--"));
         let empty = holder_id("");
-        assert!(empty.starts_with("entity-"));
+        assert!(empty.starts_with("unnamed-"));
     }
 }

--- a/src/coordinator/control.rs
+++ b/src/coordinator/control.rs
@@ -463,7 +463,9 @@ async fn sweep_stale_claims(leases: &SharedLeases, tenure_holder: &str) {
         .into_iter()
         .filter(|l| {
             l.holder_id != tenure_holder
-                && (l.resource_id.starts_with("task-") || l.resource_id.starts_with("intent-"))
+                && (l.resource_id.starts_with("task-")
+                    || l.resource_id.starts_with("intent-")
+                    || l.resource_id.starts_with("farm-"))
         })
         .collect();
     for lease in stale {

--- a/src/coordinator/control.rs
+++ b/src/coordinator/control.rs
@@ -84,6 +84,9 @@ pub(crate) fn lease_safe(input: &str) -> String {
 pub struct Coordinator {
     shutdown_tx: watch::Sender<bool>,
     handle: Option<JoinHandle<()>>,
+    /// For resetting the /health leadership flag when the loop dies without
+    /// running its own cleanup (wedge, drop).
+    app: Option<Arc<AppState>>,
     /// The current tenure's scheduler tasks. Owned here — not on the
     /// leadership loop's stack — so they can be aborted even if the loop
     /// itself dies abruptly (panic, abort, drop): a stale tenure must never
@@ -117,9 +120,11 @@ impl Coordinator {
             return Self {
                 shutdown_tx,
                 handle: None,
+                app: None,
                 scheduler_handles,
             };
         }
+        let app = Arc::clone(&state);
         let handle = tokio::spawn(leadership_loop(
             state,
             schedule,
@@ -130,6 +135,7 @@ impl Coordinator {
         Self {
             shutdown_tx,
             handle: Some(handle),
+            app: Some(app),
             scheduler_handles,
         }
     }
@@ -141,6 +147,11 @@ impl Coordinator {
     pub(crate) fn wedge_for_test(&self) {
         if let Some(handle) = &self.handle {
             handle.abort();
+        }
+        // The loop can no longer maintain the flag — don't let /health lie.
+        if let Some(app) = &self.app {
+            app.leadership
+                .store(false, std::sync::atomic::Ordering::Relaxed);
         }
     }
 
@@ -170,6 +181,10 @@ impl Drop for Coordinator {
             handle.abort();
         }
         abort_all(&self.scheduler_handles);
+        if let Some(app) = &self.app {
+            app.leadership
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+        }
     }
 }
 
@@ -345,6 +360,20 @@ async fn leadership_loop(
                 continue;
             }
 
+            // The marker may have appeared between the parking check and
+            // here (acquire + sweep + reconcile are disk work) — never start
+            // a scheduler into active isolation.
+            if crate::server::isolation::is_active(&state.root_dir) {
+                state
+                    .leadership
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                let _ = leases
+                    .lock()
+                    .await
+                    .release(CONTROL_PLANE_RESOURCE, &holder, Utc::now());
+                continue;
+            }
+
             let started = match scheduler::start(
                 Arc::clone(&state),
                 Arc::clone(&schedule),
@@ -471,7 +500,10 @@ async fn renew_until_lost_or_shutdown(
     root_dir: &std::path::Path,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) -> TenureEnd {
-    let mut since_renew = Duration::ZERO;
+    // Wall-clock deadline, not accumulated nominal sleeps: each iteration
+    // also pays stats/locks, and drift across many 2s polls could push a
+    // renewal past the ttl.
+    let mut last_renew = tokio::time::Instant::now();
     loop {
         if wait_or_shutdown(shutdown_rx, POLL_INTERVAL).await {
             return TenureEnd::Shutdown;
@@ -479,11 +511,10 @@ async fn renew_until_lost_or_shutdown(
         if crate::server::isolation::is_active(root_dir) {
             return TenureEnd::Isolated;
         }
-        since_renew += POLL_INTERVAL;
-        if since_renew < RENEW_INTERVAL {
+        if last_renew.elapsed() < RENEW_INTERVAL {
             continue;
         }
-        since_renew = Duration::ZERO;
+        last_renew = tokio::time::Instant::now();
         let renewed = {
             leases
                 .lock()

--- a/src/coordinator/control.rs
+++ b/src/coordinator/control.rs
@@ -49,6 +49,14 @@ const RETRY_BACKOFF: Duration = Duration::from_secs(15);
 /// (leadership loop, task loops, intent drain) shares this handle.
 pub type SharedLeases = Arc<tokio::sync::Mutex<DurableLeaseTable>>;
 
+/// A tenure's claim-taking identity: the shared lease table plus the
+/// tenure-scoped holder id every claim of this tenure is made under.
+#[derive(Clone)]
+pub struct TenureLeases {
+    pub leases: SharedLeases,
+    pub holder: String,
+}
+
 /// Sanitize an arbitrary string into the lease id charset.
 pub(crate) fn lease_safe(input: &str) -> String {
     let sanitized: String = input
@@ -73,6 +81,20 @@ pub(crate) fn lease_safe(input: &str) -> String {
 pub struct Coordinator {
     shutdown_tx: watch::Sender<bool>,
     handle: Option<JoinHandle<()>>,
+    /// The current tenure's scheduler tasks. Owned here — not on the
+    /// leadership loop's stack — so they can be aborted even if the loop
+    /// itself dies abruptly (panic, abort, drop): a stale tenure must never
+    /// keep acting.
+    scheduler_handles: SharedHandles,
+}
+
+type SharedHandles = Arc<std::sync::Mutex<Vec<JoinHandle<()>>>>;
+
+fn abort_all(handles: &SharedHandles) {
+    let mut guard = handles.lock().unwrap_or_else(|p| p.into_inner());
+    for handle in guard.drain(..) {
+        handle.abort();
+    }
 }
 
 impl Coordinator {
@@ -86,17 +108,26 @@ impl Coordinator {
         intent_queue: Arc<RwLock<IntentQueue>>,
     ) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let scheduler_handles: SharedHandles = Arc::new(std::sync::Mutex::new(Vec::new()));
         if !state.config.scheduler.enabled {
             tracing::info!("Scheduler disabled in config — coordinator not started");
             return Self {
                 shutdown_tx,
                 handle: None,
+                scheduler_handles,
             };
         }
-        let handle = tokio::spawn(leadership_loop(state, schedule, intent_queue, shutdown_rx));
+        let handle = tokio::spawn(leadership_loop(
+            state,
+            schedule,
+            intent_queue,
+            shutdown_rx,
+            Arc::clone(&scheduler_handles),
+        ));
         Self {
             shutdown_tx,
             handle: Some(handle),
+            scheduler_handles,
         }
     }
 
@@ -111,10 +142,11 @@ impl Coordinator {
     }
 
     /// Abort the scheduler tasks and release the lease. Bounded: gives the
-    /// loop 10s to wind down before letting go.
-    pub async fn shutdown(self) {
+    /// loop 10s to wind down before letting go. Scheduler handles are
+    /// aborted here too as a backstop — even if the loop is already dead.
+    pub async fn shutdown(mut self) {
         let _ = self.shutdown_tx.send(true);
-        if let Some(handle) = self.handle {
+        if let Some(handle) = self.handle.take() {
             if tokio::time::timeout(Duration::from_secs(10), handle)
                 .await
                 .is_err()
@@ -122,6 +154,19 @@ impl Coordinator {
                 tracing::warn!("coordinator: shutdown timed out after 10s");
             }
         }
+        abort_all(&self.scheduler_handles);
+    }
+}
+
+impl Drop for Coordinator {
+    /// Dropping the coordinator (registry overwrite, early boot error) must
+    /// not orphan a running scheduler. The watch sender's drop also resolves
+    /// `changed()` in the loop, which treats it as shutdown.
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+        abort_all(&self.scheduler_handles);
     }
 }
 
@@ -149,9 +194,15 @@ async fn leadership_loop(
     schedule: Arc<RwLock<Schedule>>,
     intent_queue: Arc<RwLock<IntentQueue>>,
     mut shutdown_rx: watch::Receiver<bool>,
+    scheduler_handles: SharedHandles,
 ) {
     let dir = state.root_dir.join("coordinator");
-    let holder = holder_id(&state.config.entity.name);
+    let holder_base = holder_id(&state.config.entity.name);
+    // Tenure-scoped holder ids: without the suffix, a predecessor tenure's
+    // leftover claim would be indistinguishable from ours, and neither the
+    // stale-claim sweep nor fenced completion could tell them apart.
+    let mut tenure: u64 = 0;
+    let mut failed_acquires: u32 = 0;
 
     'open: loop {
         if *shutdown_rx.borrow() {
@@ -177,6 +228,8 @@ async fn leadership_loop(
             if *shutdown_rx.borrow() {
                 return;
             }
+            tenure += 1;
+            let holder = format!("{holder_base}-t{tenure}");
             let acquired = {
                 leases
                     .lock()
@@ -192,27 +245,55 @@ async fn leadership_loop(
                 })) => {
                     // A crashed predecessor's lease runs out on its own; a
                     // live one keeps renewing. Either way: wait, retry.
-                    tracing::info!(
-                        "coordinator: control plane held by '{holder_id}' until {expires_at}; waiting"
-                    );
+                    failed_acquires += 1;
+                    if failed_acquires.is_multiple_of(8) {
+                        tracing::error!(
+                            "coordinator: control plane STILL held by '{holder_id}' after \
+                             {failed_acquires} attempts (until {expires_at}) — scheduler is down"
+                        );
+                    } else {
+                        tracing::info!(
+                            "coordinator: control plane held by '{holder_id}' until {expires_at}; waiting"
+                        );
+                    }
                     if wait_or_shutdown(&mut shutdown_rx, RETRY_BACKOFF).await {
                         return;
                     }
                     continue;
                 }
                 Err(e) => {
-                    tracing::warn!("coordinator: lease acquire failed ({e}); retrying");
+                    failed_acquires += 1;
+                    if failed_acquires.is_multiple_of(8) {
+                        tracing::error!(
+                            "coordinator: lease acquire STILL failing after {failed_acquires} \
+                             attempts ({e}) — scheduler is down"
+                        );
+                    } else {
+                        tracing::warn!("coordinator: lease acquire failed ({e}); retrying");
+                    }
                     if wait_or_shutdown(&mut shutdown_rx, RETRY_BACKOFF).await {
                         return;
                     }
                     continue;
                 }
             };
+            failed_acquires = 0;
 
             tracing::info!(
-                "coordinator: control-plane leadership acquired (token {}, ttl {LEASE_TTL:?})",
+                "coordinator: control-plane leadership acquired as '{holder}' \
+                 (token {}, ttl {LEASE_TTL:?})",
                 lease.fencing_token
             );
+
+            // Sweep claims left by dead tenures (a crash mid-task, a lost
+            // tenure's aborted loops). Safe by construction: no scheduler is
+            // running right now — this tenure hasn't started one, and the
+            // previous tenure's tasks were aborted before we got here — so
+            // any task-/intent- lease in the table is an orphan. Without the
+            // sweep, a daily task whose run died mid-flight would have its
+            // next fire refused (up to the 30m claim ttl — or the whole day,
+            // since the cron decides when the retry happens).
+            sweep_stale_claims(&leases, &holder).await;
 
             // Reconcile-on-reconnect (spec decision 2): other writers — the
             // CLI, the event listener, a prior wedged tenure — may have
@@ -235,11 +316,12 @@ async fn leadership_loop(
                 continue;
             }
 
-            let handles = match scheduler::start(
+            let started = match scheduler::start(
                 Arc::clone(&state),
                 Arc::clone(&schedule),
                 Arc::clone(&intent_queue),
                 Arc::clone(&leases),
+                holder.clone(),
             )
             .await
             {
@@ -261,14 +343,14 @@ async fn leadership_loop(
                 }
             };
 
-            let tenure_end = renew_until_lost_or_shutdown(&leases, &holder, &mut shutdown_rx).await;
-            tracing::info!(
-                "coordinator: ending tenure, aborting {} scheduler task(s)",
-                handles.len()
-            );
-            for handle in &handles {
-                handle.abort();
+            {
+                let mut guard = scheduler_handles.lock().unwrap_or_else(|p| p.into_inner());
+                *guard = started;
             }
+
+            let tenure_end = renew_until_lost_or_shutdown(&leases, &holder, &mut shutdown_rx).await;
+            tracing::info!("coordinator: ending tenure '{holder}', aborting scheduler task(s)");
+            abort_all(&scheduler_handles);
 
             match tenure_end {
                 TenureEnd::Shutdown => {
@@ -283,9 +365,46 @@ async fn leadership_loop(
                     return;
                 }
                 TenureEnd::Lost => {
+                    // If the renewal only failed transiently (we are still
+                    // the recorded holder), release now so the re-acquire
+                    // doesn't wait out our own ttl.
+                    let _ =
+                        leases
+                            .lock()
+                            .await
+                            .release(CONTROL_PLANE_RESOURCE, &holder, Utc::now());
                     tracing::warn!("coordinator: leadership lost; will re-acquire");
                 }
             }
+        }
+    }
+}
+
+/// Release every task-/intent- claim in the table. Called at leadership
+/// acquisition, when provably no scheduler is running — every such claim
+/// belongs to a dead tenure and would otherwise block that resource's next
+/// fire for up to its remaining ttl.
+async fn sweep_stale_claims(leases: &SharedLeases, tenure_holder: &str) {
+    let mut table = leases.lock().await;
+    let stale: Vec<_> = table
+        .leases()
+        .into_iter()
+        .filter(|l| {
+            l.holder_id != tenure_holder
+                && (l.resource_id.starts_with("task-") || l.resource_id.starts_with("intent-"))
+        })
+        .collect();
+    for lease in stale {
+        match table.release(&lease.resource_id, &lease.holder_id, Utc::now()) {
+            Ok(()) => tracing::warn!(
+                "coordinator: swept stale claim '{}' held by dead tenure '{}'",
+                lease.resource_id,
+                lease.holder_id
+            ),
+            Err(e) => tracing::warn!(
+                "coordinator: failed to sweep stale claim '{}': {e}",
+                lease.resource_id
+            ),
         }
     }
 }
@@ -342,7 +461,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
 
-        let schedule = Arc::new(RwLock::new(Schedule::load(root).unwrap()));
+        let schedule = Arc::new(RwLock::new(Schedule::load_or_init(root).unwrap()));
         let intents = Arc::new(RwLock::new(IntentQueue::load(root)));
         let task_id = schedule.read().await.tasks[0].task.id.clone();
         assert!(
@@ -374,6 +493,62 @@ mod tests {
                 .task
                 .enabled
         );
+    }
+
+    /// HIGH-1 regression: claims left by a dead tenure (crash mid-task,
+    /// aborted loops) must not block the resource's next fire — the sweep at
+    /// leadership acquisition releases them.
+    #[tokio::test]
+    async fn stale_claims_are_swept_at_leadership_acquisition() {
+        let dir = tempfile::tempdir().unwrap();
+        let leases: SharedLeases = Arc::new(tokio::sync::Mutex::new(
+            DurableLeaseTable::open(dir.path()).unwrap(),
+        ));
+
+        // A dead tenure left claims behind (unexpired — mid side-effect
+        // window when it died).
+        {
+            let mut t = leases.lock().await;
+            t.acquire(
+                "task-thinking-loop",
+                "echo-1-t1",
+                Duration::from_secs(1800),
+                Utc::now(),
+            )
+            .unwrap();
+            t.acquire(
+                "intent-abc",
+                "echo-1-t1",
+                Duration::from_secs(1800),
+                Utc::now(),
+            )
+            .unwrap();
+            // Non-claim resources are never swept.
+            t.acquire(
+                CONTROL_PLANE_RESOURCE,
+                "echo-1-t1",
+                Duration::from_secs(90),
+                Utc::now(),
+            )
+            .unwrap();
+        }
+
+        sweep_stale_claims(&leases, "echo-1-t2").await;
+
+        let t = leases.lock().await;
+        assert!(t.get("task-thinking-loop").is_none());
+        assert!(t.get("intent-abc").is_none());
+        assert!(t.get(CONTROL_PLANE_RESOURCE).is_some());
+        drop(t);
+
+        // The new tenure's fire claims immediately — no 30m wait.
+        let claimed = leases.lock().await.acquire(
+            "task-thinking-loop",
+            "echo-1-t2",
+            Duration::from_secs(1800),
+            Utc::now(),
+        );
+        assert!(claimed.is_ok());
     }
 
     #[test]

--- a/src/coordinator/control.rs
+++ b/src/coordinator/control.rs
@@ -279,6 +279,9 @@ async fn leadership_loop(
             };
             failed_acquires = 0;
 
+            state
+                .leadership
+                .store(true, std::sync::atomic::Ordering::Relaxed);
             tracing::info!(
                 "coordinator: control-plane leadership acquired as '{holder}' \
                  (token {}, ttl {LEASE_TTL:?})",
@@ -349,6 +352,9 @@ async fn leadership_loop(
             }
 
             let tenure_end = renew_until_lost_or_shutdown(&leases, &holder, &mut shutdown_rx).await;
+            state
+                .leadership
+                .store(false, std::sync::atomic::Ordering::Relaxed);
             tracing::info!("coordinator: ending tenure '{holder}', aborting scheduler task(s)");
             abort_all(&scheduler_handles);
 

--- a/src/coordinator/control.rs
+++ b/src/coordinator/control.rs
@@ -1,0 +1,275 @@
+//! Control-plane leadership: the coordinator owns the scheduler, never the
+//! interactive faculties.
+//!
+//! The load-bearing separation (coordinator spec, decision 1): chat and voice
+//! are the data plane and must stay reachable no matter what happens here.
+//! This module therefore owns exactly the control plane — the scheduler task
+//! loops, the intent drain, the liveness watchdog — and gates them on a
+//! `control-plane` lease from the Stage 0 substrate. The axum router, the
+//! session store, and every interactive handler are wired independently at
+//! boot and never consult the coordinator.
+//!
+//! Leadership lifecycle:
+//! - Acquire the `control-plane` lease (WAL-backed, fencing-tokened), then
+//!   start the scheduler. The lease WAL's exclusive file lock already
+//!   excludes a second coordinator *process*; the lease on top records the
+//!   tenure durably and fences a paused predecessor.
+//! - Renew at a third of the ttl. A failed renewal (e.g. the process stalled
+//!   past expiry and someone reclaimed) aborts the scheduler tasks and drops
+//!   back to acquiring — the stale tenure never keeps acting.
+//! - After a crash, a successor waits out the previous lease's remaining ttl
+//!   (bounded by `LEASE_TTL`) before taking over.
+//! - If the scheduler itself fails to start (bad config), the coordinator
+//!   logs, releases the lease, and exits — the data plane keeps serving.
+//!   (Previously a scheduler start error aborted the whole boot, chat
+//!   included; fail-open forbids that coupling.)
+//!
+//! Shutdown goes through `Coordinator::shutdown`, which aborts the scheduler
+//! tasks and releases the lease so a successor does not have to wait out the
+//! ttl.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use tokio::sync::{watch, RwLock};
+use tokio::task::JoinHandle;
+
+use super::durable::{DurableError, DurableLeaseTable};
+use super::lease::LeaseError;
+use crate::scheduler::{self, intent::IntentQueue, Schedule};
+use crate::server::AppState;
+
+pub const CONTROL_PLANE_RESOURCE: &str = "control-plane";
+const LEASE_TTL: Duration = Duration::from_secs(90);
+const RENEW_INTERVAL: Duration = Duration::from_secs(30);
+const RETRY_BACKOFF: Duration = Duration::from_secs(15);
+
+/// Handle to the coordinator's leadership loop.
+pub struct Coordinator {
+    shutdown_tx: watch::Sender<bool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Coordinator {
+    /// Start the leadership loop. The scheduler will run only while the
+    /// `control-plane` lease is held. `schedule`/`intent_queue` are shared
+    /// with the event listener and CLI surfaces, so the coordinator refreshes
+    /// their contents rather than replacing the `Arc`s.
+    pub fn start(
+        state: Arc<AppState>,
+        schedule: Arc<RwLock<Schedule>>,
+        intent_queue: Arc<RwLock<IntentQueue>>,
+    ) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        if !state.config.scheduler.enabled {
+            tracing::info!("Scheduler disabled in config — coordinator not started");
+            return Self {
+                shutdown_tx,
+                handle: None,
+            };
+        }
+        let handle = tokio::spawn(leadership_loop(state, schedule, intent_queue, shutdown_rx));
+        Self {
+            shutdown_tx,
+            handle: Some(handle),
+        }
+    }
+
+    /// Abort the scheduler tasks and release the lease. Bounded: gives the
+    /// loop 10s to wind down before letting go.
+    pub async fn shutdown(self) {
+        let _ = self.shutdown_tx.send(true);
+        if let Some(handle) = self.handle {
+            if tokio::time::timeout(Duration::from_secs(10), handle)
+                .await
+                .is_err()
+            {
+                tracing::warn!("coordinator: shutdown timed out after 10s");
+            }
+        }
+    }
+}
+
+enum TenureEnd {
+    Shutdown,
+    Lost,
+}
+
+/// Sleep for `dur` unless shutdown fires first. Returns true on shutdown.
+async fn wait_or_shutdown(shutdown_rx: &mut watch::Receiver<bool>, dur: Duration) -> bool {
+    tokio::select! {
+        _ = shutdown_rx.changed() => true,
+        () = tokio::time::sleep(dur) => *shutdown_rx.borrow(),
+    }
+}
+
+/// Lease holder id: entity name (sanitized to the lease id charset) + pid,
+/// so concurrent processes are distinguishable in the lease WAL.
+fn holder_id(entity_name: &str) -> String {
+    let sanitized: String = entity_name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .take(64)
+        .collect();
+    let base = if sanitized.is_empty() {
+        "entity".to_string()
+    } else {
+        sanitized
+    };
+    format!("{base}-{}", std::process::id())
+}
+
+async fn leadership_loop(
+    state: Arc<AppState>,
+    schedule: Arc<RwLock<Schedule>>,
+    intent_queue: Arc<RwLock<IntentQueue>>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    let dir = state.root_dir.join("coordinator");
+    let holder = holder_id(&state.config.entity.name);
+
+    'open: loop {
+        if *shutdown_rx.borrow() {
+            return;
+        }
+        // Opening takes the WAL's exclusive file lock — held for as long as
+        // this table lives, so it spans tenures and re-acquire attempts.
+        let mut table = match DurableLeaseTable::open(&dir) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(
+                    "coordinator: lease table unavailable ({e}); retrying in {RETRY_BACKOFF:?}"
+                );
+                if wait_or_shutdown(&mut shutdown_rx, RETRY_BACKOFF).await {
+                    return;
+                }
+                continue 'open;
+            }
+        };
+
+        loop {
+            if *shutdown_rx.borrow() {
+                return;
+            }
+            let lease = match table.acquire(CONTROL_PLANE_RESOURCE, &holder, LEASE_TTL, Utc::now())
+            {
+                Ok(lease) => lease,
+                Err(DurableError::Lease(LeaseError::Held {
+                    holder_id,
+                    expires_at,
+                    ..
+                })) => {
+                    // A crashed predecessor's lease runs out on its own; a
+                    // live one keeps renewing. Either way: wait, retry.
+                    tracing::info!(
+                        "coordinator: control plane held by '{holder_id}' until {expires_at}; waiting"
+                    );
+                    if wait_or_shutdown(&mut shutdown_rx, RETRY_BACKOFF).await {
+                        return;
+                    }
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!("coordinator: lease acquire failed ({e}); retrying");
+                    if wait_or_shutdown(&mut shutdown_rx, RETRY_BACKOFF).await {
+                        return;
+                    }
+                    continue;
+                }
+            };
+
+            tracing::info!(
+                "coordinator: control-plane leadership acquired (token {}, ttl {LEASE_TTL:?})",
+                lease.fencing_token
+            );
+
+            let handles = match scheduler::start(
+                Arc::clone(&state),
+                Arc::clone(&schedule),
+                Arc::clone(&intent_queue),
+            )
+            .await
+            {
+                Ok(handles) => handles,
+                Err(e) => {
+                    // Bad scheduler config must not hot-loop and must not
+                    // touch the data plane: give up the control plane and
+                    // leave chat/voice serving.
+                    tracing::error!(
+                        "coordinator: scheduler failed to start ({e}); \
+                         releasing control plane — interactive faculties unaffected"
+                    );
+                    let _ = table.release(CONTROL_PLANE_RESOURCE, &holder, Utc::now());
+                    return;
+                }
+            };
+
+            let tenure_end =
+                renew_until_lost_or_shutdown(&mut table, &holder, &mut shutdown_rx).await;
+            tracing::info!(
+                "coordinator: ending tenure, aborting {} scheduler task(s)",
+                handles.len()
+            );
+            for handle in &handles {
+                handle.abort();
+            }
+
+            match tenure_end {
+                TenureEnd::Shutdown => {
+                    if let Err(e) = table.release(CONTROL_PLANE_RESOURCE, &holder, Utc::now()) {
+                        tracing::warn!("coordinator: lease release on shutdown failed: {e}");
+                    }
+                    return;
+                }
+                TenureEnd::Lost => {
+                    tracing::warn!("coordinator: leadership lost; will re-acquire");
+                }
+            }
+        }
+    }
+}
+
+async fn renew_until_lost_or_shutdown(
+    table: &mut DurableLeaseTable,
+    holder: &str,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> TenureEnd {
+    loop {
+        if wait_or_shutdown(shutdown_rx, RENEW_INTERVAL).await {
+            return TenureEnd::Shutdown;
+        }
+        match table.renew(CONTROL_PLANE_RESOURCE, holder, LEASE_TTL, Utc::now()) {
+            Ok(_) => {}
+            Err(e) => {
+                // Expired (we stalled past ttl), reclaimed by a successor,
+                // or the WAL refused the write — in every case this tenure
+                // is over and the scheduler must stop.
+                tracing::warn!("coordinator: lease renewal failed ({e})");
+                return TenureEnd::Lost;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn holder_id_is_lease_charset_safe() {
+        let id = holder_id("Echo Prime (v2)!");
+        assert!(id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')));
+        assert!(id.starts_with("Echo-Prime--v2--"));
+        let empty = holder_id("");
+        assert!(empty.starts_with("entity-"));
+    }
+}

--- a/src/coordinator/control.rs
+++ b/src/coordinator/control.rs
@@ -204,6 +204,27 @@ async fn leadership_loop(
                 lease.fencing_token
             );
 
+            // Reconcile-on-reconnect (spec decision 2): other writers — the
+            // CLI, the event listener, a prior wedged tenure — may have
+            // changed control-plane state while we weren't leader. Re-read
+            // the actual files; never assume the in-memory copies. (Evaluator
+            // state and task health are re-loaded from disk inside the
+            // scheduler itself, per tenure.)
+            if let Err(e) = reconcile_control_plane(&state.root_dir, &schedule, &intent_queue).await
+            {
+                // Unknown control-plane state: fail closed on the control
+                // plane only. Release and retry; the data plane keeps serving.
+                tracing::error!("coordinator: reconcile failed ({e}); not starting scheduler");
+                let _ = leases
+                    .lock()
+                    .await
+                    .release(CONTROL_PLANE_RESOURCE, &holder, Utc::now());
+                if wait_or_shutdown(&mut shutdown_rx, RETRY_BACKOFF).await {
+                    return;
+                }
+                continue;
+            }
+
             let handles = match scheduler::start(
                 Arc::clone(&state),
                 Arc::clone(&schedule),
@@ -259,6 +280,19 @@ async fn leadership_loop(
     }
 }
 
+/// Replace the shared control-plane state with what is actually on disk.
+async fn reconcile_control_plane(
+    root_dir: &std::path::Path,
+    schedule: &Arc<RwLock<Schedule>>,
+    intent_queue: &Arc<RwLock<IntentQueue>>,
+) -> Result<(), crate::errors::SchedulerError> {
+    let fresh_schedule = Schedule::load(root_dir)?;
+    let fresh_intents = IntentQueue::load(root_dir);
+    *schedule.write().await = fresh_schedule;
+    *intent_queue.write().await = fresh_intents;
+    Ok(())
+}
+
 async fn renew_until_lost_or_shutdown(
     leases: &SharedLeases,
     holder: &str,
@@ -290,6 +324,47 @@ async fn renew_until_lost_or_shutdown(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// AC12: at leadership acquisition the shared state is replaced by disk
+    /// truth — an edit made while the coordinator was down survives.
+    #[tokio::test]
+    async fn reconcile_replaces_shared_state_with_disk_truth() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let schedule = Arc::new(RwLock::new(Schedule::load(root).unwrap()));
+        let intents = Arc::new(RwLock::new(IntentQueue::load(root)));
+        let task_id = schedule.read().await.tasks[0].task.id.clone();
+        assert!(
+            schedule
+                .read()
+                .await
+                .find_task(&task_id)
+                .unwrap()
+                .task
+                .enabled
+        );
+
+        // "CLI disabled the task while the coordinator was down."
+        {
+            let mut cli = Schedule::load(root).unwrap();
+            cli.find_task_mut(&task_id).unwrap().task.enabled = false;
+            cli.save(root).unwrap();
+        }
+
+        reconcile_control_plane(root, &schedule, &intents)
+            .await
+            .unwrap();
+        assert!(
+            !schedule
+                .read()
+                .await
+                .find_task(&task_id)
+                .unwrap()
+                .task
+                .enabled
+        );
+    }
 
     #[test]
     fn holder_id_is_lease_charset_safe() {

--- a/src/coordinator/control.rs
+++ b/src/coordinator/control.rs
@@ -173,6 +173,8 @@ impl Drop for Coordinator {
 enum TenureEnd {
     Shutdown,
     Lost,
+    /// Isolation Mode entered — release everything and park until it exits.
+    Isolated,
 }
 
 /// Sleep for `dur` unless shutdown fires first. Returns true on shutdown.
@@ -203,6 +205,7 @@ async fn leadership_loop(
     // stale-claim sweep nor fenced completion could tell them apart.
     let mut tenure: u64 = 0;
     let mut failed_acquires: u32 = 0;
+    let mut parked_logged = false;
 
     'open: loop {
         if *shutdown_rx.borrow() {
@@ -227,6 +230,26 @@ async fn leadership_loop(
         loop {
             if *shutdown_rx.borrow() {
                 return;
+            }
+            // Isolation Mode (spec Stage 2): the control plane is shed. Park —
+            // no acquire, no scheduler — until the data plane exits isolation.
+            // The marker is file-based and owned by the channel holder, so
+            // this check works no matter what state the rest of us are in.
+            if crate::server::isolation::is_active(&state.root_dir) {
+                if !parked_logged {
+                    tracing::warn!(
+                        "coordinator: ISOLATION active — control plane parked (scheduler down)                          until /resume"
+                    );
+                    parked_logged = true;
+                }
+                if wait_or_shutdown(&mut shutdown_rx, RETRY_BACKOFF).await {
+                    return;
+                }
+                continue;
+            }
+            if parked_logged {
+                tracing::info!("coordinator: isolation exited — resuming control plane");
+                parked_logged = false;
             }
             tenure += 1;
             let holder = format!("{holder_base}-t{tenure}");
@@ -351,7 +374,9 @@ async fn leadership_loop(
                 *guard = started;
             }
 
-            let tenure_end = renew_until_lost_or_shutdown(&leases, &holder, &mut shutdown_rx).await;
+            let tenure_end =
+                renew_until_lost_or_shutdown(&leases, &holder, &state.root_dir, &mut shutdown_rx)
+                    .await;
             state
                 .leadership
                 .store(false, std::sync::atomic::Ordering::Relaxed);
@@ -380,6 +405,15 @@ async fn leadership_loop(
                             .await
                             .release(CONTROL_PLANE_RESOURCE, &holder, Utc::now());
                     tracing::warn!("coordinator: leadership lost; will re-acquire");
+                }
+                TenureEnd::Isolated => {
+                    // Release so the lease is provably free while isolated
+                    // (AC19), then loop back into the parking check.
+                    let _ =
+                        leases
+                            .lock()
+                            .await
+                            .release(CONTROL_PLANE_RESOURCE, &holder, Utc::now());
                 }
             }
         }
@@ -431,11 +465,15 @@ async fn reconcile_control_plane(
 async fn renew_until_lost_or_shutdown(
     leases: &SharedLeases,
     holder: &str,
+    root_dir: &std::path::Path,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) -> TenureEnd {
     loop {
         if wait_or_shutdown(shutdown_rx, RENEW_INTERVAL).await {
             return TenureEnd::Shutdown;
+        }
+        if crate::server::isolation::is_active(root_dir) {
+            return TenureEnd::Isolated;
         }
         let renewed = {
             leases

--- a/src/coordinator/control.rs
+++ b/src/coordinator/control.rs
@@ -44,6 +44,9 @@ pub const CONTROL_PLANE_RESOURCE: &str = "control-plane";
 const LEASE_TTL: Duration = Duration::from_secs(90);
 const RENEW_INTERVAL: Duration = Duration::from_secs(30);
 const RETRY_BACKOFF: Duration = Duration::from_secs(15);
+/// How often the loop re-checks isolation/shutdown between renewals — keeps
+/// isolation-entry latency in seconds without renewing more than needed.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// The process-wide lease table. One WAL lock per process, so every consumer
 /// (leadership loop, task loops, intent drain) shares this handle.
@@ -242,7 +245,7 @@ async fn leadership_loop(
                     );
                     parked_logged = true;
                 }
-                if wait_or_shutdown(&mut shutdown_rx, RETRY_BACKOFF).await {
+                if wait_or_shutdown(&mut shutdown_rx, POLL_INTERVAL).await {
                     return;
                 }
                 continue;
@@ -468,13 +471,19 @@ async fn renew_until_lost_or_shutdown(
     root_dir: &std::path::Path,
     shutdown_rx: &mut watch::Receiver<bool>,
 ) -> TenureEnd {
+    let mut since_renew = Duration::ZERO;
     loop {
-        if wait_or_shutdown(shutdown_rx, RENEW_INTERVAL).await {
+        if wait_or_shutdown(shutdown_rx, POLL_INTERVAL).await {
             return TenureEnd::Shutdown;
         }
         if crate::server::isolation::is_active(root_dir) {
             return TenureEnd::Isolated;
         }
+        since_renew += POLL_INTERVAL;
+        if since_renew < RENEW_INTERVAL {
+            continue;
+        }
+        since_renew = Duration::ZERO;
         let renewed = {
             leases
                 .lock()

--- a/src/coordinator/durable.rs
+++ b/src/coordinator/durable.rs
@@ -1,0 +1,192 @@
+//! Durable lease table — write-ahead ordering enforced by construction.
+//!
+//! The one rule that makes fencing sound across crashes: **no fencing token
+//! reaches a caller before the event recording it is fsynced.** Each mutation
+//! is staged on a copy of the table, appended to the WAL, and only then
+//! installed and returned. A crash between mint and append therefore loses a
+//! token nobody ever held — after replay the same numeral can be reissued
+//! safely, because the original was never granted. This is what lets replay
+//! drop a torn final WAL line without regressing mutual exclusion.
+//!
+//! Stage 1 wires the coordinator through this type; bare `LeaseTable` is for
+//! the replay fold and tests only.
+
+use std::io;
+use std::path::Path;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+
+use super::lease::{Lease, LeaseError, LeaseEvent, LeaseTable};
+use super::wal::{LeaseWal, ReplayError};
+
+#[derive(Debug, Error)]
+pub enum DurableError {
+    #[error(transparent)]
+    Lease(#[from] LeaseError),
+    #[error("lease WAL append failed — mutation not applied: {0}")]
+    Wal(#[from] io::Error),
+}
+
+/// A `LeaseTable` whose every mutation is durable before it is visible.
+pub struct DurableLeaseTable {
+    table: LeaseTable,
+    wal: LeaseWal,
+}
+
+impl DurableLeaseTable {
+    /// Open the lease WAL under `dir` (taking its exclusive lock) and
+    /// recover the table from it.
+    pub fn open(dir: &Path) -> Result<Self, ReplayError> {
+        let wal = LeaseWal::new(dir)?;
+        let table = wal.replay()?;
+        Ok(Self { table, wal })
+    }
+
+    pub fn acquire(
+        &mut self,
+        resource_id: &str,
+        holder_id: &str,
+        ttl: Duration,
+        now: DateTime<Utc>,
+    ) -> Result<Lease, DurableError> {
+        let reclaim = self
+            .table
+            .get(resource_id)
+            .is_some_and(|l| l.is_expired(now));
+        let mut staged = self.table.clone();
+        let lease = staged.acquire(resource_id, holder_id, ttl, now)?;
+        let event = if reclaim {
+            LeaseEvent::Reclaimed {
+                ts: now,
+                lease: lease.clone(),
+            }
+        } else {
+            LeaseEvent::Acquired {
+                ts: now,
+                lease: lease.clone(),
+            }
+        };
+        self.wal.append(&event)?;
+        self.table = staged;
+        Ok(lease)
+    }
+
+    pub fn renew(
+        &mut self,
+        resource_id: &str,
+        holder_id: &str,
+        ttl: Duration,
+        now: DateTime<Utc>,
+    ) -> Result<Lease, DurableError> {
+        let mut staged = self.table.clone();
+        let lease = staged.renew(resource_id, holder_id, ttl, now)?;
+        self.wal.append(&LeaseEvent::Renewed {
+            ts: now,
+            lease: lease.clone(),
+        })?;
+        self.table = staged;
+        Ok(lease)
+    }
+
+    pub fn release(
+        &mut self,
+        resource_id: &str,
+        holder_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(), DurableError> {
+        let mut staged = self.table.clone();
+        staged.release(resource_id, holder_id)?;
+        self.wal.append(&LeaseEvent::Released {
+            ts: now,
+            resource_id: resource_id.to_string(),
+            holder_id: holder_id.to_string(),
+        })?;
+        self.table = staged;
+        Ok(())
+    }
+
+    pub fn get(&self, resource_id: &str) -> Option<&Lease> {
+        self.table.get(resource_id)
+    }
+
+    pub fn table(&self) -> &LeaseTable {
+        &self.table
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn t0() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 7, 12, 0, 0).unwrap()
+    }
+
+    fn secs(n: u64) -> Duration {
+        Duration::from_secs(n)
+    }
+
+    #[test]
+    fn grants_survive_restart_with_the_same_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let granted;
+        {
+            let mut durable = DurableLeaseTable::open(dir.path()).unwrap();
+            granted = durable.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        }
+        let durable = DurableLeaseTable::open(dir.path()).unwrap();
+        assert_eq!(durable.get("wal"), Some(&granted));
+    }
+
+    #[test]
+    fn failed_mutation_leaves_table_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut durable = DurableLeaseTable::open(dir.path()).unwrap();
+        durable.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+
+        let before = durable.table().clone();
+        durable
+            .acquire("wal", "echo-b", secs(30), t0() + secs(1))
+            .unwrap_err();
+        durable
+            .renew("wal", "echo-b", secs(30), t0() + secs(1))
+            .unwrap_err();
+        durable
+            .release("wal", "echo-b", t0() + secs(1))
+            .unwrap_err();
+        assert_eq!(durable.table(), &before);
+
+        // And none of the failed mutations polluted the log.
+        drop(durable);
+        let recovered = DurableLeaseTable::open(dir.path()).unwrap();
+        assert_eq!(recovered.table(), &before);
+    }
+
+    #[test]
+    fn tokens_stay_strictly_increasing_across_restart_and_reclaim() {
+        let dir = tempfile::tempdir().unwrap();
+        let first;
+        {
+            let mut durable = DurableLeaseTable::open(dir.path()).unwrap();
+            first = durable.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        }
+        let mut durable = DurableLeaseTable::open(dir.path()).unwrap();
+        let reclaimed = durable
+            .acquire("wal", "echo-b", secs(30), t0() + secs(31))
+            .unwrap();
+        assert!(reclaimed.fencing_token > first.fencing_token);
+    }
+
+    #[test]
+    fn second_durable_table_on_same_dir_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let _held = DurableLeaseTable::open(dir.path()).unwrap();
+        assert!(matches!(
+            DurableLeaseTable::open(dir.path()),
+            Err(ReplayError::Io(_))
+        ));
+    }
+}

--- a/src/coordinator/durable.rs
+++ b/src/coordinator/durable.rs
@@ -39,7 +39,15 @@ impl DurableLeaseTable {
     /// Open the lease WAL under `dir` (taking its exclusive lock) and
     /// recover the table from it.
     pub fn open(dir: &Path) -> Result<Self, ReplayError> {
-        let wal = LeaseWal::new(dir)?;
+        let wal = LeaseWal::new(dir).map_err(|e| {
+            if e.kind() == io::ErrorKind::WouldBlock {
+                ReplayError::Locked {
+                    path: dir.join("leases.jsonl"),
+                }
+            } else {
+                ReplayError::Io(e)
+            }
+        })?;
         let table = wal.replay()?;
         Ok(Self { table, wal })
     }
@@ -181,12 +189,12 @@ mod tests {
     }
 
     #[test]
-    fn second_durable_table_on_same_dir_is_refused() {
+    fn second_durable_table_on_same_dir_is_refused_as_locked() {
         let dir = tempfile::tempdir().unwrap();
         let _held = DurableLeaseTable::open(dir.path()).unwrap();
         assert!(matches!(
             DurableLeaseTable::open(dir.path()),
-            Err(ReplayError::Io(_))
+            Err(ReplayError::Locked { .. })
         ));
     }
 }

--- a/src/coordinator/durable.rs
+++ b/src/coordinator/durable.rs
@@ -81,6 +81,13 @@ impl DurableLeaseTable {
         Ok(lease)
     }
 
+    /// Renewals are deliberately NOT persisted. Renew mints no token, and
+    /// losing renewals at a crash only makes the lease look *shorter* than it
+    /// was — a successor reclaims sooner, with a strictly higher token, and
+    /// the stale holder is fenced: the safe direction. In exchange, the WAL
+    /// grows per grant instead of per renewal (a 30s renew cadence would
+    /// otherwise fsync ~2,880 lines/day forever), and crash takeover waits
+    /// out the ttl from the last *durable* grant, not the last renewal.
     pub fn renew(
         &mut self,
         resource_id: &str,
@@ -88,14 +95,7 @@ impl DurableLeaseTable {
         ttl: Duration,
         now: DateTime<Utc>,
     ) -> Result<Lease, DurableError> {
-        let mut staged = self.table.clone();
-        let lease = staged.renew(resource_id, holder_id, ttl, now)?;
-        self.wal.append(&LeaseEvent::Renewed {
-            ts: now,
-            lease: lease.clone(),
-        })?;
-        self.table = staged;
-        Ok(lease)
+        Ok(self.table.renew(resource_id, holder_id, ttl, now)?)
     }
 
     pub fn release(
@@ -117,6 +117,12 @@ impl DurableLeaseTable {
 
     pub fn get(&self, resource_id: &str) -> Option<&Lease> {
         self.table.get(resource_id)
+    }
+
+    /// Snapshot of every lease currently in the table (held or expired-but-
+    /// unreclaimed). Used by the coordinator's stale-claim sweep.
+    pub fn leases(&self) -> Vec<Lease> {
+        self.table.all().cloned().collect()
     }
 
     pub fn table(&self) -> &LeaseTable {
@@ -183,6 +189,34 @@ mod tests {
         }
         let mut durable = DurableLeaseTable::open(dir.path()).unwrap();
         let reclaimed = durable
+            .acquire("wal", "echo-b", secs(30), t0() + secs(31))
+            .unwrap();
+        assert!(reclaimed.fencing_token > first.fencing_token);
+    }
+
+    #[test]
+    fn renewals_are_memory_only_and_crash_recovery_reclaims_fast() {
+        let dir = tempfile::tempdir().unwrap();
+        let first;
+        {
+            let mut durable = DurableLeaseTable::open(dir.path()).unwrap();
+            first = durable.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+            // Renew far past the original expiry — memory only.
+            durable
+                .renew("wal", "echo-a", secs(30), t0() + secs(20))
+                .unwrap();
+            assert_eq!(
+                durable.get("wal").unwrap().expires_at(),
+                t0() + secs(20) + secs(30)
+            );
+        }
+        // "Crash": recovery sees only the durable grant, so the lease looks
+        // expired at t0+30 — a successor reclaims at t0+31 with a strictly
+        // higher token instead of waiting out the renewed expiry. The stale
+        // holder is fenced by that token: the safe direction.
+        let mut recovered = DurableLeaseTable::open(dir.path()).unwrap();
+        assert_eq!(recovered.get("wal").unwrap().expires_at(), t0() + secs(30));
+        let reclaimed = recovered
             .acquire("wal", "echo-b", secs(30), t0() + secs(31))
             .unwrap();
         assert!(reclaimed.fencing_token > first.fencing_token);

--- a/src/coordinator/farm.rs
+++ b/src/coordinator/farm.rs
@@ -1,0 +1,528 @@
+//! Subtask farming (coordinator spec, Stage 3).
+//!
+//! Delegation of bounded work to child executions, built ENTIRELY on the
+//! Stage 0 substrate — leases bound each child's tenure, fencing tokens
+//! reject a reclaimed child's late result. No new ownership primitive: if
+//! farming needed one, Stage 0 was incomplete (spec decision 6).
+//!
+//! Mechanics per subtask:
+//! - each attempt acquires the lease `farm-{farm}-{sub}` under an
+//!   attempt-scoped holder, minting a strictly higher fencing token;
+//! - the result store holds one `FencedResource` guard per subtask, fenced
+//!   AT the current attempt's token before the child runs — so a stalled
+//!   predecessor's commit is rejected in every interleaving, including the
+//!   window before the new child commits;
+//! - a child that outlives its lease ttl is reclaimed: the next attempt's
+//!   acquire (over the expired lease) mints a higher token, the guard is
+//!   re-fenced, and the old child is aborted (`kill_on_drop` reaps the CLI
+//!   subprocess). Its late result, if it slips through before the abort
+//!   lands, presents a stale token and is fenced.
+//!
+//! The executor is injected, so all of this is deterministic under test and
+//! provider-free; production passes a closure that invokes the LmProvider.
+//! Children are in-process spawned tasks (single-VPS reality) — the lease
+//! substrate would carry separate processes unchanged.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use tokio::sync::{Mutex, Semaphore};
+
+use super::control::{lease_safe, SharedLeases};
+use super::fenced::FencedResource;
+use super::lease::FencingToken;
+
+/// Hard cap on subtasks per farm — a farm is bounded work, not a fleet.
+pub const MAX_SUBTASKS: usize = 8;
+
+/// One bounded unit of delegated work.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SubtaskSpec {
+    pub id: String,
+    pub prompt: String,
+}
+
+/// A farm: a set of subtasks plus an optional synthesis prompt the caller
+/// may run over the collected results (`{results}` placeholder).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FarmSpec {
+    pub id: String,
+    #[serde(default)]
+    pub description: String,
+    pub subtasks: Vec<SubtaskSpec>,
+    #[serde(default)]
+    pub synthesis: Option<String>,
+}
+
+/// Execution knobs. Defaults are production values; tests shrink the ttl and
+/// may disable reclaim-abort to let a stalled child run long enough to prove
+/// its late commit is fenced.
+#[derive(Debug, Clone)]
+pub struct FarmCaps {
+    pub max_concurrency: usize,
+    pub max_attempts: u32,
+    pub subtask_ttl: Duration,
+    /// Abort a reclaimed child (production). `false` only in tests that
+    /// deliberately let the stale child finish and hit the fence.
+    pub reclaim_abort: bool,
+}
+
+impl Default for FarmCaps {
+    fn default() -> Self {
+        Self {
+            max_concurrency: 3,
+            max_attempts: 2,
+            subtask_ttl: Duration::from_secs(10 * 60),
+            reclaim_abort: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SubtaskResult {
+    pub sub_id: String,
+    pub text: String,
+    pub attempts: u32,
+}
+
+#[derive(Debug)]
+pub struct FarmOutcome {
+    pub results: Vec<SubtaskResult>,
+    /// Subtasks that failed every attempt (or were cut off by abort).
+    pub failed: Vec<String>,
+    /// Late commits from reclaimed children rejected by fencing — the spec's
+    /// Stage 3 exit criterion made observable.
+    pub late_fenced: u32,
+    /// Reclaims performed (stalled children superseded).
+    pub reclaims: u32,
+}
+
+/// Fenced result store: the ONLY place child output lands, guarded per
+/// subtask by a Stage 0 `FencedResource`.
+struct FarmResults {
+    inner: Mutex<HashMap<String, (FencedResource, Option<String>)>>,
+    late_fenced: std::sync::atomic::AtomicU32,
+}
+
+impl FarmResults {
+    fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+            late_fenced: std::sync::atomic::AtomicU32::new(0),
+        }
+    }
+
+    /// Raise the subtask's fence to `token` — called at every attempt's
+    /// acquire, BEFORE the child runs. Tokens are strictly increasing across
+    /// attempts, so this only ever raises.
+    async fn fence_at(&self, sub_id: &str, token: FencingToken) {
+        let mut inner = self.inner.lock().await;
+        let entry = inner
+            .entry(sub_id.to_string())
+            .or_insert_with(|| (FencedResource::new(), None));
+        entry.0 = FencedResource::at(token);
+    }
+
+    /// Commit a child's result under its token. A stale (reclaimed) child is
+    /// rejected here — parent state is never touched by it.
+    async fn commit(&self, sub_id: &str, token: FencingToken, text: String) -> bool {
+        let mut inner = self.inner.lock().await;
+        let entry = inner
+            .entry(sub_id.to_string())
+            .or_insert_with(|| (FencedResource::new(), None));
+        match entry.0.accept(token) {
+            Ok(()) => {
+                entry.1 = Some(text);
+                true
+            }
+            Err(rejected) => {
+                tracing::warn!(
+                    "farm: late result from reclaimed child on '{sub_id}' fenced ({rejected})"
+                );
+                self.late_fenced
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                false
+            }
+        }
+    }
+
+    async fn take(&self, sub_id: &str) -> Option<String> {
+        self.inner
+            .lock()
+            .await
+            .get_mut(sub_id)
+            .and_then(|(_, r)| r.take())
+    }
+}
+
+/// Run a farm to completion. The executor is one child attempt: it receives
+/// the subtask spec and returns the child's text (or an error string).
+pub async fn run_farm<F, Fut>(
+    leases: SharedLeases,
+    tenure_holder: &str,
+    root_dir: PathBuf,
+    spec: FarmSpec,
+    caps: FarmCaps,
+    executor: F,
+) -> FarmOutcome
+where
+    F: Fn(SubtaskSpec) -> Fut + Send + Sync + Clone + 'static,
+    Fut: std::future::Future<Output = Result<String, String>> + Send + 'static,
+{
+    let farm_id = lease_safe(&spec.id);
+    let results = Arc::new(FarmResults::new());
+    let semaphore = Arc::new(Semaphore::new(caps.max_concurrency.max(1)));
+    let reclaims = Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+    let subtasks: Vec<SubtaskSpec> = spec.subtasks.into_iter().take(MAX_SUBTASKS).collect();
+    let mut controllers = Vec::new();
+
+    for sub in subtasks.iter().cloned() {
+        let leases = Arc::clone(&leases);
+        let results = Arc::clone(&results);
+        let semaphore = Arc::clone(&semaphore);
+        let reclaims = Arc::clone(&reclaims);
+        let executor = executor.clone();
+        let caps = caps.clone();
+        let root_dir = root_dir.clone();
+        let tenure_holder = tenure_holder.to_string();
+        let farm_id = farm_id.clone();
+
+        controllers.push(tokio::spawn(async move {
+            subtask_controller(
+                leases,
+                results,
+                semaphore,
+                reclaims,
+                executor,
+                caps,
+                root_dir,
+                tenure_holder,
+                farm_id,
+                sub,
+            )
+            .await
+        }));
+    }
+
+    let mut outcome = FarmOutcome {
+        results: Vec::new(),
+        failed: Vec::new(),
+        late_fenced: 0,
+        reclaims: 0,
+    };
+
+    for (controller, sub) in controllers.into_iter().zip(subtasks.iter()) {
+        let attempts = controller.await.unwrap_or(None);
+        match (attempts, results.take(&sub.id).await) {
+            (Some(attempts), Some(text)) => outcome.results.push(SubtaskResult {
+                sub_id: sub.id.clone(),
+                text,
+                attempts,
+            }),
+            _ => outcome.failed.push(sub.id.clone()),
+        }
+    }
+    outcome.late_fenced = results
+        .late_fenced
+        .load(std::sync::atomic::Ordering::Relaxed);
+    outcome.reclaims = reclaims.load(std::sync::atomic::Ordering::Relaxed);
+    outcome
+}
+
+/// Drive one subtask through its attempts. Returns Some(attempt_count) when
+/// a result was committed, None when every attempt failed.
+#[allow(clippy::too_many_arguments)]
+async fn subtask_controller<F, Fut>(
+    leases: SharedLeases,
+    results: Arc<FarmResults>,
+    semaphore: Arc<Semaphore>,
+    reclaims: Arc<std::sync::atomic::AtomicU32>,
+    executor: F,
+    caps: FarmCaps,
+    root_dir: PathBuf,
+    tenure_holder: String,
+    farm_id: String,
+    sub: SubtaskSpec,
+) -> Option<u32>
+where
+    F: Fn(SubtaskSpec) -> Fut + Send + Sync + Clone + 'static,
+    Fut: std::future::Future<Output = Result<String, String>> + Send + 'static,
+{
+    let resource = format!("farm-{farm_id}-{}", lease_safe(&sub.id));
+    let mut stalled_child: Option<tokio::task::JoinHandle<()>> = None;
+
+    for attempt in 1..=caps.max_attempts {
+        // Shed with everything else: a farm never outlives isolation entry.
+        if crate::server::isolation::is_active(&root_dir) {
+            tracing::warn!(
+                "farm '{farm_id}': ISOLATION active — abandoning '{}'",
+                sub.id
+            );
+            break;
+        }
+
+        // Acquire (attempt 1) or reclaim-by-expiry (attempt >1: the previous
+        // child stalled past its ttl; this acquire mints a higher token).
+        let holder = format!("{tenure_holder}-a{attempt}");
+        let lease = {
+            leases
+                .lock()
+                .await
+                .acquire(&resource, &holder, caps.subtask_ttl, Utc::now())
+        };
+        let lease = match lease {
+            Ok(lease) => lease,
+            Err(e) => {
+                tracing::warn!("farm '{farm_id}': claim failed on '{}': {e}", sub.id);
+                break;
+            }
+        };
+
+        // Fence BEFORE the child runs: from this instant, any commit bearing
+        // an older token — a stalled predecessor waking up — is rejected,
+        // regardless of interleaving.
+        results.fence_at(&sub.id, lease.fencing_token).await;
+        if attempt > 1 {
+            reclaims.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if caps.reclaim_abort {
+                if let Some(old) = stalled_child.take() {
+                    old.abort();
+                }
+            }
+        }
+
+        // Bound concurrency across the farm; the permit travels with the
+        // child so a running child occupies a slot.
+        let permit = Arc::clone(&semaphore).acquire_owned().await.ok()?;
+        let mut child = {
+            let results = Arc::clone(&results);
+            let executor = executor.clone();
+            let sub = sub.clone();
+            let token = lease.fencing_token;
+            tokio::spawn(async move {
+                let _permit = permit;
+                if let Ok(text) = executor(sub.clone()).await {
+                    results.commit(&sub.id, token, text).await;
+                }
+            })
+        };
+
+        // Wait out this attempt's lease window. select (not timeout) so the
+        // JoinHandle survives a stall — a dropped handle would detach the
+        // child beyond reach of the reclaim abort.
+        let finished = tokio::select! {
+            _ = &mut child => true,
+            () = tokio::time::sleep(caps.subtask_ttl) => false,
+        };
+        match finished {
+            true => {
+                // Child finished (ok or executor error) within its lease.
+                let committed = {
+                    results
+                        .inner
+                        .lock()
+                        .await
+                        .get(&sub.id)
+                        .is_some_and(|(_, r)| r.is_some())
+                };
+                let _ = { leases.lock().await.release(&resource, &holder, Utc::now()) };
+                if committed {
+                    return Some(attempt);
+                }
+                // Executor error: retry on the next attempt (fresh acquire —
+                // the lease was released, watermark still climbs).
+            }
+            false => {
+                // Stalled past the ttl: keep the handle; the NEXT attempt's
+                // acquire reclaims by expiry and re-fences before (optionally)
+                // aborting it. Do not release — expiry is the reclaim signal.
+                tracing::warn!(
+                    "farm '{farm_id}': child on '{}' exceeded ttl {:?} — reclaiming",
+                    sub.id,
+                    caps.subtask_ttl
+                );
+                stalled_child = Some(child);
+            }
+        }
+    }
+
+    // Out of attempts (or aborted): reap a still-stalled child.
+    if let Some(old) = stalled_child.take() {
+        old.abort();
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinator::durable::DurableLeaseTable;
+
+    fn shared_leases(dir: &std::path::Path) -> SharedLeases {
+        Arc::new(tokio::sync::Mutex::new(
+            DurableLeaseTable::open(&dir.join("coordinator")).unwrap(),
+        ))
+    }
+
+    fn spec(subs: &[(&str, &str)]) -> FarmSpec {
+        FarmSpec {
+            id: "f1".into(),
+            description: "test farm".into(),
+            subtasks: subs
+                .iter()
+                .map(|(id, prompt)| SubtaskSpec {
+                    id: (*id).into(),
+                    prompt: (*prompt).into(),
+                })
+                .collect(),
+            synthesis: None,
+        }
+    }
+
+    fn caps(ttl_ms: u64, reclaim_abort: bool) -> FarmCaps {
+        FarmCaps {
+            max_concurrency: 3,
+            max_attempts: 2,
+            subtask_ttl: Duration::from_millis(ttl_ms),
+            reclaim_abort,
+        }
+    }
+
+    /// AC20: concurrent subtasks, unique tokens, all results present.
+    #[tokio::test]
+    async fn farm_runs_all_subtasks_and_collects_results() {
+        let dir = tempfile::tempdir().unwrap();
+        let leases = shared_leases(dir.path());
+        let outcome = run_farm(
+            Arc::clone(&leases),
+            "tenure-1",
+            dir.path().to_path_buf(),
+            spec(&[("a", "pa"), ("b", "pb"), ("c", "pc")]),
+            caps(5_000, true),
+            |sub: SubtaskSpec| async move { Ok(format!("done:{}", sub.id)) },
+        )
+        .await;
+
+        assert_eq!(outcome.results.len(), 3);
+        assert!(outcome.failed.is_empty());
+        assert_eq!(outcome.late_fenced, 0);
+        let mut texts: Vec<_> = outcome.results.iter().map(|r| r.text.clone()).collect();
+        texts.sort();
+        assert_eq!(texts, vec!["done:a", "done:b", "done:c"]);
+        // Tokens were minted per subtask resource (watermarks exist).
+        let table = leases.lock().await;
+        for sub in ["a", "b", "c"] {
+            assert!(table.table().watermark(&format!("farm-f1-{sub}")).is_some());
+        }
+    }
+
+    /// AC21 + AC22 (spec Stage 3 exit): a stalled child is reclaimed under a
+    /// strictly higher token; its LATE commit is rejected by fencing; the
+    /// outcome carries exactly one result — the successor's.
+    #[tokio::test]
+    async fn reclaimed_child_late_result_is_fenced_and_parent_uncorrupted() {
+        let dir = tempfile::tempdir().unwrap();
+        let leases = shared_leases(dir.path());
+
+        // Attempt 1 stalls past the 200ms ttl and finishes late (600ms);
+        // attempt 2 completes promptly. reclaim_abort=false lets the stale
+        // child live long enough to actually hit the fence.
+        let attempt = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let attempt_c = Arc::clone(&attempt);
+        let outcome = run_farm(
+            Arc::clone(&leases),
+            "tenure-1",
+            dir.path().to_path_buf(),
+            spec(&[("slow", "p")]),
+            caps(200, false),
+            move |_sub: SubtaskSpec| {
+                let n = attempt_c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                async move {
+                    if n == 0 {
+                        tokio::time::sleep(Duration::from_millis(600)).await;
+                        Ok("STALE result from reclaimed child".to_string())
+                    } else {
+                        Ok("fresh result".to_string())
+                    }
+                }
+            },
+        )
+        .await;
+
+        // Give the stale child time to fire its late commit before asserting.
+        tokio::time::sleep(Duration::from_millis(600)).await;
+
+        assert_eq!(outcome.results.len(), 1, "exactly one result");
+        assert_eq!(outcome.results[0].text, "fresh result");
+        assert_eq!(outcome.results[0].attempts, 2);
+        assert_eq!(outcome.reclaims, 1);
+        // Token strictly increased across the reclaim.
+        let table = leases.lock().await;
+        assert!(table.table().watermark("farm-f1-slow").unwrap() >= FencingToken(2));
+    }
+
+    /// The late-fenced counter observes the rejection when the stale child
+    /// commits after the farm reports (deterministic ordering variant).
+    #[tokio::test]
+    async fn late_commit_is_observably_fenced() {
+        let results = Arc::new(FarmResults::new());
+
+        // Simulate the exact interleaving at the store level: attempt 1
+        // fenced at token 1; reclaim re-fences at token 2 BEFORE the stale
+        // child commits; stale commit rejected; successor accepted.
+        results.fence_at("s", FencingToken(1)).await;
+        results.fence_at("s", FencingToken(2)).await;
+        assert!(!results.commit("s", FencingToken(1), "stale".into()).await);
+        assert!(results.commit("s", FencingToken(2), "fresh".into()).await);
+        assert_eq!(results.take("s").await.as_deref(), Some("fresh"));
+        assert_eq!(
+            results
+                .late_fenced
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+    }
+
+    /// AC23: entering isolation abandons the farm — no commits after.
+    #[tokio::test]
+    async fn isolation_abandons_the_farm() {
+        let dir = tempfile::tempdir().unwrap();
+        let leases = shared_leases(dir.path());
+        crate::server::isolation::enter(dir.path(), "test", None).unwrap();
+
+        let outcome = run_farm(
+            leases,
+            "tenure-1",
+            dir.path().to_path_buf(),
+            spec(&[("a", "p")]),
+            caps(1_000, true),
+            |_sub: SubtaskSpec| async move { Ok("should never land".to_string()) },
+        )
+        .await;
+
+        assert!(outcome.results.is_empty());
+        assert_eq!(outcome.failed, vec!["a".to_string()]);
+    }
+
+    /// Executor errors retry and then fail cleanly (no result, no panic).
+    #[tokio::test]
+    async fn failing_executor_exhausts_attempts() {
+        let dir = tempfile::tempdir().unwrap();
+        let leases = shared_leases(dir.path());
+        let outcome = run_farm(
+            leases,
+            "tenure-1",
+            dir.path().to_path_buf(),
+            spec(&[("a", "p")]),
+            caps(2_000, true),
+            |_sub: SubtaskSpec| async move { Err("provider exploded".to_string()) },
+        )
+        .await;
+        assert!(outcome.results.is_empty());
+        assert_eq!(outcome.failed, vec!["a".to_string()]);
+    }
+}

--- a/src/coordinator/farm.rs
+++ b/src/coordinator/farm.rs
@@ -357,6 +357,154 @@ where
     None
 }
 
+/// Parse and run a `[FARM: {json}]` marker under the current tenure. Returns
+/// the farm's composed result text (synthesized when the spec asks for it),
+/// or an error string for the caller to log. Children run WITHOUT tools —
+/// bounded reasoning work; anything that needs side effects is not a farm.
+pub async fn run_farm_from_marker(
+    farm_json: &str,
+    state: &Arc<crate::server::AppState>,
+    tenure: &super::control::TenureLeases,
+) -> Result<String, String> {
+    let spec: FarmSpec =
+        serde_json::from_str(farm_json).map_err(|e| format!("invalid [FARM:] json: {e}"))?;
+    if spec.subtasks.is_empty() {
+        return Err("farm has no subtasks".to_string());
+    }
+    if spec.subtasks.len() > MAX_SUBTASKS {
+        return Err(format!(
+            "farm has {} subtasks (max {MAX_SUBTASKS})",
+            spec.subtasks.len()
+        ));
+    }
+    {
+        let mut ids: Vec<&str> = spec.subtasks.iter().map(|s| s.id.as_str()).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        if ids.len() != spec.subtasks.len() {
+            return Err("duplicate subtask ids".to_string());
+        }
+    }
+
+    let system_prompt = crate::server::prompt::build_task_system_prompt_async(
+        state.root_dir.clone(),
+        state.config.clone(),
+    )
+    .await
+    .map_err(|e| format!("cannot build farm system prompt: {e}"))?;
+
+    let synthesis = spec.synthesis.clone();
+    let description = spec.description.clone();
+    let farm_label = spec.id.clone();
+    let max_tokens = state.config.llm.max_tokens;
+
+    let exec_state = Arc::clone(state);
+    let exec_prompt = system_prompt.clone();
+    let executor = move |sub: SubtaskSpec| {
+        let state = Arc::clone(&exec_state);
+        let system_prompt = exec_prompt.clone();
+        async move {
+            let messages = vec![pulse_system_types::llm::Message {
+                role: pulse_system_types::llm::Role::User,
+                content: pulse_system_types::llm::MessageContent::Text(sub.prompt),
+                source: None,
+            }];
+            let response = state
+                .provider
+                .invoke(&system_prompt, &messages, max_tokens, None)
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(response_text(&response))
+        }
+    };
+
+    let outcome = run_farm(
+        Arc::clone(&tenure.leases),
+        &tenure.holder,
+        state.root_dir.clone(),
+        spec,
+        FarmCaps::default(),
+        executor,
+    )
+    .await;
+
+    if outcome.results.is_empty() {
+        return Err(format!(
+            "farm '{farm_label}' produced no results (failed: {:?})",
+            outcome.failed
+        ));
+    }
+
+    let mut composed = String::new();
+    for r in &outcome.results {
+        composed.push_str(&format!(
+            "## {}
+{}
+
+",
+            r.sub_id, r.text
+        ));
+    }
+    if !outcome.failed.is_empty() {
+        composed.push_str(&format!(
+            "(failed subtasks: {:?})
+",
+            outcome.failed
+        ));
+    }
+
+    let final_text = match synthesis {
+        Some(template) => {
+            let prompt = template.replace("{results}", &composed);
+            let messages = vec![pulse_system_types::llm::Message {
+                role: pulse_system_types::llm::Role::User,
+                content: pulse_system_types::llm::MessageContent::Text(prompt),
+                source: None,
+            }];
+            match state
+                .provider
+                .invoke(&system_prompt, &messages, max_tokens, None)
+                .await
+            {
+                Ok(response) => response_text(&response),
+                Err(e) => {
+                    tracing::warn!(
+                        "farm '{farm_label}': synthesis failed ({e}); using raw results"
+                    );
+                    composed
+                }
+            }
+        }
+        None => composed,
+    };
+
+    crate::logbook::write_entry(
+        &state.root_dir,
+        "Farm",
+        &description,
+        &format!(
+            "{} subtask(s), {} reclaim(s), {} late-fenced",
+            outcome.results.len(),
+            outcome.reclaims,
+            outcome.late_fenced
+        ),
+    );
+
+    Ok(final_text)
+}
+
+fn response_text(response: &pulse_system_types::llm::LlmResponse) -> String {
+    response
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            pulse_system_types::llm::ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/coordinator/farm.rs
+++ b/src/coordinator/farm.rs
@@ -6,17 +6,33 @@
 //! farming needed one, Stage 0 was incomplete (spec decision 6).
 //!
 //! Mechanics per subtask:
-//! - each attempt acquires the lease `farm-{farm}-{sub}` under an
-//!   attempt-scoped holder, minting a strictly higher fencing token;
-//! - the result store holds one `FencedResource` guard per subtask, fenced
-//!   AT the current attempt's token before the child runs — so a stalled
-//!   predecessor's commit is rejected in every interleaving, including the
-//!   window before the new child commits;
+//! - each attempt acquires the lease `farm-{farm}-s{index}` (index-keyed:
+//!   LLM-chosen subtask ids never collide or overflow at the lease layer)
+//!   under an attempt-scoped holder, minting a strictly higher fencing
+//!   token;
+//! - the result store holds one `FencedResource` guard per subtask, raised
+//!   TO the current attempt's token before the child runs — a stalled
+//!   predecessor's commit is rejected in every interleaving — and a
+//!   controller only trusts a commit made under its OWN token;
 //! - a child that outlives its lease ttl is reclaimed: the next attempt's
 //!   acquire (over the expired lease) mints a higher token, the guard is
-//!   re-fenced, and the old child is aborted (`kill_on_drop` reaps the CLI
-//!   subprocess). Its late result, if it slips through before the abort
-//!   lands, presents a stale token and is fenced.
+//!   raised, and the old child is aborted (`kill_on_drop` reaps the CLI
+//!   subprocess). Its late result, if it fires first, presents a stale
+//!   token and is fenced.
+//!
+//! Lifetime discipline: every spawned task (controllers and children) sits
+//! behind an abort-on-drop guard, so dropping `run_farm`'s future — tenure
+//! loss, shutdown, the wall-budget deadline — reaps the whole farm,
+//! provider subprocesses included. Leases a killed farm leaves behind are
+//! released by the coordinator's stale-claim sweep at the next leadership
+//! acquisition.
+//!
+//! Budgets: `wall_budget` (default 20min) keeps a farm inside its parent
+//! task's 30min lease; `subtask_ttl` (default 16min) sits above the
+//! provider's 15min subprocess timeout so a slow-but-legitimate child is
+//! not reclaimed while its subprocess is still within budget. The lease
+//! stall path depends on a non-decreasing wall clock (documented Stage 0
+//! precondition).
 //!
 //! The executor is injected, so all of this is deterministic under test and
 //! provider-free; production passes a closure that invokes the LmProvider.
@@ -57,14 +73,18 @@ pub struct FarmSpec {
     pub synthesis: Option<String>,
 }
 
-/// Execution knobs. Defaults are production values; tests shrink the ttl and
-/// may disable reclaim-abort to let a stalled child run long enough to prove
-/// its late commit is fenced.
+/// Execution knobs. Defaults are production values; tests shrink the
+/// durations and may disable reclaim-abort to let a stalled child run long
+/// enough to prove its late commit is fenced.
 #[derive(Debug, Clone)]
 pub struct FarmCaps {
     pub max_concurrency: usize,
     pub max_attempts: u32,
+    /// Per-attempt lease ttl. Must exceed the provider's own subprocess
+    /// timeout (15min) or legitimately slow children get reclaimed mid-work.
     pub subtask_ttl: Duration,
+    /// Whole-farm wall budget — keeps a farm inside its parent's lease.
+    pub wall_budget: Duration,
     /// Abort a reclaimed child (production). `false` only in tests that
     /// deliberately let the stale child finish and hit the fence.
     pub reclaim_abort: bool,
@@ -75,7 +95,8 @@ impl Default for FarmCaps {
         Self {
             max_concurrency: 3,
             max_attempts: 2,
-            subtask_ttl: Duration::from_secs(10 * 60),
+            subtask_ttl: Duration::from_secs(16 * 60),
+            wall_budget: Duration::from_secs(20 * 60),
             reclaim_abort: true,
         }
     }
@@ -91,7 +112,7 @@ pub struct SubtaskResult {
 #[derive(Debug)]
 pub struct FarmOutcome {
     pub results: Vec<SubtaskResult>,
-    /// Subtasks that failed every attempt (or were cut off by abort).
+    /// Subtasks that failed every attempt (or were cut off by the budget).
     pub failed: Vec<String>,
     /// Late commits from reclaimed children rejected by fencing — the spec's
     /// Stage 3 exit criterion made observable.
@@ -100,10 +121,22 @@ pub struct FarmOutcome {
     pub reclaims: u32,
 }
 
+/// A spawned task aborted when dropped — nothing in a farm outlives the
+/// farm's future.
+struct AbortOnDrop<T>(tokio::task::JoinHandle<T>);
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 /// Fenced result store: the ONLY place child output lands, guarded per
-/// subtask by a Stage 0 `FencedResource`.
+/// subtask by a Stage 0 `FencedResource`. Results carry the committing
+/// token so a controller can distinguish its own attempt's commit.
 struct FarmResults {
-    inner: Mutex<HashMap<String, (FencedResource, Option<String>)>>,
+    #[allow(clippy::type_complexity)]
+    inner: Mutex<HashMap<String, (FencedResource, Option<(FencingToken, String)>)>>,
     late_fenced: std::sync::atomic::AtomicU32,
 }
 
@@ -115,15 +148,16 @@ impl FarmResults {
         }
     }
 
-    /// Raise the subtask's fence to `token` — called at every attempt's
-    /// acquire, BEFORE the child runs. Tokens are strictly increasing across
-    /// attempts, so this only ever raises.
-    async fn fence_at(&self, sub_id: &str, token: FencingToken) {
+    /// Raise the subtask's fence to at least `token` — called at every
+    /// attempt's acquire, BEFORE the child runs. Never lowers: a stale or
+    /// duplicate caller cannot un-fence a newer epoch.
+    async fn raise_fence(&self, sub_id: &str, token: FencingToken) {
         let mut inner = self.inner.lock().await;
         let entry = inner
             .entry(sub_id.to_string())
             .or_insert_with(|| (FencedResource::new(), None));
-        entry.0 = FencedResource::at(token);
+        let target = entry.0.high_water().map_or(token, |high| high.max(token));
+        entry.0 = FencedResource::at(target);
     }
 
     /// Commit a child's result under its token. A stale (reclaimed) child is
@@ -135,7 +169,7 @@ impl FarmResults {
             .or_insert_with(|| (FencedResource::new(), None));
         match entry.0.accept(token) {
             Ok(()) => {
-                entry.1 = Some(text);
+                entry.1 = Some((token, text));
                 true
             }
             Err(rejected) => {
@@ -149,17 +183,20 @@ impl FarmResults {
         }
     }
 
-    async fn take(&self, sub_id: &str) -> Option<String> {
-        self.inner
-            .lock()
-            .await
-            .get_mut(sub_id)
-            .and_then(|(_, r)| r.take())
+    /// Take the result iff it was committed under `token` — a controller
+    /// only trusts its own attempt's commit.
+    async fn take_if_token(&self, sub_id: &str, token: FencingToken) -> Option<String> {
+        let mut inner = self.inner.lock().await;
+        let entry = inner.get_mut(sub_id)?;
+        match &entry.1 {
+            Some((t, _)) if *t == token => entry.1.take().map(|(_, text)| text),
+            _ => None,
+        }
     }
 }
 
-/// Run a farm to completion. The executor is one child attempt: it receives
-/// the subtask spec and returns the child's text (or an error string).
+/// Run a farm to completion (or its wall budget). The executor is one child
+/// attempt: it receives the subtask spec and returns the child's text.
 pub async fn run_farm<F, Fut>(
     leases: SharedLeases,
     tenure_holder: &str,
@@ -177,10 +214,32 @@ where
     let semaphore = Arc::new(Semaphore::new(caps.max_concurrency.max(1)));
     let reclaims = Arc::new(std::sync::atomic::AtomicU32::new(0));
 
-    let subtasks: Vec<SubtaskSpec> = spec.subtasks.into_iter().take(MAX_SUBTASKS).collect();
-    let mut controllers = Vec::new();
+    let mut outcome = FarmOutcome {
+        results: Vec::new(),
+        failed: Vec::new(),
+        late_fenced: 0,
+        reclaims: 0,
+    };
 
-    for sub in subtasks.iter().cloned() {
+    // Dedup here too (the direct API must not rely on the marker path's
+    // validation): a duplicate id would share a results key across distinct
+    // lease resources and confuse token scoping.
+    let mut seen = std::collections::HashSet::new();
+    let mut subtasks: Vec<SubtaskSpec> = Vec::new();
+    for sub in spec.subtasks.into_iter().take(MAX_SUBTASKS) {
+        if seen.insert(sub.id.clone()) {
+            subtasks.push(sub);
+        } else {
+            tracing::warn!(
+                "farm '{farm_id}': duplicate subtask id '{}' dropped",
+                sub.id
+            );
+            outcome.failed.push(sub.id);
+        }
+    }
+
+    let mut controllers: Vec<(AbortOnDrop<ControllerOutput>, SubtaskSpec)> = Vec::new();
+    for (index, sub) in subtasks.into_iter().enumerate() {
         let leases = Arc::clone(&leases);
         let results = Arc::clone(&results);
         let semaphore = Arc::clone(&semaphore);
@@ -190,8 +249,9 @@ where
         let root_dir = root_dir.clone();
         let tenure_holder = tenure_holder.to_string();
         let farm_id = farm_id.clone();
+        let sub_for_task = sub.clone();
 
-        controllers.push(tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             subtask_controller(
                 leases,
                 results,
@@ -202,30 +262,42 @@ where
                 root_dir,
                 tenure_holder,
                 farm_id,
-                sub,
+                index,
+                sub_for_task,
             )
             .await
-        }));
+        });
+        controllers.push((AbortOnDrop(handle), sub));
     }
 
-    let mut outcome = FarmOutcome {
-        results: Vec::new(),
-        failed: Vec::new(),
-        late_fenced: 0,
-        reclaims: 0,
-    };
-
-    for (controller, sub) in controllers.into_iter().zip(subtasks.iter()) {
-        let attempts = controller.await.unwrap_or(None);
-        match (attempts, results.take(&sub.id).await) {
-            (Some(attempts), Some(text)) => outcome.results.push(SubtaskResult {
+    // Join under the wall budget. Past the deadline every remaining
+    // controller — and, via its guards, every remaining child — is aborted
+    // by drop: the farm cannot outrun its parent's lease.
+    let deadline = tokio::time::Instant::now() + caps.wall_budget;
+    for (mut controller, sub) in controllers {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let joined = tokio::time::timeout(remaining, &mut controller.0).await;
+        let output = match joined {
+            Ok(join_result) => join_result.ok().flatten(),
+            Err(_) => {
+                tracing::warn!(
+                    "farm '{farm_id}': wall budget {:?} exhausted — aborting '{}'",
+                    caps.wall_budget,
+                    sub.id
+                );
+                None
+            }
+        };
+        match output {
+            Some((attempts, text)) => outcome.results.push(SubtaskResult {
                 sub_id: sub.id.clone(),
                 text,
                 attempts,
             }),
-            _ => outcome.failed.push(sub.id.clone()),
+            None => outcome.failed.push(sub.id.clone()),
         }
     }
+
     outcome.late_fenced = results
         .late_fenced
         .load(std::sync::atomic::Ordering::Relaxed);
@@ -233,8 +305,11 @@ where
     outcome
 }
 
-/// Drive one subtask through its attempts. Returns Some(attempt_count) when
-/// a result was committed, None when every attempt failed.
+type ControllerOutput = Option<(u32, String)>;
+
+/// Drive one subtask through its attempts. Returns the attempt count and
+/// the committed text — taken from the store only under this attempt's own
+/// token, so a stale predecessor's commit can never masquerade as ours.
 #[allow(clippy::too_many_arguments)]
 async fn subtask_controller<F, Fut>(
     leases: SharedLeases,
@@ -246,14 +321,17 @@ async fn subtask_controller<F, Fut>(
     root_dir: PathBuf,
     tenure_holder: String,
     farm_id: String,
+    index: usize,
     sub: SubtaskSpec,
-) -> Option<u32>
+) -> ControllerOutput
 where
     F: Fn(SubtaskSpec) -> Fut + Send + Sync + Clone + 'static,
     Fut: std::future::Future<Output = Result<String, String>> + Send + 'static,
 {
-    let resource = format!("farm-{farm_id}-{}", lease_safe(&sub.id));
-    let mut stalled_child: Option<tokio::task::JoinHandle<()>> = None;
+    // Index-keyed: LLM-chosen ids can neither collide nor overflow the
+    // lease id budget once composed with the farm id.
+    let resource = format!("farm-{farm_id}-s{index}");
+    let mut stalled_child: Option<AbortOnDrop<bool>> = None;
 
     for attempt in 1..=caps.max_attempts {
         // Shed with everything else: a farm never outlives isolation entry.
@@ -262,36 +340,35 @@ where
                 "farm '{farm_id}': ISOLATION active — abandoning '{}'",
                 sub.id
             );
-            break;
+            return None;
         }
 
         // Acquire (attempt 1) or reclaim-by-expiry (attempt >1: the previous
         // child stalled past its ttl; this acquire mints a higher token).
         let holder = format!("{tenure_holder}-a{attempt}");
-        let lease = {
+        let acquired = {
             leases
                 .lock()
                 .await
                 .acquire(&resource, &holder, caps.subtask_ttl, Utc::now())
         };
-        let lease = match lease {
+        let lease = match acquired {
             Ok(lease) => lease,
             Err(e) => {
                 tracing::warn!("farm '{farm_id}': claim failed on '{}': {e}", sub.id);
-                break;
+                return None;
             }
         };
 
-        // Fence BEFORE the child runs: from this instant, any commit bearing
-        // an older token — a stalled predecessor waking up — is rejected,
-        // regardless of interleaving.
-        results.fence_at(&sub.id, lease.fencing_token).await;
+        // Raise the fence BEFORE the child runs: from this instant any
+        // commit bearing an older token — a stalled predecessor waking up —
+        // is rejected, regardless of interleaving.
+        results.raise_fence(&sub.id, lease.fencing_token).await;
         if attempt > 1 {
             reclaims.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             if caps.reclaim_abort {
-                if let Some(old) = stalled_child.take() {
-                    old.abort();
-                }
+                // Guard drop aborts the child; kill_on_drop reaps the CLI.
+                stalled_child = None;
             }
         }
 
@@ -303,57 +380,65 @@ where
             let executor = executor.clone();
             let sub = sub.clone();
             let token = lease.fencing_token;
-            tokio::spawn(async move {
+            AbortOnDrop(tokio::spawn(async move {
                 let _permit = permit;
-                if let Ok(text) = executor(sub.clone()).await {
-                    results.commit(&sub.id, token, text).await;
+                match executor(sub.clone()).await {
+                    Ok(text) => results.commit(&sub.id, token, text).await,
+                    Err(e) => {
+                        tracing::warn!("farm child '{}' failed: {e}", sub.id);
+                        false
+                    }
                 }
-            })
+            }))
         };
 
         // Wait out this attempt's lease window. select (not timeout) so the
-        // JoinHandle survives a stall — a dropped handle would detach the
-        // child beyond reach of the reclaim abort.
-        let finished = tokio::select! {
-            _ = &mut child => true,
-            () = tokio::time::sleep(caps.subtask_ttl) => false,
+        // guard survives a stall — the handle must stay reachable for the
+        // reclaim abort, and abort-on-drop must cover farm teardown.
+        let finished: Option<bool> = tokio::select! {
+            joined = &mut child.0 => Some(joined.unwrap_or(false)),
+            () = tokio::time::sleep(caps.subtask_ttl) => None,
         };
+
         match finished {
-            true => {
-                // Child finished (ok or executor error) within its lease.
-                let committed = {
-                    results
-                        .inner
-                        .lock()
-                        .await
-                        .get(&sub.id)
-                        .is_some_and(|(_, r)| r.is_some())
-                };
+            Some(committed) => {
                 let _ = { leases.lock().await.release(&resource, &holder, Utc::now()) };
                 if committed {
-                    return Some(attempt);
+                    // Only OUR token's commit counts — a stale predecessor's
+                    // text under an older token is invisible here.
+                    if let Some(text) = results.take_if_token(&sub.id, lease.fencing_token).await {
+                        // Test determinism: with reclaim-abort disabled, a
+                        // still-running stale child gets its lease window to
+                        // fire (and be fenced) before the farm reports.
+                        if let Some(mut old) = stalled_child.take() {
+                            if !caps.reclaim_abort {
+                                let _ = tokio::time::timeout(caps.subtask_ttl, &mut old.0).await;
+                            }
+                        }
+                        return Some((attempt, text));
+                    }
                 }
-                // Executor error: retry on the next attempt (fresh acquire —
-                // the lease was released, watermark still climbs).
+                // Executor error (or a commit that wasn't ours): retry on
+                // the next attempt — the lease was released, the watermark
+                // still climbs.
             }
-            false => {
-                // Stalled past the ttl: keep the handle; the NEXT attempt's
-                // acquire reclaims by expiry and re-fences before (optionally)
-                // aborting it. Do not release — expiry is the reclaim signal.
+            None => {
+                // Stalled past the ttl: keep the guard; the NEXT attempt's
+                // acquire reclaims by expiry and raises the fence before
+                // (optionally) aborting it. Do not release — expiry is the
+                // reclaim signal. If this was the last attempt, the guard's
+                // drop reaps the child on return.
                 tracing::warn!(
                     "farm '{farm_id}': child on '{}' exceeded ttl {:?} — reclaiming",
                     sub.id,
                     caps.subtask_ttl
                 );
                 stalled_child = Some(child);
+                continue;
             }
         }
     }
 
-    // Out of attempts (or aborted): reap a still-stalled child.
-    if let Some(old) = stalled_child.take() {
-        old.abort();
-    }
     None
 }
 
@@ -376,14 +461,6 @@ pub async fn run_farm_from_marker(
             "farm has {} subtasks (max {MAX_SUBTASKS})",
             spec.subtasks.len()
         ));
-    }
-    {
-        let mut ids: Vec<&str> = spec.subtasks.iter().map(|s| s.id.as_str()).collect();
-        ids.sort_unstable();
-        ids.dedup();
-        if ids.len() != spec.subtasks.len() {
-            return Err("duplicate subtask ids".to_string());
-        }
     }
 
     let system_prompt = crate::server::prompt::build_task_system_prompt_async(
@@ -437,20 +514,10 @@ pub async fn run_farm_from_marker(
 
     let mut composed = String::new();
     for r in &outcome.results {
-        composed.push_str(&format!(
-            "## {}
-{}
-
-",
-            r.sub_id, r.text
-        ));
+        composed.push_str(&format!("## {}\n{}\n\n", r.sub_id, r.text));
     }
     if !outcome.failed.is_empty() {
-        composed.push_str(&format!(
-            "(failed subtasks: {:?})
-",
-            outcome.failed
-        ));
+        composed.push_str(&format!("(failed subtasks: {:?})\n", outcome.failed));
     }
 
     let final_text = match synthesis {
@@ -536,6 +603,7 @@ mod tests {
             max_concurrency: 3,
             max_attempts: 2,
             subtask_ttl: Duration::from_millis(ttl_ms),
+            wall_budget: Duration::from_secs(30),
             reclaim_abort,
         }
     }
@@ -550,7 +618,7 @@ mod tests {
             "tenure-1",
             dir.path().to_path_buf(),
             spec(&[("a", "pa"), ("b", "pb"), ("c", "pc")]),
-            caps(5_000, true),
+            caps(10_000, true),
             |sub: SubtaskSpec| async move { Ok(format!("done:{}", sub.id)) },
         )
         .await;
@@ -561,24 +629,26 @@ mod tests {
         let mut texts: Vec<_> = outcome.results.iter().map(|r| r.text.clone()).collect();
         texts.sort();
         assert_eq!(texts, vec!["done:a", "done:b", "done:c"]);
-        // Tokens were minted per subtask resource (watermarks exist).
+        // Tokens were minted per index-keyed subtask resource.
         let table = leases.lock().await;
-        for sub in ["a", "b", "c"] {
-            assert!(table.table().watermark(&format!("farm-f1-{sub}")).is_some());
+        for i in 0..3 {
+            assert!(table.table().watermark(&format!("farm-f1-s{i}")).is_some());
         }
     }
 
     /// AC21 + AC22 (spec Stage 3 exit): a stalled child is reclaimed under a
-    /// strictly higher token; its LATE commit is rejected by fencing; the
-    /// outcome carries exactly one result — the successor's.
+    /// strictly higher token; its LATE result is rejected by fencing —
+    /// observable in the outcome — and exactly one result survives: the
+    /// successor's.
     #[tokio::test]
     async fn reclaimed_child_late_result_is_fenced_and_parent_uncorrupted() {
         let dir = tempfile::tempdir().unwrap();
         let leases = shared_leases(dir.path());
 
-        // Attempt 1 stalls past the 200ms ttl and finishes late (600ms);
-        // attempt 2 completes promptly. reclaim_abort=false lets the stale
-        // child live long enough to actually hit the fence.
+        // Attempt 1 stalls past the 1s ttl and finishes at 1.8s; attempt 2
+        // completes promptly. reclaim_abort=false keeps the stale child
+        // alive, and the controller waits for it to hit the fence before the
+        // farm reports — so late_fenced is asserted, not assumed.
         let attempt = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let attempt_c = Arc::clone(&attempt);
         let outcome = run_farm(
@@ -586,12 +656,12 @@ mod tests {
             "tenure-1",
             dir.path().to_path_buf(),
             spec(&[("slow", "p")]),
-            caps(200, false),
+            caps(1_000, false),
             move |_sub: SubtaskSpec| {
                 let n = attempt_c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 async move {
                     if n == 0 {
-                        tokio::time::sleep(Duration::from_millis(600)).await;
+                        tokio::time::sleep(Duration::from_millis(1_800)).await;
                         Ok("STALE result from reclaimed child".to_string())
                     } else {
                         Ok("fresh result".to_string())
@@ -601,32 +671,37 @@ mod tests {
         )
         .await;
 
-        // Give the stale child time to fire its late commit before asserting.
-        tokio::time::sleep(Duration::from_millis(600)).await;
-
         assert_eq!(outcome.results.len(), 1, "exactly one result");
         assert_eq!(outcome.results[0].text, "fresh result");
         assert_eq!(outcome.results[0].attempts, 2);
         assert_eq!(outcome.reclaims, 1);
+        assert_eq!(
+            outcome.late_fenced, 1,
+            "the stale commit must hit the fence"
+        );
         // Token strictly increased across the reclaim.
         let table = leases.lock().await;
-        assert!(table.table().watermark("farm-f1-slow").unwrap() >= FencingToken(2));
+        assert!(table.table().watermark("farm-f1-s0").unwrap() >= FencingToken(2));
     }
 
-    /// The late-fenced counter observes the rejection when the stale child
-    /// commits after the farm reports (deterministic ordering variant).
+    /// Store-level pin of the exact interleaving, incl. that a fence can
+    /// never be lowered and a controller only takes its own token's result.
     #[tokio::test]
-    async fn late_commit_is_observably_fenced() {
+    async fn late_commit_is_observably_fenced_and_token_scoped() {
         let results = Arc::new(FarmResults::new());
 
-        // Simulate the exact interleaving at the store level: attempt 1
-        // fenced at token 1; reclaim re-fences at token 2 BEFORE the stale
-        // child commits; stale commit rejected; successor accepted.
-        results.fence_at("s", FencingToken(1)).await;
-        results.fence_at("s", FencingToken(2)).await;
+        results.raise_fence("s", FencingToken(1)).await;
+        results.raise_fence("s", FencingToken(2)).await;
+        // Attempting to lower the fence is a no-op.
+        results.raise_fence("s", FencingToken(1)).await;
         assert!(!results.commit("s", FencingToken(1), "stale".into()).await);
         assert!(results.commit("s", FencingToken(2), "fresh".into()).await);
-        assert_eq!(results.take("s").await.as_deref(), Some("fresh"));
+        // A controller holding token 1 cannot take token 2's result.
+        assert!(results.take_if_token("s", FencingToken(1)).await.is_none());
+        assert_eq!(
+            results.take_if_token("s", FencingToken(2)).await.as_deref(),
+            Some("fresh")
+        );
         assert_eq!(
             results
                 .late_fenced
@@ -671,6 +746,48 @@ mod tests {
         )
         .await;
         assert!(outcome.results.is_empty());
+        assert_eq!(outcome.failed, vec!["a".to_string()]);
+    }
+
+    /// The wall budget aborts a farm that would outrun its parent's lease.
+    #[tokio::test]
+    async fn wall_budget_bounds_the_farm() {
+        let dir = tempfile::tempdir().unwrap();
+        let leases = shared_leases(dir.path());
+        let mut c = caps(10_000, true);
+        c.wall_budget = Duration::from_millis(300);
+        let outcome = run_farm(
+            leases,
+            "tenure-1",
+            dir.path().to_path_buf(),
+            spec(&[("a", "p")]),
+            c,
+            |_sub: SubtaskSpec| async move {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                Ok("too late".to_string())
+            },
+        )
+        .await;
+        assert!(outcome.results.is_empty());
+        assert_eq!(outcome.failed, vec!["a".to_string()]);
+    }
+
+    /// Duplicate subtask ids are dropped (kept once), not silently collided.
+    #[tokio::test]
+    async fn duplicate_subtask_ids_are_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let leases = shared_leases(dir.path());
+        let outcome = run_farm(
+            leases,
+            "tenure-1",
+            dir.path().to_path_buf(),
+            spec(&[("a", "p1"), ("a", "p2")]),
+            caps(5_000, true),
+            |sub: SubtaskSpec| async move { Ok(format!("done:{}", sub.prompt)) },
+        )
+        .await;
+        assert_eq!(outcome.results.len(), 1);
+        assert_eq!(outcome.results[0].text, "done:p1");
         assert_eq!(outcome.failed, vec!["a".to_string()]);
     }
 }

--- a/src/coordinator/fenced.rs
+++ b/src/coordinator/fenced.rs
@@ -4,15 +4,23 @@
 //! paused past lease expiry can still present a formerly-valid token — the
 //! resource, not the lease table, is the last line of defense: any write
 //! bearing a token below the highest it has seen is rejected.
+//!
+//! **Trust boundary:** the guard orders tokens; it cannot know which were
+//! actually issued. A holder presenting a never-issued high token (say
+//! `u64::MAX`) would fence every legitimate writer with no reset path.
+//! Holders are trusted to present only tokens the lease table granted them;
+//! Stage 1's wiring must cross-check presented tokens against the
+//! coordinator's watermark before they reach `accept`. Guard state is not
+//! yet persisted — rebuild after restart via `FencedResource::at` from the
+//! recovered watermark (same Stage 1 wiring).
 
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::lease::FencingToken;
 
 /// A write was fenced: the presented token is stale.
 #[derive(Debug, Error, PartialEq, Eq)]
-#[error("write fenced: presented token {presented:?} < high-water {high_water:?}")]
+#[error("write fenced: presented token {presented} < high-water {high_water}")]
 pub struct Rejected {
     pub presented: FencingToken,
     pub high_water: FencingToken,
@@ -20,8 +28,8 @@ pub struct Rejected {
 
 /// Per-resource fencing guard. One instance protects one resource; it tracks
 /// the highest token it has ever accepted, independent of the lease table
-/// (which may be down, restarted, or lagging — decision 3 in the spec).
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// (which may be down, restarted, or lagging).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FencedResource {
     high_water: Option<FencingToken>,
 }
@@ -32,7 +40,7 @@ impl FencedResource {
     }
 
     /// Rebuild a guard at a known watermark (e.g. after WAL recovery).
-    pub fn at(high_water: FencingToken) -> Self {
+    pub const fn at(high_water: FencingToken) -> Self {
         Self {
             high_water: Some(high_water),
         }
@@ -53,7 +61,7 @@ impl FencedResource {
         }
     }
 
-    pub fn high_water(&self) -> Option<FencingToken> {
+    pub const fn high_water(&self) -> Option<FencingToken> {
         self.high_water
     }
 }

--- a/src/coordinator/fenced.rs
+++ b/src/coordinator/fenced.rs
@@ -1,0 +1,114 @@
+//! Fencing enforcement at the protected resource.
+//!
+//! Leases bound intent; this guard enforces correctness. A holder that was
+//! paused past lease expiry can still present a formerly-valid token — the
+//! resource, not the lease table, is the last line of defense: any write
+//! bearing a token below the highest it has seen is rejected.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::lease::FencingToken;
+
+/// A write was fenced: the presented token is stale.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[error("write fenced: presented token {presented:?} < high-water {high_water:?}")]
+pub struct Rejected {
+    pub presented: FencingToken,
+    pub high_water: FencingToken,
+}
+
+/// Per-resource fencing guard. One instance protects one resource; it tracks
+/// the highest token it has ever accepted, independent of the lease table
+/// (which may be down, restarted, or lagging — decision 3 in the spec).
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FencedResource {
+    high_water: Option<FencingToken>,
+}
+
+impl FencedResource {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Rebuild a guard at a known watermark (e.g. after WAL recovery).
+    pub fn at(high_water: FencingToken) -> Self {
+        Self {
+            high_water: Some(high_water),
+        }
+    }
+
+    /// Admit or fence a write. Tokens equal to the high-water are admitted —
+    /// the same ownership epoch writes many times. Strictly lower is fenced.
+    pub fn accept(&mut self, token: FencingToken) -> Result<(), Rejected> {
+        match self.high_water {
+            Some(high) if token < high => Err(Rejected {
+                presented: token,
+                high_water: high,
+            }),
+            _ => {
+                self.high_water = Some(token);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn high_water(&self) -> Option<FencingToken> {
+        self.high_water
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_write_is_admitted_and_recorded() {
+        let mut guard = FencedResource::new();
+        assert!(guard.accept(FencingToken(1)).is_ok());
+        assert_eq!(guard.high_water(), Some(FencingToken(1)));
+    }
+
+    #[test]
+    fn same_epoch_writes_repeatedly() {
+        let mut guard = FencedResource::new();
+        guard.accept(FencingToken(3)).unwrap();
+        assert!(guard.accept(FencingToken(3)).is_ok());
+    }
+
+    #[test]
+    fn stale_token_is_fenced() {
+        let mut guard = FencedResource::new();
+        guard.accept(FencingToken(2)).unwrap();
+        let err = guard.accept(FencingToken(1)).unwrap_err();
+        assert_eq!(
+            err,
+            Rejected {
+                presented: FencingToken(1),
+                high_water: FencingToken(2),
+            }
+        );
+        assert_eq!(guard.high_water(), Some(FencingToken(2)));
+    }
+
+    #[test]
+    fn paused_holder_wakes_stale_and_is_rejected() {
+        // The race from spec decision 3, end to end at the resource:
+        // A holds token 1, pauses past expiry; B reclaims with token 2 and
+        // writes; A wakes and writes with 1 — fenced. B keeps writing fine.
+        let mut guard = FencedResource::new();
+        let a = FencingToken(1);
+        let b = FencingToken(2);
+        guard.accept(b).unwrap();
+        assert!(guard.accept(a).is_err());
+        assert!(guard.accept(b).is_ok());
+    }
+
+    #[test]
+    fn recovery_constructor_fences_below_watermark() {
+        let mut guard = FencedResource::at(FencingToken(7));
+        assert!(guard.accept(FencingToken(6)).is_err());
+        assert!(guard.accept(FencingToken(7)).is_ok());
+        assert!(guard.accept(FencingToken(8)).is_ok());
+    }
+}

--- a/src/coordinator/lease.rs
+++ b/src/coordinator/lease.rs
@@ -70,6 +70,7 @@ impl fmt::Display for FencingToken {
 
 /// A granted lease on a resource.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Lease {
     pub resource_id: String,
     pub holder_id: String,
@@ -187,6 +188,18 @@ pub enum ApplyError {
         resource_id: String,
         token: FencingToken,
         current: FencingToken,
+    },
+    #[error("renew of an expired lease on '{resource_id}' (expired {expired_at}, event ts {ts})")]
+    RenewedExpired {
+        resource_id: String,
+        expired_at: DateTime<Utc>,
+        ts: DateTime<Utc>,
+    },
+    #[error("implausible granted_at on '{resource_id}': {granted_at} vs event ts {ts}")]
+    ImplausibleGrantTime {
+        resource_id: String,
+        granted_at: DateTime<Utc>,
+        ts: DateTime<Utc>,
     },
     #[error("invalid lease in event: {0}")]
     InvalidLease(#[from] LeaseError),
@@ -326,8 +339,14 @@ impl LeaseTable {
     /// violation is an error — the caller (replay) fails closed.
     pub fn apply(&mut self, event: &LeaseEvent) -> Result<(), ApplyError> {
         match event {
-            LeaseEvent::Acquired { lease, .. } | LeaseEvent::Reclaimed { lease, .. } => {
-                Self::validate_event_lease(lease)?;
+            // Note: an `Acquired` over a live unexpired lease is accepted
+            // here even though the online path forbids it — replay cannot
+            // re-derive the online expiry decision (it used an injected
+            // `now`, not the event `ts`, and clocks skew across restarts).
+            // Safety holds regardless: the incoming token is strictly
+            // higher, so the displaced holder is fenced at the resource.
+            LeaseEvent::Acquired { ts, lease } | LeaseEvent::Reclaimed { ts, lease } => {
+                Self::validate_event_lease(lease, *ts)?;
                 if let Some(watermark) = self.watermark(&lease.resource_id) {
                     if lease.fencing_token <= watermark {
                         return Err(ApplyError::TokenRegression {
@@ -341,8 +360,8 @@ impl LeaseTable {
                 self.watermarks
                     .insert(lease.resource_id.clone(), lease.fencing_token);
             }
-            LeaseEvent::Renewed { lease, .. } => {
-                Self::validate_event_lease(lease)?;
+            LeaseEvent::Renewed { ts, lease } => {
+                Self::validate_event_lease(lease, *ts)?;
                 let current =
                     self.leases
                         .get(&lease.resource_id)
@@ -350,6 +369,16 @@ impl LeaseTable {
                             op: "renew",
                             resource_id: lease.resource_id.clone(),
                         })?;
+                // A renew of a lease already expired at the event's own ts
+                // would resurrect it with its original token and no
+                // watermark bump — a state the online path forbids.
+                if current.is_expired(*ts) {
+                    return Err(ApplyError::RenewedExpired {
+                        resource_id: lease.resource_id.clone(),
+                        expired_at: current.expires_at(),
+                        ts: *ts,
+                    });
+                }
                 if current.holder_id != lease.holder_id {
                     return Err(ApplyError::HolderMismatch {
                         op: "renew",
@@ -393,10 +422,22 @@ impl LeaseTable {
         Ok(())
     }
 
-    fn validate_event_lease(lease: &Lease) -> Result<(), LeaseError> {
+    fn validate_event_lease(lease: &Lease, ts: DateTime<Utc>) -> Result<(), ApplyError> {
         validate_id("resource", &lease.resource_id)?;
         validate_id("holder", &lease.holder_id)?;
-        validate_ttl(&lease.resource_id, lease.ttl)
+        validate_ttl(&lease.resource_id, lease.ttl)?;
+        // A grant time far from the append time has no online equivalent —
+        // an unbounded granted_at would let a forged line park a resource
+        // beyond any reclaim (its expiry saturating past every real clock).
+        let skew = (lease.granted_at - ts).abs();
+        if skew > TimeDelta::from_std(MAX_TTL).expect("MAX_TTL fits TimeDelta") {
+            return Err(ApplyError::ImplausibleGrantTime {
+                resource_id: lease.resource_id.clone(),
+                granted_at: lease.granted_at,
+                ts,
+            });
+        }
+        Ok(())
     }
 
     fn next_token(&self, resource_id: &str) -> Result<FencingToken, LeaseError> {
@@ -721,6 +762,49 @@ mod tests {
             ApplyError::HolderMismatch { .. }
         ));
         assert!(table.get("wal").is_some());
+    }
+
+    #[test]
+    fn apply_rejects_renew_of_expired_lease() {
+        let mut source = LeaseTable::new();
+        let lease = source.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+
+        let mut table = LeaseTable::new();
+        table.apply(&acquired(&lease)).unwrap();
+
+        // Renew stamped after expiry would resurrect the lease with its
+        // original token and no watermark bump.
+        let mut resurrected = lease.clone();
+        resurrected.granted_at = t0() + secs(100);
+        let err = table
+            .apply(&LeaseEvent::Renewed {
+                ts: t0() + secs(100),
+                lease: resurrected,
+            })
+            .unwrap_err();
+        assert!(matches!(err, ApplyError::RenewedExpired { .. }));
+    }
+
+    #[test]
+    fn apply_rejects_implausible_grant_time() {
+        // A forged granted_at far past the append ts would saturate expiry
+        // beyond any reclaim, parking the resource forever.
+        let mut table = LeaseTable::new();
+        let forged = Lease {
+            resource_id: "wal".to_string(),
+            holder_id: "echo-a".to_string(),
+            fencing_token: FencingToken(1),
+            granted_at: DateTime::<Utc>::MAX_UTC - secs(10),
+            ttl: secs(30),
+        };
+        let err = table
+            .apply(&LeaseEvent::Acquired {
+                ts: t0(),
+                lease: forged,
+            })
+            .unwrap_err();
+        assert!(matches!(err, ApplyError::ImplausibleGrantTime { .. }));
+        assert!(table.get("wal").is_none());
     }
 
     #[test]

--- a/src/coordinator/lease.rs
+++ b/src/coordinator/lease.rs
@@ -8,18 +8,65 @@
 //!
 //! Time is injected (`now` parameters) — expiry is never read from the wall
 //! clock inside this module, so tests control the clock deterministically.
+//! The injected clock must be non-decreasing across calls; a backwards `now`
+//! can un-expire a lease.
+//!
+//! `LeaseTable` alone is in-memory intent. Durability and the write-ahead
+//! ordering that makes fencing sound across crashes live in `durable.rs` —
+//! use `DurableLeaseTable` unless you are the replay path or a test.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::time::Duration;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+/// Longest ttl a lease may carry. Bounds the expiry arithmetic (see
+/// `Lease::expires_at`) and stops a bad config value from parking a resource
+/// effectively forever.
+pub const MAX_TTL: Duration = Duration::from_secs(86_400);
+
+/// Ids become map keys and WAL-line values — bound their size and charset.
+const MAX_ID_BYTES: usize = 128;
+
+fn validate_id(kind: &'static str, id: &str) -> Result<(), LeaseError> {
+    let len_ok = !id.is_empty() && id.len() <= MAX_ID_BYTES;
+    let chars_ok = id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    if len_ok && chars_ok {
+        Ok(())
+    } else {
+        Err(LeaseError::InvalidId {
+            kind,
+            id: id.to_string(),
+        })
+    }
+}
+
+fn validate_ttl(resource_id: &str, ttl: Duration) -> Result<(), LeaseError> {
+    if ttl > Duration::ZERO && ttl <= MAX_TTL {
+        Ok(())
+    } else {
+        Err(LeaseError::InvalidTtl {
+            resource_id: resource_id.to_string(),
+            ttl,
+        })
+    }
+}
 
 /// Monotonically increasing per-resource token. Issued on acquire and on
 /// reclaim-on-expiry; never reused, never decremented.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct FencingToken(pub u64);
+
+impl fmt::Display for FencingToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "#{}", self.0)
+    }
+}
 
 /// A granted lease on a resource.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -28,13 +75,20 @@ pub struct Lease {
     pub holder_id: String,
     pub fencing_token: FencingToken,
     pub granted_at: DateTime<Utc>,
-    /// Time-to-live from `granted_at`. Renewal resets `granted_at`.
+    /// Time-to-live from `granted_at`. Renewal resets `granted_at` and
+    /// replaces `ttl` — a renew may therefore also shorten a lease.
     pub ttl: Duration,
 }
 
 impl Lease {
+    /// Total: `validate_ttl` bounds every ttl entering through `acquire`,
+    /// `renew`, or replay, but a hand-built `Lease` must still never panic —
+    /// out-of-range arithmetic saturates to the far future instead.
     pub fn expires_at(&self) -> DateTime<Utc> {
-        self.granted_at + self.ttl
+        TimeDelta::from_std(self.ttl)
+            .ok()
+            .and_then(|d| self.granted_at.checked_add_signed(d))
+            .unwrap_or(DateTime::<Utc>::MAX_UTC)
     }
 
     pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
@@ -67,6 +121,75 @@ pub enum LeaseError {
     },
     #[error("fencing token overflow on resource '{resource_id}'")]
     TokenOverflow { resource_id: String },
+    #[error("invalid ttl {ttl:?} on '{resource_id}': must be > 0 and <= {MAX_TTL:?}")]
+    InvalidTtl { resource_id: String, ttl: Duration },
+    #[error("invalid {kind} id '{id}': need 1-{MAX_ID_BYTES} bytes of [A-Za-z0-9._-]")]
+    InvalidId { kind: &'static str, id: String },
+}
+
+/// A state change worth surviving a restart. Domain type: the WAL stores
+/// these verbatim and `LeaseTable::apply` folds them back, enforcing the
+/// table's invariants on the way in.
+///
+/// `ts` is append time (== `lease.granted_at` for events the coordinator
+/// writes itself; kept separate for auditability of replays and clock skew).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum LeaseEvent {
+    /// Fresh acquire on a free resource.
+    Acquired {
+        ts: DateTime<Utc>,
+        lease: Lease,
+    },
+    /// Acquire over an expired lease — same replay semantics as `Acquired`,
+    /// logged distinctly so reclaims are auditable.
+    Reclaimed {
+        ts: DateTime<Utc>,
+        lease: Lease,
+    },
+    Renewed {
+        ts: DateTime<Utc>,
+        lease: Lease,
+    },
+    Released {
+        ts: DateTime<Utc>,
+        resource_id: String,
+        holder_id: String,
+    },
+}
+
+/// Replay validation failures. Replay fails closed: a log that violates the
+/// table's invariants is corruption or tampering, never silently absorbed.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ApplyError {
+    #[error("token would regress on '{resource_id}': event {token}, watermark {watermark}")]
+    TokenRegression {
+        resource_id: String,
+        token: FencingToken,
+        watermark: FencingToken,
+    },
+    #[error(
+        "{op} holder mismatch on '{resource_id}': event '{event_holder}', table '{table_holder}'"
+    )]
+    HolderMismatch {
+        op: &'static str,
+        resource_id: String,
+        event_holder: String,
+        table_holder: String,
+    },
+    #[error("{op} on '{resource_id}' with no lease in table")]
+    NoLease {
+        op: &'static str,
+        resource_id: String,
+    },
+    #[error("renew changed the fencing token on '{resource_id}': event {token}, lease {current}")]
+    RenewMintedToken {
+        resource_id: String,
+        token: FencingToken,
+        current: FencingToken,
+    },
+    #[error("invalid lease in event: {0}")]
+    InvalidLease(#[from] LeaseError),
 }
 
 /// In-memory lease table: at most one unexpired lease per resource, plus the
@@ -94,6 +217,10 @@ impl LeaseTable {
         ttl: Duration,
         now: DateTime<Utc>,
     ) -> Result<Lease, LeaseError> {
+        validate_id("resource", resource_id)?;
+        validate_id("holder", holder_id)?;
+        validate_ttl(resource_id, ttl)?;
+
         if let Some(existing) = self.leases.get(resource_id) {
             if !existing.is_expired(now) {
                 return Err(LeaseError::Held {
@@ -117,10 +244,11 @@ impl LeaseTable {
         Ok(lease)
     }
 
-    /// Extend a held lease. Holder must match and the lease must be unexpired
-    /// — an expired lease may already have been reclaimed, so the holder must
-    /// go back through `acquire` and take a fresh token.
-    /// The fencing token is unchanged: renewal is the same ownership epoch.
+    /// Reset a held lease's ttl (which may shorten it). Holder must match and
+    /// the lease must be unexpired — an expired lease may already have been
+    /// reclaimed, so the holder must go back through `acquire` and take a
+    /// fresh token. The fencing token is unchanged: renewal is the same
+    /// ownership epoch.
     pub fn renew(
         &mut self,
         resource_id: &str,
@@ -128,6 +256,10 @@ impl LeaseTable {
         ttl: Duration,
         now: DateTime<Utc>,
     ) -> Result<Lease, LeaseError> {
+        validate_id("resource", resource_id)?;
+        validate_id("holder", holder_id)?;
+        validate_ttl(resource_id, ttl)?;
+
         let lease = self
             .leases
             .get_mut(resource_id)
@@ -188,6 +320,85 @@ impl LeaseTable {
         self.watermarks.get(resource_id).copied()
     }
 
+    /// Fold one replayed event into the table, enforcing the same invariants
+    /// the online path does: ids and ttl valid, tokens never regress, renew
+    /// never mints, release and renew only by the recorded holder. Any
+    /// violation is an error — the caller (replay) fails closed.
+    pub fn apply(&mut self, event: &LeaseEvent) -> Result<(), ApplyError> {
+        match event {
+            LeaseEvent::Acquired { lease, .. } | LeaseEvent::Reclaimed { lease, .. } => {
+                Self::validate_event_lease(lease)?;
+                if let Some(watermark) = self.watermark(&lease.resource_id) {
+                    if lease.fencing_token <= watermark {
+                        return Err(ApplyError::TokenRegression {
+                            resource_id: lease.resource_id.clone(),
+                            token: lease.fencing_token,
+                            watermark,
+                        });
+                    }
+                }
+                self.leases.insert(lease.resource_id.clone(), lease.clone());
+                self.watermarks
+                    .insert(lease.resource_id.clone(), lease.fencing_token);
+            }
+            LeaseEvent::Renewed { lease, .. } => {
+                Self::validate_event_lease(lease)?;
+                let current =
+                    self.leases
+                        .get(&lease.resource_id)
+                        .ok_or_else(|| ApplyError::NoLease {
+                            op: "renew",
+                            resource_id: lease.resource_id.clone(),
+                        })?;
+                if current.holder_id != lease.holder_id {
+                    return Err(ApplyError::HolderMismatch {
+                        op: "renew",
+                        resource_id: lease.resource_id.clone(),
+                        event_holder: lease.holder_id.clone(),
+                        table_holder: current.holder_id.clone(),
+                    });
+                }
+                if current.fencing_token != lease.fencing_token {
+                    return Err(ApplyError::RenewMintedToken {
+                        resource_id: lease.resource_id.clone(),
+                        token: lease.fencing_token,
+                        current: current.fencing_token,
+                    });
+                }
+                self.leases.insert(lease.resource_id.clone(), lease.clone());
+            }
+            LeaseEvent::Released {
+                resource_id,
+                holder_id,
+                ..
+            } => {
+                let current = self
+                    .leases
+                    .get(resource_id)
+                    .ok_or_else(|| ApplyError::NoLease {
+                        op: "release",
+                        resource_id: resource_id.clone(),
+                    })?;
+                if current.holder_id != *holder_id {
+                    return Err(ApplyError::HolderMismatch {
+                        op: "release",
+                        resource_id: resource_id.clone(),
+                        event_holder: holder_id.clone(),
+                        table_holder: current.holder_id.clone(),
+                    });
+                }
+                self.leases.remove(resource_id);
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_event_lease(lease: &Lease) -> Result<(), LeaseError> {
+        validate_id("resource", &lease.resource_id)?;
+        validate_id("holder", &lease.holder_id)?;
+        validate_ttl(&lease.resource_id, lease.ttl)
+    }
+
     fn next_token(&self, resource_id: &str) -> Result<FencingToken, LeaseError> {
         match self.watermarks.get(resource_id) {
             None => Ok(FencingToken(1)),
@@ -196,31 +407,11 @@ impl LeaseTable {
             Some(FencingToken(n)) => {
                 n.checked_add(1)
                     .map(FencingToken)
-                    .ok_or(LeaseError::TokenOverflow {
+                    .ok_or_else(|| LeaseError::TokenOverflow {
                         resource_id: resource_id.to_string(),
                     })
             }
         }
-    }
-
-    /// Restore-from-WAL constructor: install a recovered lease and watermark
-    /// without issuing a new token. Watermark is kept even if the lease slot
-    /// is empty (released before shutdown).
-    pub(crate) fn restore(
-        &mut self,
-        resource_id: &str,
-        lease: Option<Lease>,
-        watermark: FencingToken,
-    ) {
-        match lease {
-            Some(l) => {
-                self.leases.insert(resource_id.to_string(), l);
-            }
-            None => {
-                self.leases.remove(resource_id);
-            }
-        }
-        self.watermarks.insert(resource_id.to_string(), watermark);
     }
 }
 
@@ -308,6 +499,17 @@ mod tests {
     }
 
     #[test]
+    fn renew_can_shorten_a_lease() {
+        let mut table = LeaseTable::new();
+        table.acquire("wal", "echo-a", secs(60), t0()).unwrap();
+        let renewed = table
+            .renew("wal", "echo-a", secs(5), t0() + secs(1))
+            .unwrap();
+        assert_eq!(renewed.expires_at(), t0() + secs(1) + secs(5));
+        assert!(renewed.is_expired(t0() + secs(6)));
+    }
+
+    #[test]
     fn renew_by_non_holder_fails_and_state_unchanged() {
         let mut table = LeaseTable::new();
         table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
@@ -380,5 +582,162 @@ mod tests {
             .insert("wal".to_string(), FencingToken(u64::MAX));
         let err = table.acquire("wal", "echo-a", secs(30), t0()).unwrap_err();
         assert!(matches!(err, LeaseError::TokenOverflow { .. }));
+    }
+
+    #[test]
+    fn zero_and_oversized_ttls_are_rejected() {
+        let mut table = LeaseTable::new();
+        assert!(matches!(
+            table
+                .acquire("wal", "echo-a", Duration::ZERO, t0())
+                .unwrap_err(),
+            LeaseError::InvalidTtl { .. }
+        ));
+        assert!(matches!(
+            table
+                .acquire("wal", "echo-a", secs(u64::MAX), t0())
+                .unwrap_err(),
+            LeaseError::InvalidTtl { .. }
+        ));
+        table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        assert!(matches!(
+            table
+                .renew("wal", "echo-a", Duration::ZERO, t0() + secs(1))
+                .unwrap_err(),
+            LeaseError::InvalidTtl { .. }
+        ));
+    }
+
+    #[test]
+    fn expires_at_is_total_even_for_absurd_ttl() {
+        // A hand-built lease with u64::MAX ttl must not panic (the chrono
+        // Add impl would); it saturates to the far future instead.
+        let lease = Lease {
+            resource_id: "wal".to_string(),
+            holder_id: "echo-a".to_string(),
+            fencing_token: FencingToken(1),
+            granted_at: t0(),
+            ttl: secs(u64::MAX),
+        };
+        assert_eq!(lease.expires_at(), DateTime::<Utc>::MAX_UTC);
+        assert!(!lease.is_expired(t0()));
+    }
+
+    #[test]
+    fn malformed_ids_are_rejected() {
+        let mut table = LeaseTable::new();
+        for bad in ["", "a\nb", "spaced id", "ütf", &"x".repeat(129)] {
+            assert!(matches!(
+                table.acquire(bad, "echo-a", secs(30), t0()).unwrap_err(),
+                LeaseError::InvalidId { .. }
+            ));
+            assert!(matches!(
+                table.acquire("wal", bad, secs(30), t0()).unwrap_err(),
+                LeaseError::InvalidId { .. }
+            ));
+        }
+    }
+
+    // --- apply() — the replay fold enforces the online invariants ---
+
+    fn acquired(lease: &Lease) -> LeaseEvent {
+        LeaseEvent::Acquired {
+            ts: lease.granted_at,
+            lease: lease.clone(),
+        }
+    }
+
+    #[test]
+    fn apply_rejects_token_regression() {
+        let mut source = LeaseTable::new();
+        let first = source.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        source.release("wal", "echo-a").unwrap();
+        let second = source
+            .acquire("wal", "echo-b", secs(30), t0() + secs(1))
+            .unwrap();
+
+        let mut table = LeaseTable::new();
+        table.apply(&acquired(&second)).unwrap();
+        let err = table.apply(&acquired(&first)).unwrap_err();
+        assert!(matches!(err, ApplyError::TokenRegression { .. }));
+        assert_eq!(table.get("wal").unwrap().holder_id, "echo-b");
+    }
+
+    #[test]
+    fn apply_rejects_renew_by_wrong_holder_or_wrong_token() {
+        let mut source = LeaseTable::new();
+        let lease = source.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+
+        let mut table = LeaseTable::new();
+        table.apply(&acquired(&lease)).unwrap();
+
+        let mut forged = lease.clone();
+        forged.holder_id = "echo-b".to_string();
+        let err = table
+            .apply(&LeaseEvent::Renewed {
+                ts: t0(),
+                lease: forged,
+            })
+            .unwrap_err();
+        assert!(matches!(err, ApplyError::HolderMismatch { .. }));
+
+        let mut minted = lease.clone();
+        minted.fencing_token = FencingToken(99);
+        let err = table
+            .apply(&LeaseEvent::Renewed {
+                ts: t0(),
+                lease: minted,
+            })
+            .unwrap_err();
+        assert!(matches!(err, ApplyError::RenewMintedToken { .. }));
+    }
+
+    #[test]
+    fn apply_rejects_release_by_wrong_holder_and_release_of_nothing() {
+        let mut source = LeaseTable::new();
+        let lease = source.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+
+        let mut table = LeaseTable::new();
+        assert!(matches!(
+            table
+                .apply(&LeaseEvent::Released {
+                    ts: t0(),
+                    resource_id: "wal".to_string(),
+                    holder_id: "echo-a".to_string(),
+                })
+                .unwrap_err(),
+            ApplyError::NoLease { .. }
+        ));
+
+        table.apply(&acquired(&lease)).unwrap();
+        assert!(matches!(
+            table
+                .apply(&LeaseEvent::Released {
+                    ts: t0(),
+                    resource_id: "wal".to_string(),
+                    holder_id: "echo-b".to_string(),
+                })
+                .unwrap_err(),
+            ApplyError::HolderMismatch { .. }
+        ));
+        assert!(table.get("wal").is_some());
+    }
+
+    #[test]
+    fn apply_rejects_invalid_ttl_from_a_forged_event() {
+        let mut table = LeaseTable::new();
+        let poisoned = Lease {
+            resource_id: "wal".to_string(),
+            holder_id: "echo-a".to_string(),
+            fencing_token: FencingToken(1),
+            granted_at: t0(),
+            ttl: secs(u64::MAX),
+        };
+        let err = table.apply(&acquired(&poisoned)).unwrap_err();
+        assert!(matches!(
+            err,
+            ApplyError::InvalidLease(LeaseError::InvalidTtl { .. })
+        ));
+        assert!(table.get("wal").is_none());
     }
 }

--- a/src/coordinator/lease.rs
+++ b/src/coordinator/lease.rs
@@ -333,6 +333,11 @@ impl LeaseTable {
         self.watermarks.get(resource_id).copied()
     }
 
+    /// Every lease in the table, held or expired-but-unreclaimed.
+    pub fn all(&self) -> impl Iterator<Item = &Lease> {
+        self.leases.values()
+    }
+
     /// Fold one replayed event into the table, enforcing the same invariants
     /// the online path does: ids and ttl valid, tokens never regress, renew
     /// never mints, release and renew only by the recorded holder. Any

--- a/src/coordinator/lease.rs
+++ b/src/coordinator/lease.rs
@@ -1,0 +1,384 @@
+//! Lease primitive: ownership with a ttl, made safe by fencing tokens.
+//!
+//! A lease with a timeout alone is insufficient — a paused holder can hold a
+//! "valid" lease past a wall-clock reclaim and wake up to write stale. Every
+//! lease therefore carries a fencing token that is monotonically increasing
+//! per resource; the protected resource (see `fenced.rs`) rejects any write
+//! bearing a token older than the highest it has seen.
+//!
+//! Time is injected (`now` parameters) — expiry is never read from the wall
+//! clock inside this module, so tests control the clock deterministically.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Monotonically increasing per-resource token. Issued on acquire and on
+/// reclaim-on-expiry; never reused, never decremented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct FencingToken(pub u64);
+
+/// A granted lease on a resource.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lease {
+    pub resource_id: String,
+    pub holder_id: String,
+    pub fencing_token: FencingToken,
+    pub granted_at: DateTime<Utc>,
+    /// Time-to-live from `granted_at`. Renewal resets `granted_at`.
+    pub ttl: Duration,
+}
+
+impl Lease {
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.granted_at + self.ttl
+    }
+
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        now >= self.expires_at()
+    }
+}
+
+/// Lease operation errors. State is never mutated on the error path.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum LeaseError {
+    #[error("resource '{resource_id}' held by '{holder_id}' until {expires_at}")]
+    Held {
+        resource_id: String,
+        holder_id: String,
+        expires_at: DateTime<Utc>,
+    },
+    #[error("resource '{resource_id}' has no active lease")]
+    NotHeld { resource_id: String },
+    #[error("resource '{resource_id}' held by '{actual_holder}', not '{holder_id}'")]
+    NotHolder {
+        resource_id: String,
+        holder_id: String,
+        actual_holder: String,
+    },
+    #[error("lease on '{resource_id}' held by '{holder_id}' expired at {expired_at}; re-acquire")]
+    Expired {
+        resource_id: String,
+        holder_id: String,
+        expired_at: DateTime<Utc>,
+    },
+    #[error("fencing token overflow on resource '{resource_id}'")]
+    TokenOverflow { resource_id: String },
+}
+
+/// In-memory lease table: at most one unexpired lease per resource, plus the
+/// per-resource high-water fencing token, which outlives individual leases —
+/// release does not reset it, so the next acquire is always strictly higher.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct LeaseTable {
+    leases: HashMap<String, Lease>,
+    watermarks: HashMap<String, FencingToken>,
+}
+
+impl LeaseTable {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Acquire a lease. Fails if the resource is held and unexpired — even by
+    /// the requesting holder (holders extend via `renew`, not re-acquire).
+    /// Acquiring over an expired lease IS reclaim-on-expiry: the new lease
+    /// gets a strictly higher token, fencing the stale prior holder.
+    pub fn acquire(
+        &mut self,
+        resource_id: &str,
+        holder_id: &str,
+        ttl: Duration,
+        now: DateTime<Utc>,
+    ) -> Result<Lease, LeaseError> {
+        if let Some(existing) = self.leases.get(resource_id) {
+            if !existing.is_expired(now) {
+                return Err(LeaseError::Held {
+                    resource_id: resource_id.to_string(),
+                    holder_id: existing.holder_id.clone(),
+                    expires_at: existing.expires_at(),
+                });
+            }
+        }
+
+        let token = self.next_token(resource_id)?;
+        let lease = Lease {
+            resource_id: resource_id.to_string(),
+            holder_id: holder_id.to_string(),
+            fencing_token: token,
+            granted_at: now,
+            ttl,
+        };
+        self.leases.insert(resource_id.to_string(), lease.clone());
+        self.watermarks.insert(resource_id.to_string(), token);
+        Ok(lease)
+    }
+
+    /// Extend a held lease. Holder must match and the lease must be unexpired
+    /// — an expired lease may already have been reclaimed, so the holder must
+    /// go back through `acquire` and take a fresh token.
+    /// The fencing token is unchanged: renewal is the same ownership epoch.
+    pub fn renew(
+        &mut self,
+        resource_id: &str,
+        holder_id: &str,
+        ttl: Duration,
+        now: DateTime<Utc>,
+    ) -> Result<Lease, LeaseError> {
+        let lease = self
+            .leases
+            .get_mut(resource_id)
+            .ok_or_else(|| LeaseError::NotHeld {
+                resource_id: resource_id.to_string(),
+            })?;
+
+        if lease.holder_id != holder_id {
+            return Err(LeaseError::NotHolder {
+                resource_id: resource_id.to_string(),
+                holder_id: holder_id.to_string(),
+                actual_holder: lease.holder_id.clone(),
+            });
+        }
+        if lease.is_expired(now) {
+            return Err(LeaseError::Expired {
+                resource_id: resource_id.to_string(),
+                holder_id: holder_id.to_string(),
+                expired_at: lease.expires_at(),
+            });
+        }
+
+        lease.granted_at = now;
+        lease.ttl = ttl;
+        Ok(lease.clone())
+    }
+
+    /// Release a held lease. Holder must match. The watermark is untouched —
+    /// the next acquire still gets a strictly higher token.
+    pub fn release(&mut self, resource_id: &str, holder_id: &str) -> Result<(), LeaseError> {
+        let lease = self
+            .leases
+            .get(resource_id)
+            .ok_or_else(|| LeaseError::NotHeld {
+                resource_id: resource_id.to_string(),
+            })?;
+
+        if lease.holder_id != holder_id {
+            return Err(LeaseError::NotHolder {
+                resource_id: resource_id.to_string(),
+                holder_id: holder_id.to_string(),
+                actual_holder: lease.holder_id.clone(),
+            });
+        }
+
+        self.leases.remove(resource_id);
+        Ok(())
+    }
+
+    /// The active lease on a resource, if any (expired leases linger until
+    /// reclaimed — callers decide with `is_expired`).
+    pub fn get(&self, resource_id: &str) -> Option<&Lease> {
+        self.leases.get(resource_id)
+    }
+
+    /// Highest fencing token ever issued for a resource.
+    pub fn watermark(&self, resource_id: &str) -> Option<FencingToken> {
+        self.watermarks.get(resource_id).copied()
+    }
+
+    fn next_token(&self, resource_id: &str) -> Result<FencingToken, LeaseError> {
+        match self.watermarks.get(resource_id) {
+            None => Ok(FencingToken(1)),
+            // Overflow must error, never wrap or saturate — a reused token
+            // would let a fenced stale holder write again.
+            Some(FencingToken(n)) => {
+                n.checked_add(1)
+                    .map(FencingToken)
+                    .ok_or(LeaseError::TokenOverflow {
+                        resource_id: resource_id.to_string(),
+                    })
+            }
+        }
+    }
+
+    /// Restore-from-WAL constructor: install a recovered lease and watermark
+    /// without issuing a new token. Watermark is kept even if the lease slot
+    /// is empty (released before shutdown).
+    pub(crate) fn restore(
+        &mut self,
+        resource_id: &str,
+        lease: Option<Lease>,
+        watermark: FencingToken,
+    ) {
+        match lease {
+            Some(l) => {
+                self.leases.insert(resource_id.to_string(), l);
+            }
+            None => {
+                self.leases.remove(resource_id);
+            }
+        }
+        self.watermarks.insert(resource_id.to_string(), watermark);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn t0() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 7, 12, 0, 0).unwrap()
+    }
+
+    fn secs(n: u64) -> Duration {
+        Duration::from_secs(n)
+    }
+
+    #[test]
+    fn acquire_free_resource_issues_token_1() {
+        let mut table = LeaseTable::new();
+        let lease = table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        assert_eq!(lease.fencing_token, FencingToken(1));
+        assert_eq!(lease.holder_id, "echo-a");
+        assert_eq!(lease.expires_at(), t0() + secs(30));
+    }
+
+    #[test]
+    fn tokens_strictly_increase_across_release_reacquire() {
+        let mut table = LeaseTable::new();
+        let first = table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        table.release("wal", "echo-a").unwrap();
+        let second = table.acquire("wal", "echo-b", secs(30), t0()).unwrap();
+        assert!(second.fencing_token > first.fencing_token);
+    }
+
+    #[test]
+    fn acquire_held_unexpired_fails_without_disturbing_lease() {
+        let mut table = LeaseTable::new();
+        table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        let err = table
+            .acquire("wal", "echo-b", secs(30), t0() + secs(10))
+            .unwrap_err();
+        assert!(matches!(err, LeaseError::Held { .. }));
+        assert_eq!(table.get("wal").unwrap().holder_id, "echo-a");
+        assert_eq!(table.watermark("wal"), Some(FencingToken(1)));
+    }
+
+    #[test]
+    fn acquire_by_current_holder_while_unexpired_also_fails() {
+        let mut table = LeaseTable::new();
+        table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        let err = table
+            .acquire("wal", "echo-a", secs(30), t0() + secs(10))
+            .unwrap_err();
+        assert!(matches!(err, LeaseError::Held { .. }));
+    }
+
+    #[test]
+    fn reclaim_on_expiry_issues_strictly_higher_token() {
+        let mut table = LeaseTable::new();
+        let stale = table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        let reclaimed = table
+            .acquire("wal", "echo-b", secs(30), t0() + secs(31))
+            .unwrap();
+        assert!(reclaimed.fencing_token > stale.fencing_token);
+        assert_eq!(table.get("wal").unwrap().holder_id, "echo-b");
+    }
+
+    #[test]
+    fn expiry_boundary_is_inclusive() {
+        let mut table = LeaseTable::new();
+        let lease = table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        assert!(!lease.is_expired(t0() + secs(29)));
+        assert!(lease.is_expired(t0() + secs(30)));
+    }
+
+    #[test]
+    fn renew_extends_ttl_and_keeps_token() {
+        let mut table = LeaseTable::new();
+        let lease = table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        let renewed = table
+            .renew("wal", "echo-a", secs(60), t0() + secs(20))
+            .unwrap();
+        assert_eq!(renewed.fencing_token, lease.fencing_token);
+        assert_eq!(renewed.expires_at(), t0() + secs(20) + secs(60));
+    }
+
+    #[test]
+    fn renew_by_non_holder_fails_and_state_unchanged() {
+        let mut table = LeaseTable::new();
+        table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        let err = table
+            .renew("wal", "echo-b", secs(60), t0() + secs(10))
+            .unwrap_err();
+        assert!(matches!(err, LeaseError::NotHolder { .. }));
+        let lease = table.get("wal").unwrap();
+        assert_eq!(lease.holder_id, "echo-a");
+        assert_eq!(lease.expires_at(), t0() + secs(30));
+    }
+
+    #[test]
+    fn renew_expired_lease_fails() {
+        let mut table = LeaseTable::new();
+        table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        let err = table
+            .renew("wal", "echo-a", secs(30), t0() + secs(31))
+            .unwrap_err();
+        assert!(matches!(err, LeaseError::Expired { .. }));
+    }
+
+    #[test]
+    fn release_frees_resource_immediately() {
+        let mut table = LeaseTable::new();
+        table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        table.release("wal", "echo-a").unwrap();
+        assert!(table.get("wal").is_none());
+        let next = table
+            .acquire("wal", "echo-b", secs(30), t0() + secs(1))
+            .unwrap();
+        assert_eq!(next.fencing_token, FencingToken(2));
+    }
+
+    #[test]
+    fn release_by_non_holder_fails() {
+        let mut table = LeaseTable::new();
+        table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        let err = table.release("wal", "echo-b").unwrap_err();
+        assert!(matches!(err, LeaseError::NotHolder { .. }));
+        assert!(table.get("wal").is_some());
+    }
+
+    #[test]
+    fn operations_on_unknown_resource_fail() {
+        let mut table = LeaseTable::new();
+        assert!(matches!(
+            table.renew("ghost", "echo-a", secs(30), t0()).unwrap_err(),
+            LeaseError::NotHeld { .. }
+        ));
+        assert!(matches!(
+            table.release("ghost", "echo-a").unwrap_err(),
+            LeaseError::NotHeld { .. }
+        ));
+    }
+
+    #[test]
+    fn watermarks_are_per_resource() {
+        let mut table = LeaseTable::new();
+        table.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        let other = table.acquire("journal", "echo-b", secs(30), t0()).unwrap();
+        assert_eq!(other.fencing_token, FencingToken(1));
+    }
+
+    #[test]
+    fn token_overflow_errors_instead_of_wrapping() {
+        let mut table = LeaseTable::new();
+        table
+            .watermarks
+            .insert("wal".to_string(), FencingToken(u64::MAX));
+        let err = table.acquire("wal", "echo-a", secs(30), t0()).unwrap_err();
+        assert!(matches!(err, LeaseError::TokenOverflow { .. }));
+    }
+}

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod control;
 pub mod durable;
+pub mod farm;
 pub mod fenced;
 pub mod lease;
 pub mod wal;

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -9,3 +9,4 @@
 
 pub mod fenced;
 pub mod lease;
+pub mod wal;

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -10,3 +10,6 @@
 pub mod fenced;
 pub mod lease;
 pub mod wal;
+
+#[cfg(test)]
+mod proptests;

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -9,9 +9,11 @@
 //! therefore the lease table. `wal::LeaseWal` enforces this with an exclusive
 //! file lock held for the process lifetime; a second coordinator instance
 //! fails to open rather than silently sharing the log.
-// Nothing wires the coordinator in until Stage 1 — suppress dead_code until then.
+// Stages 2-3 consumers (FencedResource, parts of the lease API) are not
+// wired yet — keep dead_code suppressed until the umbrella lands complete.
 #![allow(dead_code)]
 
+pub mod control;
 pub mod durable;
 pub mod fenced;
 pub mod lease;

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -4,9 +4,15 @@
 //! tokens enforce *correctness at the resource* (a stale holder that wakes
 //! past reclaim is rejected on write). Stages 1–3 (fail-open faculties,
 //! isolation mode, subtask farming) build on this module.
+//!
+//! **Single-writer invariant:** exactly one process owns the lease WAL and
+//! therefore the lease table. `wal::LeaseWal` enforces this with an exclusive
+//! file lock held for the process lifetime; a second coordinator instance
+//! fails to open rather than silently sharing the log.
 // Nothing wires the coordinator in until Stage 1 — suppress dead_code until then.
 #![allow(dead_code)]
 
+pub mod durable;
 pub mod fenced;
 pub mod lease;
 pub mod wal;

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -1,0 +1,11 @@
+//! Coordinator substrate — Stage 0 of the coordinator spec.
+//!
+//! Leases bound *intent* (who may act on a resource, for how long); fencing
+//! tokens enforce *correctness at the resource* (a stale holder that wakes
+//! past reclaim is rejected on write). Stages 1–3 (fail-open faculties,
+//! isolation mode, subtask farming) build on this module.
+// Nothing wires the coordinator in until Stage 1 — suppress dead_code until then.
+#![allow(dead_code)]
+
+pub mod fenced;
+pub mod lease;

--- a/src/coordinator/mod.rs
+++ b/src/coordinator/mod.rs
@@ -9,10 +9,6 @@
 //! therefore the lease table. `wal::LeaseWal` enforces this with an exclusive
 //! file lock held for the process lifetime; a second coordinator instance
 //! fails to open rather than silently sharing the log.
-// Stages 2-3 consumers (FencedResource, parts of the lease API) are not
-// wired yet — keep dead_code suppressed until the umbrella lands complete.
-#![allow(dead_code)]
-
 pub mod control;
 pub mod durable;
 pub mod farm;

--- a/src/coordinator/proptests.rs
+++ b/src/coordinator/proptests.rs
@@ -1,0 +1,134 @@
+//! Property tests for the lease + fencing substrate.
+//!
+//! A state machine drives arbitrary interleavings of acquire / renew /
+//! release / time-advance / write ops — including the paused-holder-wakes-
+//! stale race, which here is just "a holder still writing with a token that
+//! has since been superseded". Invariants checked at every step:
+//!
+//! 1. Fencing tokens are strictly increasing per resource.
+//! 2. The holder of the highest issued token is never fenced.
+//! 3. A stale holder is always fenced once the superseding holder has written.
+//! 4. WAL replay reconstructs the live table exactly (checked at the end).
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use chrono::{DateTime, TimeZone, Utc};
+use proptest::prelude::*;
+
+use super::fenced::FencedResource;
+use super::lease::{FencingToken, LeaseTable};
+use super::wal::{LeaseEvent, LeaseWal};
+
+#[derive(Debug, Clone)]
+enum Op {
+    Acquire { r: u8, h: u8, ttl_secs: u8 },
+    Renew { r: u8, h: u8, ttl_secs: u8 },
+    Release { r: u8, h: u8 },
+    Advance { secs: u8 },
+    Write { r: u8, h: u8 },
+}
+
+fn op_strategy() -> impl Strategy<Value = Op> {
+    // 2 resources, 3 holders — small domain forces collisions.
+    let r = 0..2u8;
+    let h = 0..3u8;
+    prop_oneof![
+        (r.clone(), h.clone(), 1..60u8).prop_map(|(r, h, ttl_secs)| Op::Acquire { r, h, ttl_secs }),
+        (r.clone(), h.clone(), 1..60u8).prop_map(|(r, h, ttl_secs)| Op::Renew { r, h, ttl_secs }),
+        (r.clone(), h.clone()).prop_map(|(r, h)| Op::Release { r, h }),
+        (1..120u8).prop_map(|secs| Op::Advance { secs }),
+        (r, h).prop_map(|(r, h)| Op::Write { r, h }),
+    ]
+}
+
+fn rid(r: u8) -> String {
+    format!("res-{r}")
+}
+
+fn hid(h: u8) -> String {
+    format!("holder-{h}")
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn lease_fencing_invariants(ops in prop::collection::vec(op_strategy(), 1..120)) {
+        let dir = tempfile::tempdir().unwrap();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+        let mut table = LeaseTable::new();
+        let mut now: DateTime<Utc> = Utc.with_ymd_and_hms(2026, 8, 7, 12, 0, 0).unwrap();
+
+        // One fencing guard per resource.
+        let mut guards: HashMap<String, FencedResource> = HashMap::new();
+        // Every token ever issued, per resource (invariant 1).
+        let mut issued: HashMap<String, Vec<FencingToken>> = HashMap::new();
+        // Each holder's belief about the token it holds — kept even after the
+        // lease is reclaimed under it. This IS the paused stale holder.
+        let mut believed: HashMap<(String, String), FencingToken> = HashMap::new();
+
+        for op in ops {
+            match op {
+                Op::Acquire { r, h, ttl_secs } => {
+                    let (r, h) = (rid(r), hid(h));
+                    let reclaim = table.get(&r).is_some_and(|l| l.is_expired(now));
+                    if let Ok(lease) = table.acquire(&r, &h, Duration::from_secs(ttl_secs as u64), now) {
+                        // Invariant 1: strictly above everything issued before.
+                        let prior = issued.entry(r.clone()).or_default();
+                        prop_assert!(prior.iter().all(|t| lease.fencing_token > *t),
+                            "token {:?} not above prior {:?}", lease.fencing_token, prior);
+                        prior.push(lease.fencing_token);
+                        believed.insert((r, h), lease.fencing_token);
+                        let event = if reclaim {
+                            LeaseEvent::Reclaimed { ts: now, lease }
+                        } else {
+                            LeaseEvent::Acquired { ts: now, lease }
+                        };
+                        wal.append(&event).unwrap();
+                    }
+                }
+                Op::Renew { r, h, ttl_secs } => {
+                    let (r, h) = (rid(r), hid(h));
+                    if let Ok(lease) = table.renew(&r, &h, Duration::from_secs(ttl_secs as u64), now) {
+                        // Renewal never mints a token.
+                        prop_assert_eq!(believed.get(&(r, h)).copied(), Some(lease.fencing_token));
+                        wal.append(&LeaseEvent::Renewed { ts: now, lease }).unwrap();
+                    }
+                }
+                Op::Release { r, h } => {
+                    let (r, h) = (rid(r), hid(h));
+                    if table.release(&r, &h).is_ok() {
+                        believed.remove(&(r.clone(), h.clone()));
+                        wal.append(&LeaseEvent::Released { ts: now, resource_id: r, holder_id: h }).unwrap();
+                    }
+                }
+                Op::Advance { secs } => {
+                    now += Duration::from_secs(secs as u64);
+                }
+                Op::Write { r, h } => {
+                    let (r, h) = (rid(r), hid(h));
+                    let Some(&token) = believed.get(&(r.clone(), h)) else { continue };
+                    let guard = guards.entry(r.clone()).or_default();
+                    let max_issued = issued[&r].iter().max().copied().unwrap();
+                    let result = guard.accept(token);
+
+                    if token == max_issued {
+                        // Invariant 2: the newest epoch is never fenced.
+                        prop_assert!(result.is_ok(),
+                            "newest token {:?} fenced on {}", token, r);
+                    } else if guard.high_water().is_some_and(|hw| hw > token) {
+                        // Invariant 3: once a newer epoch has written, the
+                        // stale waker is rejected — the AC7 race.
+                        prop_assert!(result.is_err(),
+                            "stale token {:?} accepted on {} past high-water", token, r);
+                    }
+                }
+            }
+        }
+
+        // Invariant 4: the log alone rebuilds the live table.
+        let recovered = wal.replay().unwrap();
+        prop_assert_eq!(recovered, table);
+    }
+}

--- a/src/coordinator/proptests.rs
+++ b/src/coordinator/proptests.rs
@@ -24,12 +24,31 @@ use super::lease::FencingToken;
 
 #[derive(Debug, Clone)]
 enum Op {
-    Acquire { r: u8, h: u8, ttl_secs: u8 },
-    Renew { r: u8, h: u8, ttl_secs: u8 },
-    Release { r: u8, h: u8 },
-    Advance { secs: u8 },
+    Acquire {
+        r: u8,
+        h: u8,
+        ttl_secs: u8,
+    },
+    Renew {
+        r: u8,
+        h: u8,
+        ttl_secs: u8,
+    },
+    Release {
+        r: u8,
+        h: u8,
+    },
+    Advance {
+        secs: u8,
+    },
     Restart,
-    Write { r: u8, h: u8 },
+    /// Crash mid-append: torn unterminated bytes land on the log, then the
+    /// coordinator restarts. Acked state must survive unchanged.
+    TearAndRestart,
+    Write {
+        r: u8,
+        h: u8,
+    },
 }
 
 fn op_strategy() -> impl Strategy<Value = Op> {
@@ -44,6 +63,7 @@ fn op_strategy() -> impl Strategy<Value = Op> {
         2 => (r.clone(), h.clone()).prop_map(|(r, h)| Op::Release { r, h }),
         3 => (1..120u8).prop_map(|secs| Op::Advance { secs }),
         1 => Just(Op::Restart),
+        1 => Just(Op::TearAndRestart),
         4 => (r, h).prop_map(|(r, h)| Op::Write { r, h }),
     ]
 }
@@ -113,6 +133,21 @@ proptest! {
                     let before = durable.table().clone();
                     drop(durable);
                     durable = DurableLeaseTable::open(dir.path()).unwrap();
+                    prop_assert_eq!(durable.table(), &before);
+                }
+                Op::TearAndRestart => {
+                    let before = durable.table().clone();
+                    drop(durable);
+                    {
+                        use std::io::Write;
+                        let mut f = std::fs::OpenOptions::new()
+                            .append(true)
+                            .open(dir.path().join("leases.jsonl"))
+                            .unwrap();
+                        f.write_all(br#"{"v":1,"e":{"event":"acq"#).unwrap();
+                    }
+                    durable = DurableLeaseTable::open(dir.path()).unwrap();
+                    // Torn bytes are truncated; every acked grant survives.
                     prop_assert_eq!(durable.table(), &before);
                 }
                 Op::Write { r, h } => {

--- a/src/coordinator/proptests.rs
+++ b/src/coordinator/proptests.rs
@@ -1,14 +1,16 @@
 //! Property tests for the lease + fencing substrate.
 //!
 //! A state machine drives arbitrary interleavings of acquire / renew /
-//! release / time-advance / write ops — including the paused-holder-wakes-
-//! stale race, which here is just "a holder still writing with a token that
-//! has since been superseded". Invariants checked at every step:
+//! release / time-advance / restart / write ops against the *durable* table —
+//! including the paused-holder-wakes-stale race, which here is just "a holder
+//! still writing with a token that has since been superseded". Invariants:
 //!
-//! 1. Fencing tokens are strictly increasing per resource.
+//! 1. Fencing tokens are strictly increasing per resource — including across
+//!    restarts (recovery must never regress the watermark).
 //! 2. The holder of the highest issued token is never fenced.
 //! 3. A stale holder is always fenced once the superseding holder has written.
-//! 4. WAL replay reconstructs the live table exactly (checked at the end).
+//! 4. Every restart recovers exactly the pre-restart table (WAL replay == live
+//!    state), checked at each `Op::Restart`, not just once at the end.
 
 use std::collections::HashMap;
 use std::time::Duration;
@@ -16,9 +18,9 @@ use std::time::Duration;
 use chrono::{DateTime, TimeZone, Utc};
 use proptest::prelude::*;
 
+use super::durable::DurableLeaseTable;
 use super::fenced::FencedResource;
-use super::lease::{FencingToken, LeaseTable};
-use super::wal::{LeaseEvent, LeaseWal};
+use super::lease::FencingToken;
 
 #[derive(Debug, Clone)]
 enum Op {
@@ -26,6 +28,7 @@ enum Op {
     Renew { r: u8, h: u8, ttl_secs: u8 },
     Release { r: u8, h: u8 },
     Advance { secs: u8 },
+    Restart,
     Write { r: u8, h: u8 },
 }
 
@@ -34,11 +37,14 @@ fn op_strategy() -> impl Strategy<Value = Op> {
     let r = 0..2u8;
     let h = 0..3u8;
     prop_oneof![
-        (r.clone(), h.clone(), 1..60u8).prop_map(|(r, h, ttl_secs)| Op::Acquire { r, h, ttl_secs }),
-        (r.clone(), h.clone(), 1..60u8).prop_map(|(r, h, ttl_secs)| Op::Renew { r, h, ttl_secs }),
-        (r.clone(), h.clone()).prop_map(|(r, h)| Op::Release { r, h }),
-        (1..120u8).prop_map(|secs| Op::Advance { secs }),
-        (r, h).prop_map(|(r, h)| Op::Write { r, h }),
+        4 => (r.clone(), h.clone(), 1..60u8)
+            .prop_map(|(r, h, ttl_secs)| Op::Acquire { r, h, ttl_secs }),
+        2 => (r.clone(), h.clone(), 1..60u8)
+            .prop_map(|(r, h, ttl_secs)| Op::Renew { r, h, ttl_secs }),
+        2 => (r.clone(), h.clone()).prop_map(|(r, h)| Op::Release { r, h }),
+        3 => (1..120u8).prop_map(|secs| Op::Advance { secs }),
+        1 => Just(Op::Restart),
+        4 => (r, h).prop_map(|(r, h)| Op::Write { r, h }),
     ]
 }
 
@@ -51,16 +57,16 @@ fn hid(h: u8) -> String {
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(256))]
+    #![proptest_config(ProptestConfig::with_cases(192))]
 
     #[test]
     fn lease_fencing_invariants(ops in prop::collection::vec(op_strategy(), 1..120)) {
         let dir = tempfile::tempdir().unwrap();
-        let wal = LeaseWal::new(dir.path()).unwrap();
-        let mut table = LeaseTable::new();
+        let mut durable = DurableLeaseTable::open(dir.path()).unwrap();
         let mut now: DateTime<Utc> = Utc.with_ymd_and_hms(2026, 8, 7, 12, 0, 0).unwrap();
 
-        // One fencing guard per resource.
+        // One fencing guard per resource. Guards live at the resource, so a
+        // coordinator restart does not reset them.
         let mut guards: HashMap<String, FencedResource> = HashMap::new();
         // Every token ever issued, per resource (invariant 1).
         let mut issued: HashMap<String, Vec<FencingToken>> = HashMap::new();
@@ -72,39 +78,42 @@ proptest! {
             match op {
                 Op::Acquire { r, h, ttl_secs } => {
                     let (r, h) = (rid(r), hid(h));
-                    let reclaim = table.get(&r).is_some_and(|l| l.is_expired(now));
-                    if let Ok(lease) = table.acquire(&r, &h, Duration::from_secs(ttl_secs as u64), now) {
-                        // Invariant 1: strictly above everything issued before.
+                    if let Ok(lease) =
+                        durable.acquire(&r, &h, Duration::from_secs(u64::from(ttl_secs)), now)
+                    {
+                        // Invariant 1: strictly above everything issued
+                        // before — across restarts too.
                         let prior = issued.entry(r.clone()).or_default();
                         prop_assert!(prior.iter().all(|t| lease.fencing_token > *t),
-                            "token {:?} not above prior {:?}", lease.fencing_token, prior);
+                            "token {} not above prior {:?}", lease.fencing_token, prior);
                         prior.push(lease.fencing_token);
                         believed.insert((r, h), lease.fencing_token);
-                        let event = if reclaim {
-                            LeaseEvent::Reclaimed { ts: now, lease }
-                        } else {
-                            LeaseEvent::Acquired { ts: now, lease }
-                        };
-                        wal.append(&event).unwrap();
                     }
                 }
                 Op::Renew { r, h, ttl_secs } => {
                     let (r, h) = (rid(r), hid(h));
-                    if let Ok(lease) = table.renew(&r, &h, Duration::from_secs(ttl_secs as u64), now) {
+                    if let Ok(lease) =
+                        durable.renew(&r, &h, Duration::from_secs(u64::from(ttl_secs)), now)
+                    {
                         // Renewal never mints a token.
                         prop_assert_eq!(believed.get(&(r, h)).copied(), Some(lease.fencing_token));
-                        wal.append(&LeaseEvent::Renewed { ts: now, lease }).unwrap();
                     }
                 }
                 Op::Release { r, h } => {
                     let (r, h) = (rid(r), hid(h));
-                    if table.release(&r, &h).is_ok() {
-                        believed.remove(&(r.clone(), h.clone()));
-                        wal.append(&LeaseEvent::Released { ts: now, resource_id: r, holder_id: h }).unwrap();
+                    if durable.release(&r, &h, now).is_ok() {
+                        believed.remove(&(r, h));
                     }
                 }
                 Op::Advance { secs } => {
-                    now += Duration::from_secs(secs as u64);
+                    now += Duration::from_secs(u64::from(secs));
+                }
+                Op::Restart => {
+                    // Invariant 4: recovery reproduces the live table exactly.
+                    let before = durable.table().clone();
+                    drop(durable);
+                    durable = DurableLeaseTable::open(dir.path()).unwrap();
+                    prop_assert_eq!(durable.table(), &before);
                 }
                 Op::Write { r, h } => {
                     let (r, h) = (rid(r), hid(h));
@@ -116,19 +125,16 @@ proptest! {
                     if token == max_issued {
                         // Invariant 2: the newest epoch is never fenced.
                         prop_assert!(result.is_ok(),
-                            "newest token {:?} fenced on {}", token, r);
+                            "newest token {} fenced on {}", token, r);
                     } else if guard.high_water().is_some_and(|hw| hw > token) {
                         // Invariant 3: once a newer epoch has written, the
                         // stale waker is rejected — the AC7 race.
                         prop_assert!(result.is_err(),
-                            "stale token {:?} accepted on {} past high-water", token, r);
+                            "stale token {} accepted on {} past high-water", token, r);
                     }
                 }
             }
         }
 
-        // Invariant 4: the log alone rebuilds the live table.
-        let recovered = wal.replay().unwrap();
-        prop_assert_eq!(recovered, table);
     }
 }

--- a/src/coordinator/proptests.rs
+++ b/src/coordinator/proptests.rs
@@ -76,6 +76,44 @@ fn hid(h: u8) -> String {
     format!("holder-{h}")
 }
 
+/// Recovery guarantee with memory-only renewals: recovery reproduces the
+/// last durable GRANT for each resource exactly (holder, token, watermark,
+/// grant expiry); renewals are deliberately forgotten. Forgetting an
+/// extending renew shortens the recovered lease (faster reclaim, higher
+/// token — safe); forgetting a shortening renew restores the grant's longer
+/// expiry (a bounded liveness cost, never a safety loss: fencing does not
+/// depend on expiry).
+fn assert_recovery_sound(
+    after: &super::lease::LeaseTable,
+    before: &super::lease::LeaseTable,
+    durable_grants: &HashMap<String, chrono::DateTime<Utc>>,
+    resources: &[String],
+) -> Result<(), proptest::test_runner::TestCaseError> {
+    for r in resources {
+        prop_assert_eq!(
+            before.watermark(r),
+            after.watermark(r),
+            "watermark changed across restart on {}",
+            r
+        );
+        match (before.get(r), after.get(r)) {
+            (None, None) => {}
+            (Some(b), Some(a)) => {
+                prop_assert_eq!(&b.holder_id, &a.holder_id, "holder changed on {}", r);
+                prop_assert_eq!(b.fencing_token, a.fencing_token, "token changed on {}", r);
+                prop_assert_eq!(
+                    Some(a.expires_at()),
+                    durable_grants.get(r).copied(),
+                    "recovered expiry is not the durable grant's on {}",
+                    r
+                );
+            }
+            (b, a) => prop_assert!(false, "lease presence changed on {}: {:?} -> {:?}", r, b, a),
+        }
+    }
+    Ok(())
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(192))]
 
@@ -93,6 +131,9 @@ proptest! {
         // Each holder's belief about the token it holds — kept even after the
         // lease is reclaimed under it. This IS the paused stale holder.
         let mut believed: HashMap<(String, String), FencingToken> = HashMap::new();
+        // Expiry of the last durable GRANT per resource — what recovery
+        // reproduces (renewals are memory-only by design).
+        let mut durable_grants: HashMap<String, chrono::DateTime<Utc>> = HashMap::new();
 
         for op in ops {
             match op {
@@ -107,6 +148,7 @@ proptest! {
                         prop_assert!(prior.iter().all(|t| lease.fencing_token > *t),
                             "token {} not above prior {:?}", lease.fencing_token, prior);
                         prior.push(lease.fencing_token);
+                        durable_grants.insert(r.clone(), lease.expires_at());
                         believed.insert((r, h), lease.fencing_token);
                     }
                 }
@@ -122,6 +164,7 @@ proptest! {
                 Op::Release { r, h } => {
                     let (r, h) = (rid(r), hid(h));
                     if durable.release(&r, &h, now).is_ok() {
+                        durable_grants.remove(&r);
                         believed.remove(&(r, h));
                     }
                 }
@@ -129,11 +172,13 @@ proptest! {
                     now += Duration::from_secs(u64::from(secs));
                 }
                 Op::Restart => {
-                    // Invariant 4: recovery reproduces the live table exactly.
+                    // Invariant 4: recovery is sound — grants/releases exact,
+                    // renewals may be forgotten (shorter expiry only).
                     let before = durable.table().clone();
                     drop(durable);
                     durable = DurableLeaseTable::open(dir.path()).unwrap();
-                    prop_assert_eq!(durable.table(), &before);
+                    let resources: Vec<String> = (0..2u8).map(rid).collect();
+                    assert_recovery_sound(durable.table(), &before, &durable_grants, &resources)?;
                 }
                 Op::TearAndRestart => {
                     let before = durable.table().clone();
@@ -148,7 +193,8 @@ proptest! {
                     }
                     durable = DurableLeaseTable::open(dir.path()).unwrap();
                     // Torn bytes are truncated; every acked grant survives.
-                    prop_assert_eq!(durable.table(), &before);
+                    let resources: Vec<String> = (0..2u8).map(rid).collect();
+                    assert_recovery_sound(durable.table(), &before, &durable_grants, &resources)?;
                 }
                 Op::Write { r, h } => {
                     let (r, h) = (rid(r), hid(h));

--- a/src/coordinator/wal.rs
+++ b/src/coordinator/wal.rs
@@ -1,138 +1,205 @@
 //! Lease event log — persistence for the lease table.
 //!
-//! Mirrors the conversation WAL's mechanics (`src/wal.rs`: JSONL, `O_APPEND`,
-//! torn-trailing-line-tolerant replay) but keeps its own log — `WalEntry` is
-//! conversation-shaped and lease events don't belong in it. Every append is
-//! fsynced: lease state is correctness-critical, there is no "replaceable"
-//! tier like chat messages have.
+//! JSONL like the conversation WAL (`src/wal.rs`) but with the guarantees a
+//! correctness-critical log needs and a chat log doesn't:
 //!
-//! Replay folds events back into a `LeaseTable`, preserving the per-resource
-//! token watermark even for resources whose lease was released before
-//! shutdown — the watermark is what keeps post-restart tokens strictly
-//! increasing.
+//! - **Exclusive lock, held for the process lifetime.** Exactly one process
+//!   owns the lease log; a second `LeaseWal::new` on the same directory
+//!   fails instead of silently interleaving appends.
+//! - **fsync on every append** (`sync_all` — file size metadata is part of
+//!   the correctness story), plus one directory fsync at creation so the
+//!   dentry itself survives a crash.
+//! - **Versioned lines** (`{"v":1,"e":{…}}`) so a future format change fails
+//!   loudly instead of silently replaying to an empty table.
+//! - **Fail-closed replay.** Only a torn *final* line is tolerated (a crash
+//!   mid-append; safe because `DurableLeaseTable` never hands out a token
+//!   before its event is durable, so a torn tail is a grant nobody received).
+//!   A bad line anywhere else, an unknown version, or an event that violates
+//!   the table's invariants (`LeaseTable::apply`) aborts recovery.
+//! - **0700 directory / 0600 file** — whoever can write this file owns the
+//!   coordinator's mutual exclusion.
 
-use std::cmp::max;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, BufRead, BufReader, Write as IoWrite};
+use std::io::{self, BufRead, BufReader, Write as _};
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-use super::lease::{FencingToken, Lease, LeaseTable};
+use super::lease::{ApplyError, LeaseEvent, LeaseTable};
 
-/// A state change worth surviving a restart.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "event", rename_all = "snake_case")]
-pub enum LeaseEvent {
-    /// Fresh acquire on a free resource.
-    Acquired {
-        ts: DateTime<Utc>,
-        lease: Lease,
-    },
-    /// Acquire over an expired lease — same replay semantics as `Acquired`,
-    /// logged distinctly so reclaims are auditable.
-    Reclaimed {
-        ts: DateTime<Utc>,
-        lease: Lease,
-    },
-    Renewed {
-        ts: DateTime<Utc>,
-        lease: Lease,
-    },
-    Released {
-        ts: DateTime<Utc>,
-        resource_id: String,
-        holder_id: String,
-    },
+const WAL_VERSION: u32 = 1;
+
+/// Lines beyond this are treated as corruption, not parsed — bounds replay
+/// memory against a runaway or corrupt line. Generous: real events are <1 KiB.
+const MAX_LINE_BYTES: usize = 64 * 1024;
+
+#[derive(Serialize)]
+struct WalLineRef<'a> {
+    v: u32,
+    e: &'a LeaseEvent,
+}
+
+#[derive(Deserialize)]
+struct WalLine {
+    v: u32,
+    e: LeaseEvent,
+}
+
+/// Replay failures. `Corrupt`/`Version`/`Apply` mean the log cannot be
+/// trusted — the coordinator must not serve leases from a guessed state.
+#[derive(Debug, Error)]
+pub enum ReplayError {
+    #[error("lease WAL io: {0}")]
+    Io(#[from] io::Error),
+    #[error("lease WAL line {line} is corrupt and not the final line — refusing to guess state")]
+    Corrupt { line: usize },
+    #[error("lease WAL line {line} has version {found}, expected {WAL_VERSION}")]
+    Version { line: usize, found: u32 },
+    #[error("lease WAL line {line} violates lease invariants: {source}")]
+    Apply { line: usize, source: ApplyError },
 }
 
 /// Append-only JSONL log of lease events at `{dir}/leases.jsonl`.
+#[derive(Debug)]
 pub struct LeaseWal {
     path: PathBuf,
+    /// Held open for the process lifetime; carries the exclusive lock.
+    file: File,
 }
 
 impl LeaseWal {
-    /// Create a lease WAL under `dir` (created if missing).
+    /// Open (creating if needed) the lease WAL under `dir` and take the
+    /// exclusive lock. Fails if another process holds it.
     pub fn new(dir: &Path) -> io::Result<Self> {
-        fs::create_dir_all(dir)?;
-        Ok(Self {
-            path: dir.join("leases.jsonl"),
-        })
+        let mut builder = fs::DirBuilder::new();
+        builder.recursive(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        builder.create(dir)?;
+
+        let path = dir.join("leases.jsonl");
+        let mut opts = OpenOptions::new();
+        opts.create(true).append(true).read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let file = opts.open(&path)?;
+
+        file.try_lock().map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::WouldBlock,
+                format!(
+                    "lease WAL at {} is locked by another process ({e}); \
+                     exactly one coordinator may own it",
+                    path.display()
+                ),
+            )
+        })?;
+
+        // Make the dentry durable: sync_all on the file covers its contents,
+        // not the directory entry pointing at it.
+        File::open(dir)?.sync_all()?;
+
+        Ok(Self { path, file })
     }
 
-    /// Append one event. `O_APPEND` for single-write atomicity, fsync always —
-    /// every lease event is correctness-critical.
+    /// Append one event. `O_APPEND` for single-write atomicity, `sync_all`
+    /// always — every lease event is correctness-critical.
     pub fn append(&self, event: &LeaseEvent) -> io::Result<()> {
-        let mut line = serde_json::to_string(event)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let mut line = serde_json::to_string(&WalLineRef {
+            v: WAL_VERSION,
+            e: event,
+        })
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         line.push('\n');
 
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)?;
-        file.write_all(line.as_bytes())?;
-        file.sync_data()?;
+        (&self.file).write_all(line.as_bytes())?;
+        self.file.sync_all()?;
         Ok(())
     }
 
-    /// Read all events. Tolerates torn writes: unparseable lines are skipped
-    /// with a warning, intact entries are kept.
-    pub fn read(&self) -> io::Result<Vec<LeaseEvent>> {
-        if !self.path.exists() {
-            return Ok(Vec::new());
+    /// Read all events, failing closed on anything but a torn final line.
+    /// Reads raw bytes (not `lines()`) so a tear inside a multi-byte UTF-8
+    /// sequence is corruption to classify, not an io error that loses the log.
+    pub fn read(&self) -> Result<Vec<LeaseEvent>, ReplayError> {
+        let file = match File::open(&self.path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e.into()),
+        };
+        let mut reader = BufReader::new(file);
+
+        let mut raw_lines: Vec<Vec<u8>> = Vec::new();
+        loop {
+            let mut buf = Vec::new();
+            let n = reader.read_until(b'\n', &mut buf)?;
+            if n == 0 {
+                break;
+            }
+            if buf.last() == Some(&b'\n') {
+                buf.pop();
+            }
+            raw_lines.push(buf);
         }
 
-        let file = File::open(&self.path)?;
-        let reader = BufReader::new(file);
-        let mut events = Vec::new();
+        let last_content_idx = raw_lines
+            .iter()
+            .rposition(|l| !l.iter().all(u8::is_ascii_whitespace));
 
-        for (line_num, line) in reader.lines().enumerate() {
-            let line = line?;
-            if line.trim().is_empty() {
+        let mut events = Vec::new();
+        for (idx, raw) in raw_lines.iter().enumerate() {
+            if raw.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }
-            match serde_json::from_str::<LeaseEvent>(&line) {
-                Ok(event) => events.push(event),
-                Err(e) => {
+            let parsed = if raw.len() > MAX_LINE_BYTES {
+                None
+            } else {
+                std::str::from_utf8(raw)
+                    .ok()
+                    .and_then(|s| serde_json::from_str::<WalLine>(s).ok())
+            };
+            match parsed {
+                Some(line) if line.v == WAL_VERSION => events.push(line.e),
+                Some(line) => {
+                    return Err(ReplayError::Version {
+                        line: idx + 1,
+                        found: line.v,
+                    });
+                }
+                None if Some(idx) == last_content_idx => {
+                    // Torn final line: a crash mid-append. The event was never
+                    // acknowledged (grants are durable-before-visible), so
+                    // dropping it is safe.
                     tracing::warn!(
-                        "lease WAL parse error at line {}: {} (skipping)",
-                        line_num + 1,
-                        e
+                        "lease WAL: dropping torn final line {} ({} bytes)",
+                        idx + 1,
+                        raw.len()
                     );
                 }
+                None => return Err(ReplayError::Corrupt { line: idx + 1 }),
             }
         }
 
         Ok(events)
     }
 
-    /// Rebuild the lease table from the log. Watermarks survive release;
-    /// a `Released` for a resource the log never granted is ignored.
-    pub fn replay(&self) -> io::Result<LeaseTable> {
+    /// Rebuild the lease table from the log via `LeaseTable::apply`, which
+    /// enforces every online invariant during the fold. Watermarks survive
+    /// release, so post-restart tokens stay strictly increasing.
+    pub fn replay(&self) -> Result<LeaseTable, ReplayError> {
         let mut table = LeaseTable::new();
-
-        for event in self.read()? {
-            match event {
-                LeaseEvent::Acquired { lease, .. }
-                | LeaseEvent::Reclaimed { lease, .. }
-                | LeaseEvent::Renewed { lease, .. } => {
-                    let resource_id = lease.resource_id.clone();
-                    let watermark = max(
-                        table.watermark(&resource_id).unwrap_or(FencingToken(0)),
-                        lease.fencing_token,
-                    );
-                    table.restore(&resource_id, Some(lease), watermark);
-                }
-                LeaseEvent::Released { resource_id, .. } => {
-                    if let Some(watermark) = table.watermark(&resource_id) {
-                        table.restore(&resource_id, None, watermark);
-                    }
-                }
-            }
+        for (idx, event) in self.read()?.into_iter().enumerate() {
+            table.apply(&event).map_err(|source| ReplayError::Apply {
+                line: idx + 1,
+                source,
+            })?;
         }
-
         Ok(table)
     }
 
@@ -144,8 +211,10 @@ impl LeaseWal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
+    use chrono::{DateTime, TimeZone, Utc};
     use std::time::Duration;
+
+    use super::super::lease::{FencingToken, Lease};
 
     fn t0() -> DateTime<Utc> {
         Utc.with_ymd_and_hms(2026, 8, 7, 12, 0, 0).unwrap()
@@ -155,7 +224,12 @@ mod tests {
         Duration::from_secs(n)
     }
 
-    /// Drive a table and log every state change, as a coordinator would.
+    fn append_raw(wal: &LeaseWal, bytes: &[u8]) {
+        let mut file = OpenOptions::new().append(true).open(wal.path()).unwrap();
+        file.write_all(bytes).unwrap();
+    }
+
+    /// Drive a table and log every state change, as the durable layer does.
     fn logged_acquire(
         table: &mut LeaseTable,
         wal: &LeaseWal,
@@ -190,6 +264,39 @@ mod tests {
     }
 
     #[test]
+    fn golden_wire_format_is_pinned() {
+        // If this test breaks, the on-disk format changed: bump WAL_VERSION
+        // and write a migration, don't just update the string.
+        let lease = Lease {
+            resource_id: "wal".to_string(),
+            holder_id: "echo-a".to_string(),
+            fencing_token: FencingToken(1),
+            granted_at: t0(),
+            ttl: secs(30),
+        };
+        let event = LeaseEvent::Acquired {
+            ts: t0(),
+            lease: lease.clone(),
+        };
+        let line = serde_json::to_string(&WalLineRef { v: 1, e: &event }).unwrap();
+        assert_eq!(
+            line,
+            r#"{"v":1,"e":{"event":"acquired","ts":"2026-08-07T12:00:00Z","lease":{"resource_id":"wal","holder_id":"echo-a","fencing_token":1,"granted_at":"2026-08-07T12:00:00Z","ttl":{"secs":30,"nanos":0}}}}"#
+        );
+
+        let released = LeaseEvent::Released {
+            ts: t0(),
+            resource_id: "wal".to_string(),
+            holder_id: "echo-a".to_string(),
+        };
+        let line = serde_json::to_string(&WalLineRef { v: 1, e: &released }).unwrap();
+        assert_eq!(
+            line,
+            r#"{"v":1,"e":{"event":"released","ts":"2026-08-07T12:00:00Z","resource_id":"wal","holder_id":"echo-a"}}"#
+        );
+    }
+
+    #[test]
     fn restart_recovers_leases_and_watermarks_exactly() {
         let dir = tempfile::tempdir().unwrap();
         let mut table = LeaseTable::new();
@@ -207,7 +314,7 @@ mod tests {
             .unwrap();
         }
 
-        // "Restart": fresh handle over the same directory.
+        // "Restart": fresh handle over the same directory (lock was dropped).
         let recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
         assert_eq!(recovered, table);
         assert_eq!(
@@ -220,16 +327,18 @@ mod tests {
     fn watermark_survives_release_so_next_token_is_higher() {
         let dir = tempfile::tempdir().unwrap();
         let mut table = LeaseTable::new();
-        let wal = LeaseWal::new(dir.path()).unwrap();
-
-        let first = logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
-        table.release("wal", "echo-a").unwrap();
-        wal.append(&LeaseEvent::Released {
-            ts: t0() + secs(5),
-            resource_id: "wal".to_string(),
-            holder_id: "echo-a".to_string(),
-        })
-        .unwrap();
+        let first;
+        {
+            let wal = LeaseWal::new(dir.path()).unwrap();
+            first = logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
+            table.release("wal", "echo-a").unwrap();
+            wal.append(&LeaseEvent::Released {
+                ts: t0() + secs(5),
+                resource_id: "wal".to_string(),
+                holder_id: "echo-a".to_string(),
+            })
+            .unwrap();
+        }
 
         let mut recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
         assert!(recovered.get("wal").is_none());
@@ -250,6 +359,7 @@ mod tests {
         logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
         let reclaimed =
             logged_acquire(&mut table, &wal, "wal", "echo-b", secs(30), t0() + secs(31));
+        drop(wal);
 
         let recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
         assert_eq!(recovered.get("wal").unwrap().holder_id, "echo-b");
@@ -257,26 +367,69 @@ mod tests {
     }
 
     #[test]
-    fn torn_trailing_line_keeps_intact_prefix_and_does_not_panic() {
+    fn torn_ascii_tail_is_dropped_and_intact_prefix_kept() {
         let dir = tempfile::tempdir().unwrap();
         let mut table = LeaseTable::new();
         let wal = LeaseWal::new(dir.path()).unwrap();
 
         logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
         logged_acquire(&mut table, &wal, "journal", "echo-b", secs(30), t0());
-
-        // Simulate a torn write: half a JSON object, no newline.
-        let mut file = OpenOptions::new().append(true).open(wal.path()).unwrap();
-        file.write_all(br#"{"event":"acquired","ts":"2026-"#)
-            .unwrap();
-        drop(file);
+        append_raw(&wal, br#"{"v":1,"e":{"event":"acquired","ts":"2026-"#);
+        drop(wal);
 
         let recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
         assert_eq!(recovered, table);
     }
 
     #[test]
-    fn released_for_unknown_resource_is_ignored() {
+    fn torn_multibyte_utf8_tail_is_dropped_not_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut table = LeaseTable::new();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+
+        logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
+        // First two bytes of a 3-byte UTF-8 char ("€"): invalid as UTF-8.
+        append_raw(&wal, &[b'{', b'"', 0xE2, 0x82]);
+        drop(wal);
+
+        let recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
+        assert_eq!(recovered, table);
+    }
+
+    #[test]
+    fn corrupt_mid_file_line_is_fatal_not_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut table = LeaseTable::new();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+
+        logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
+        append_raw(&wal, b"garbage-not-json\n");
+        logged_acquire(&mut table, &wal, "journal", "echo-b", secs(30), t0());
+        drop(wal);
+
+        let err = LeaseWal::new(dir.path()).unwrap().replay().unwrap_err();
+        assert!(matches!(err, ReplayError::Corrupt { line: 2 }));
+    }
+
+    #[test]
+    fn unknown_version_is_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+        append_raw(
+            &wal,
+            br#"{"v":2,"e":{"event":"released","ts":"2026-08-07T12:00:00Z","resource_id":"wal","holder_id":"echo-a"}}
+"#,
+        );
+        drop(wal);
+
+        let err = LeaseWal::new(dir.path()).unwrap().replay().unwrap_err();
+        assert!(matches!(err, ReplayError::Version { line: 1, found: 2 }));
+    }
+
+    #[test]
+    fn forged_released_for_unheld_resource_is_fatal() {
+        // Under fail-closed replay a Released with no matching lease is
+        // tampering or state loss, not noise to ignore.
         let dir = tempfile::tempdir().unwrap();
         let wal = LeaseWal::new(dir.path()).unwrap();
         wal.append(&LeaseEvent::Released {
@@ -286,7 +439,34 @@ mod tests {
         })
         .unwrap();
 
-        let recovered = wal.replay().unwrap();
-        assert_eq!(recovered, LeaseTable::new());
+        let err = wal.replay().unwrap_err();
+        assert!(matches!(
+            err,
+            ReplayError::Apply {
+                line: 1,
+                source: ApplyError::NoLease { .. }
+            }
+        ));
+    }
+
+    #[test]
+    fn second_open_on_same_dir_is_refused_while_locked() {
+        let dir = tempfile::tempdir().unwrap();
+        let _wal = LeaseWal::new(dir.path()).unwrap();
+        let err = LeaseWal::new(dir.path()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn log_file_and_dir_are_private() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("leases");
+        let wal = LeaseWal::new(&sub).unwrap();
+        let dir_mode = fs::metadata(&sub).unwrap().permissions().mode() & 0o777;
+        let file_mode = fs::metadata(wal.path()).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, 0o700);
+        assert_eq!(file_mode, 0o600);
     }
 }

--- a/src/coordinator/wal.rs
+++ b/src/coordinator/wal.rs
@@ -1,0 +1,292 @@
+//! Lease event log — persistence for the lease table.
+//!
+//! Mirrors the conversation WAL's mechanics (`src/wal.rs`: JSONL, `O_APPEND`,
+//! torn-trailing-line-tolerant replay) but keeps its own log — `WalEntry` is
+//! conversation-shaped and lease events don't belong in it. Every append is
+//! fsynced: lease state is correctness-critical, there is no "replaceable"
+//! tier like chat messages have.
+//!
+//! Replay folds events back into a `LeaseTable`, preserving the per-resource
+//! token watermark even for resources whose lease was released before
+//! shutdown — the watermark is what keeps post-restart tokens strictly
+//! increasing.
+
+use std::cmp::max;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write as IoWrite};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::lease::{FencingToken, Lease, LeaseTable};
+
+/// A state change worth surviving a restart.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum LeaseEvent {
+    /// Fresh acquire on a free resource.
+    Acquired {
+        ts: DateTime<Utc>,
+        lease: Lease,
+    },
+    /// Acquire over an expired lease — same replay semantics as `Acquired`,
+    /// logged distinctly so reclaims are auditable.
+    Reclaimed {
+        ts: DateTime<Utc>,
+        lease: Lease,
+    },
+    Renewed {
+        ts: DateTime<Utc>,
+        lease: Lease,
+    },
+    Released {
+        ts: DateTime<Utc>,
+        resource_id: String,
+        holder_id: String,
+    },
+}
+
+/// Append-only JSONL log of lease events at `{dir}/leases.jsonl`.
+pub struct LeaseWal {
+    path: PathBuf,
+}
+
+impl LeaseWal {
+    /// Create a lease WAL under `dir` (created if missing).
+    pub fn new(dir: &Path) -> io::Result<Self> {
+        fs::create_dir_all(dir)?;
+        Ok(Self {
+            path: dir.join("leases.jsonl"),
+        })
+    }
+
+    /// Append one event. `O_APPEND` for single-write atomicity, fsync always —
+    /// every lease event is correctness-critical.
+    pub fn append(&self, event: &LeaseEvent) -> io::Result<()> {
+        let mut line = serde_json::to_string(event)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        line.push('\n');
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        file.write_all(line.as_bytes())?;
+        file.sync_data()?;
+        Ok(())
+    }
+
+    /// Read all events. Tolerates torn writes: unparseable lines are skipped
+    /// with a warning, intact entries are kept.
+    pub fn read(&self) -> io::Result<Vec<LeaseEvent>> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let file = File::open(&self.path)?;
+        let reader = BufReader::new(file);
+        let mut events = Vec::new();
+
+        for (line_num, line) in reader.lines().enumerate() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<LeaseEvent>(&line) {
+                Ok(event) => events.push(event),
+                Err(e) => {
+                    tracing::warn!(
+                        "lease WAL parse error at line {}: {} (skipping)",
+                        line_num + 1,
+                        e
+                    );
+                }
+            }
+        }
+
+        Ok(events)
+    }
+
+    /// Rebuild the lease table from the log. Watermarks survive release;
+    /// a `Released` for a resource the log never granted is ignored.
+    pub fn replay(&self) -> io::Result<LeaseTable> {
+        let mut table = LeaseTable::new();
+
+        for event in self.read()? {
+            match event {
+                LeaseEvent::Acquired { lease, .. }
+                | LeaseEvent::Reclaimed { lease, .. }
+                | LeaseEvent::Renewed { lease, .. } => {
+                    let resource_id = lease.resource_id.clone();
+                    let watermark = max(
+                        table.watermark(&resource_id).unwrap_or(FencingToken(0)),
+                        lease.fencing_token,
+                    );
+                    table.restore(&resource_id, Some(lease), watermark);
+                }
+                LeaseEvent::Released { resource_id, .. } => {
+                    if let Some(watermark) = table.watermark(&resource_id) {
+                        table.restore(&resource_id, None, watermark);
+                    }
+                }
+            }
+        }
+
+        Ok(table)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::time::Duration;
+
+    fn t0() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 7, 12, 0, 0).unwrap()
+    }
+
+    fn secs(n: u64) -> Duration {
+        Duration::from_secs(n)
+    }
+
+    /// Drive a table and log every state change, as a coordinator would.
+    fn logged_acquire(
+        table: &mut LeaseTable,
+        wal: &LeaseWal,
+        resource: &str,
+        holder: &str,
+        ttl: Duration,
+        now: DateTime<Utc>,
+    ) -> Lease {
+        let reclaim = table.get(resource).is_some_and(|l| l.is_expired(now));
+        let lease = table.acquire(resource, holder, ttl, now).unwrap();
+        let event = if reclaim {
+            LeaseEvent::Reclaimed {
+                ts: now,
+                lease: lease.clone(),
+            }
+        } else {
+            LeaseEvent::Acquired {
+                ts: now,
+                lease: lease.clone(),
+            }
+        };
+        wal.append(&event).unwrap();
+        lease
+    }
+
+    #[test]
+    fn empty_log_replays_to_empty_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+        let table = wal.replay().unwrap();
+        assert_eq!(table, LeaseTable::new());
+    }
+
+    #[test]
+    fn restart_recovers_leases_and_watermarks_exactly() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut table = LeaseTable::new();
+        {
+            let wal = LeaseWal::new(dir.path()).unwrap();
+            logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
+            logged_acquire(&mut table, &wal, "journal", "echo-b", secs(60), t0());
+            let renewed = table
+                .renew("wal", "echo-a", secs(90), t0() + secs(10))
+                .unwrap();
+            wal.append(&LeaseEvent::Renewed {
+                ts: t0() + secs(10),
+                lease: renewed,
+            })
+            .unwrap();
+        }
+
+        // "Restart": fresh handle over the same directory.
+        let recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
+        assert_eq!(recovered, table);
+        assert_eq!(
+            recovered.get("wal").unwrap().expires_at(),
+            t0() + secs(10) + secs(90)
+        );
+    }
+
+    #[test]
+    fn watermark_survives_release_so_next_token_is_higher() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut table = LeaseTable::new();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+
+        let first = logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
+        table.release("wal", "echo-a").unwrap();
+        wal.append(&LeaseEvent::Released {
+            ts: t0() + secs(5),
+            resource_id: "wal".to_string(),
+            holder_id: "echo-a".to_string(),
+        })
+        .unwrap();
+
+        let mut recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
+        assert!(recovered.get("wal").is_none());
+        assert_eq!(recovered.watermark("wal"), Some(first.fencing_token));
+
+        let next = recovered
+            .acquire("wal", "echo-b", secs(30), t0() + secs(10))
+            .unwrap();
+        assert!(next.fencing_token > first.fencing_token);
+    }
+
+    #[test]
+    fn reclaim_event_replays_like_acquire() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut table = LeaseTable::new();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+
+        logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
+        let reclaimed =
+            logged_acquire(&mut table, &wal, "wal", "echo-b", secs(30), t0() + secs(31));
+
+        let recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
+        assert_eq!(recovered.get("wal").unwrap().holder_id, "echo-b");
+        assert_eq!(recovered.watermark("wal"), Some(reclaimed.fencing_token));
+    }
+
+    #[test]
+    fn torn_trailing_line_keeps_intact_prefix_and_does_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut table = LeaseTable::new();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+
+        logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
+        logged_acquire(&mut table, &wal, "journal", "echo-b", secs(30), t0());
+
+        // Simulate a torn write: half a JSON object, no newline.
+        let mut file = OpenOptions::new().append(true).open(wal.path()).unwrap();
+        file.write_all(br#"{"event":"acquired","ts":"2026-"#)
+            .unwrap();
+        drop(file);
+
+        let recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
+        assert_eq!(recovered, table);
+    }
+
+    #[test]
+    fn released_for_unknown_resource_is_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+        wal.append(&LeaseEvent::Released {
+            ts: t0(),
+            resource_id: "ghost".to_string(),
+            holder_id: "echo-a".to_string(),
+        })
+        .unwrap();
+
+        let recovered = wal.replay().unwrap();
+        assert_eq!(recovered, LeaseTable::new());
+    }
+}

--- a/src/coordinator/wal.rs
+++ b/src/coordinator/wal.rs
@@ -6,22 +6,35 @@
 //! - **Exclusive lock, held for the process lifetime.** Exactly one process
 //!   owns the lease log; a second `LeaseWal::new` on the same directory
 //!   fails instead of silently interleaving appends.
+//! - **Tail repair at open.** Under the lock, before replay or any append,
+//!   unterminated trailing bytes (a crash mid-append) are truncated away —
+//!   a later append can therefore never glue onto torn bytes and take an
+//!   acked event down with it on the next recovery.
+//! - **Failure-atomic appends.** A short write or failed fsync rewinds the
+//!   file to its pre-append length; if the rewind itself fails the WAL is
+//!   poisoned and refuses further appends rather than corrupting the log.
 //! - **fsync on every append** (`sync_all` — file size metadata is part of
 //!   the correctness story), plus one directory fsync at creation so the
 //!   dentry itself survives a crash.
 //! - **Versioned lines** (`{"v":1,"e":{…}}`) so a future format change fails
 //!   loudly instead of silently replaying to an empty table.
-//! - **Fail-closed replay.** Only a torn *final* line is tolerated (a crash
-//!   mid-append; safe because `DurableLeaseTable` never hands out a token
-//!   before its event is durable, so a torn tail is a grant nobody received).
-//!   A bad line anywhere else, an unknown version, or an event that violates
-//!   the table's invariants (`LeaseTable::apply`) aborts recovery.
-//! - **0700 directory / 0600 file** — whoever can write this file owns the
-//!   coordinator's mutual exclusion.
+//! - **Fail-closed replay.** After tail repair, every surviving line must
+//!   parse, carry the current version, and satisfy the lease-table
+//!   invariants (`LeaseTable::apply`) — anything else aborts recovery. Only
+//!   an *unterminated* final line (torn append; provably a grant nobody
+//!   received, because grants are durable-before-visible) is ever dropped.
+//! - **0700 directory / 0600 file, symlinks refused, loose pre-existing
+//!   modes tightened** — whoever can write this file owns the coordinator's
+//!   mutual exclusion.
+//!
+//! Known deferred work (Stage 1, before real wiring): snapshot+truncate
+//! compaction (log and replay currently grow with history), and an operator
+//! repair path for a log that fails closed mid-file.
 
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, BufRead, BufReader, Write as _};
+use std::io::{self, BufRead, BufReader, Read, Write as _};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -30,8 +43,9 @@ use super::lease::{ApplyError, LeaseEvent, LeaseTable};
 
 const WAL_VERSION: u32 = 1;
 
-/// Lines beyond this are treated as corruption, not parsed — bounds replay
-/// memory against a runaway or corrupt line. Generous: real events are <1 KiB.
+/// Longest admissible line. Checked incrementally while reading, so a
+/// newline-free or runaway line cannot balloon replay memory. Generous:
+/// real events are <1 KiB.
 const MAX_LINE_BYTES: usize = 64 * 1024;
 
 #[derive(Serialize)]
@@ -41,6 +55,7 @@ struct WalLineRef<'a> {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct WalLine {
     v: u32,
     e: LeaseEvent,
@@ -48,16 +63,28 @@ struct WalLine {
 
 /// Replay failures. `Corrupt`/`Version`/`Apply` mean the log cannot be
 /// trusted — the coordinator must not serve leases from a guessed state.
+/// `Locked` is operational, not corruption: another coordinator owns the log.
 #[derive(Debug, Error)]
 pub enum ReplayError {
     #[error("lease WAL io: {0}")]
     Io(#[from] io::Error),
-    #[error("lease WAL line {line} is corrupt and not the final line — refusing to guess state")]
+    #[error("lease WAL at {path} is locked by another coordinator process")]
+    Locked { path: PathBuf },
+    #[error("lease WAL line {line} is corrupt — refusing to guess state")]
     Corrupt { line: usize },
     #[error("lease WAL line {line} has version {found}, expected {WAL_VERSION}")]
     Version { line: usize, found: u32 },
     #[error("lease WAL line {line} violates lease invariants: {source}")]
     Apply { line: usize, source: ApplyError },
+}
+
+struct RawLine {
+    /// 1-based physical line number in the file (blank lines counted).
+    number: usize,
+    bytes: Vec<u8>,
+    /// Whether the line ended with `\n`. After tail repair only a line
+    /// appended concurrently with this read can be unterminated.
+    terminated: bool,
 }
 
 /// Append-only JSONL log of lease events at `{dir}/leases.jsonl`.
@@ -66,11 +93,15 @@ pub struct LeaseWal {
     path: PathBuf,
     /// Held open for the process lifetime; carries the exclusive lock.
     file: File,
+    /// Set when a failed append could not be rewound — the log's tail state
+    /// is unknown and further appends would corrupt it.
+    poisoned: AtomicBool,
 }
 
 impl LeaseWal {
-    /// Open (creating if needed) the lease WAL under `dir` and take the
-    /// exclusive lock. Fails if another process holds it.
+    /// Open (creating if needed) the lease WAL under `dir`, take the
+    /// exclusive lock, and repair any torn tail. Fails if another process
+    /// holds the lock, or if the log path is a symlink.
     pub fn new(dir: &Path) -> io::Result<Self> {
         let mut builder = fs::DirBuilder::new();
         builder.recursive(true);
@@ -80,8 +111,24 @@ impl LeaseWal {
             builder.mode(0o700);
         }
         builder.create(dir)?;
+        #[cfg(unix)]
+        Self::tighten_dir_modes(dir)?;
 
         let path = dir.join("leases.jsonl");
+
+        // Refuse a planted symlink: fsynced appends must never land on a
+        // path an attacker chose. (Racy against a writer inside the dir, but
+        // the dir is 0700-owned; this closes the pre-planted case.)
+        match fs::symlink_metadata(&path) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("lease WAL path {} is a symlink — refusing", path.display()),
+                ));
+            }
+            _ => {}
+        }
+
         let mut opts = OpenOptions::new();
         opts.create(true).append(true).read(true);
         #[cfg(unix)]
@@ -90,6 +137,16 @@ impl LeaseWal {
             opts.mode(0o600);
         }
         let file = opts.open(&path)?;
+
+        let meta = file.metadata()?;
+        if !meta.is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("lease WAL path {} is not a regular file", path.display()),
+            ));
+        }
+        #[cfg(unix)]
+        Self::tighten_file_modes(&file, &meta)?;
 
         file.try_lock().map_err(|e| {
             io::Error::new(
@@ -102,16 +159,102 @@ impl LeaseWal {
             )
         })?;
 
+        // Under the lock, before replay or any append: drop unterminated
+        // trailing bytes so no future append can glue onto a torn tail.
+        Self::repair_tail(&file)?;
+
         // Make the dentry durable: sync_all on the file covers its contents,
         // not the directory entry pointing at it.
         File::open(dir)?.sync_all()?;
 
-        Ok(Self { path, file })
+        Ok(Self {
+            path,
+            file,
+            poisoned: AtomicBool::new(false),
+        })
     }
 
-    /// Append one event. `O_APPEND` for single-write atomicity, `sync_all`
-    /// always — every lease event is correctness-critical.
+    #[cfg(unix)]
+    fn tighten_dir_modes(dir: &Path) -> io::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+        let meta = fs::metadata(dir)?;
+        if meta.permissions().mode() & 0o077 != 0 {
+            tracing::warn!(
+                "lease WAL dir {} had loose mode {:o}; tightening to 0700",
+                dir.display(),
+                meta.permissions().mode() & 0o777
+            );
+            fs::set_permissions(dir, fs::Permissions::from_mode(0o700))?;
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn tighten_file_modes(file: &File, meta: &fs::Metadata) -> io::Result<()> {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        if meta.nlink() != 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "lease WAL file has multiple hard links — refusing",
+            ));
+        }
+        if meta.permissions().mode() & 0o077 != 0 {
+            tracing::warn!(
+                "lease WAL file had loose mode {:o}; tightening to 0600",
+                meta.permissions().mode() & 0o777
+            );
+            file.set_permissions(fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(())
+    }
+
+    /// Truncate anything after the last `\n`. Bounded memory: streams the
+    /// file in chunks. Appends go through `O_APPEND`, so the read cursor
+    /// position this leaves behind is irrelevant.
+    fn repair_tail(file: &File) -> io::Result<()> {
+        let len = file.metadata()?.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        let mut reader = BufReader::new(file);
+        let mut chunk = [0u8; 8192];
+        let mut offset: u64 = 0;
+        let mut keep: u64 = 0;
+        loop {
+            let n = reader.read(&mut chunk)?;
+            if n == 0 {
+                break;
+            }
+            for (i, b) in chunk[..n].iter().enumerate() {
+                if *b == b'\n' {
+                    keep = offset + i as u64 + 1;
+                }
+            }
+            offset += n as u64;
+        }
+
+        if keep < len {
+            tracing::warn!(
+                "lease WAL: truncating {} unterminated trailing bytes (torn append)",
+                len - keep
+            );
+            file.set_len(keep)?;
+            file.sync_all()?;
+        }
+        Ok(())
+    }
+
+    /// Append one event, failure-atomically: on any write or fsync error the
+    /// file is rewound to its pre-append length; if the rewind fails the WAL
+    /// poisons itself and refuses all further appends.
     pub fn append(&self, event: &LeaseEvent) -> io::Result<()> {
+        if self.poisoned.load(Ordering::Acquire) {
+            return Err(io::Error::other(
+                "lease WAL is poisoned by an earlier failed append — restart to recover",
+            ));
+        }
+
         let mut line = serde_json::to_string(&WalLineRef {
             v: WAL_VERSION,
             e: event,
@@ -119,74 +262,117 @@ impl LeaseWal {
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         line.push('\n');
 
-        (&self.file).write_all(line.as_bytes())?;
-        self.file.sync_all()?;
-        Ok(())
+        // Single writer (exclusive lock), so len == the O_APPEND write offset.
+        let before = self.file.metadata()?.len();
+
+        let result = (&self.file)
+            .write_all(line.as_bytes())
+            .and_then(|()| self.file.sync_all());
+
+        if let Err(e) = result {
+            match self
+                .file
+                .set_len(before)
+                .and_then(|()| self.file.sync_all())
+            {
+                Ok(()) => Err(e),
+                Err(rewind_err) => {
+                    self.poisoned.store(true, Ordering::Release);
+                    Err(io::Error::other(format!(
+                        "lease WAL append failed ({e}) and rewind failed ({rewind_err}); \
+                         WAL poisoned — restart to recover"
+                    )))
+                }
+            }
+        } else {
+            Ok(())
+        }
     }
 
-    /// Read all events, failing closed on anything but a torn final line.
-    /// Reads raw bytes (not `lines()`) so a tear inside a multi-byte UTF-8
-    /// sequence is corruption to classify, not an io error that loses the log.
-    pub fn read(&self) -> Result<Vec<LeaseEvent>, ReplayError> {
+    fn read_raw(&self) -> io::Result<Vec<RawLine>> {
         let file = match File::open(&self.path) {
             Ok(f) => f,
             Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
-            Err(e) => return Err(e.into()),
+            Err(e) => return Err(e),
         };
         let mut reader = BufReader::new(file);
 
-        let mut raw_lines: Vec<Vec<u8>> = Vec::new();
+        let mut lines = Vec::new();
+        let mut number = 0usize;
         loop {
             let mut buf = Vec::new();
-            let n = reader.read_until(b'\n', &mut buf)?;
+            let n = (&mut reader)
+                .take(MAX_LINE_BYTES as u64 + 1)
+                .read_until(b'\n', &mut buf)?;
             if n == 0 {
                 break;
             }
-            if buf.last() == Some(&b'\n') {
+            number += 1;
+            let terminated = buf.last() == Some(&b'\n');
+            if terminated {
                 buf.pop();
             }
-            raw_lines.push(buf);
+            lines.push(RawLine {
+                number,
+                bytes: buf,
+                terminated,
+            });
+            // An over-cap line without a newline was cut mid-line; the caller
+            // classifies it via its length. Stop reading rather than resync.
+            if !terminated && lines.last().is_some_and(|l| l.bytes.len() > MAX_LINE_BYTES) {
+                break;
+            }
         }
+        Ok(lines)
+    }
 
-        let last_content_idx = raw_lines
-            .iter()
-            .rposition(|l| !l.iter().all(u8::is_ascii_whitespace));
+    fn read_numbered(&self) -> Result<Vec<(usize, LeaseEvent)>, ReplayError> {
+        let raw = self.read_raw()?;
 
         let mut events = Vec::new();
-        for (idx, raw) in raw_lines.iter().enumerate() {
-            if raw.iter().all(u8::is_ascii_whitespace) {
+        for line in &raw {
+            if line.bytes.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }
-            let parsed = if raw.len() > MAX_LINE_BYTES {
-                None
-            } else {
-                std::str::from_utf8(raw)
-                    .ok()
-                    .and_then(|s| serde_json::from_str::<WalLine>(s).ok())
-            };
+            if line.bytes.len() > MAX_LINE_BYTES {
+                return Err(ReplayError::Corrupt { line: line.number });
+            }
+            let parsed = std::str::from_utf8(&line.bytes)
+                .ok()
+                .and_then(|s| serde_json::from_str::<WalLine>(s).ok());
             match parsed {
-                Some(line) if line.v == WAL_VERSION => events.push(line.e),
-                Some(line) => {
+                Some(wal_line) if wal_line.v == WAL_VERSION => {
+                    events.push((line.number, wal_line.e));
+                }
+                Some(wal_line) => {
                     return Err(ReplayError::Version {
-                        line: idx + 1,
-                        found: line.v,
+                        line: line.number,
+                        found: wal_line.v,
                     });
                 }
-                None if Some(idx) == last_content_idx => {
-                    // Torn final line: a crash mid-append. The event was never
-                    // acknowledged (grants are durable-before-visible), so
-                    // dropping it is safe.
+                None if !line.terminated => {
+                    // Unterminated tail: an append racing this read, or a
+                    // torn write `new()` has not repaired yet. The event was
+                    // never acknowledged (grants are durable-before-visible),
+                    // so dropping it is safe. Tail repair at open keeps this
+                    // from ever compounding across appends.
                     tracing::warn!(
-                        "lease WAL: dropping torn final line {} ({} bytes)",
-                        idx + 1,
-                        raw.len()
+                        "lease WAL: ignoring unterminated trailing line {} ({} bytes)",
+                        line.number,
+                        line.bytes.len()
                     );
                 }
-                None => return Err(ReplayError::Corrupt { line: idx + 1 }),
+                None => return Err(ReplayError::Corrupt { line: line.number }),
             }
         }
 
         Ok(events)
+    }
+
+    /// Read all events, failing closed on anything but an unterminated
+    /// (torn) final line.
+    pub fn read(&self) -> Result<Vec<LeaseEvent>, ReplayError> {
+        Ok(self.read_numbered()?.into_iter().map(|(_, e)| e).collect())
     }
 
     /// Rebuild the lease table from the log via `LeaseTable::apply`, which
@@ -194,11 +380,10 @@ impl LeaseWal {
     /// release, so post-restart tokens stay strictly increasing.
     pub fn replay(&self) -> Result<LeaseTable, ReplayError> {
         let mut table = LeaseTable::new();
-        for (idx, event) in self.read()?.into_iter().enumerate() {
-            table.apply(&event).map_err(|source| ReplayError::Apply {
-                line: idx + 1,
-                source,
-            })?;
+        for (line, event) in self.read_numbered()? {
+            table
+                .apply(&event)
+                .map_err(|source| ReplayError::Apply { line, source })?;
         }
         Ok(table)
     }
@@ -224,12 +409,14 @@ mod tests {
         Duration::from_secs(n)
     }
 
-    fn append_raw(wal: &LeaseWal, bytes: &[u8]) {
-        let mut file = OpenOptions::new().append(true).open(wal.path()).unwrap();
+    fn append_raw(path: &Path, bytes: &[u8]) {
+        let mut file = OpenOptions::new().append(true).open(path).unwrap();
         file.write_all(bytes).unwrap();
     }
 
-    /// Drive a table and log every state change, as the durable layer does.
+    /// Drive a table and log every state change, as the durable layer does
+    /// (append is a `DurableLeaseTable` responsibility; order there is
+    /// append-then-commit — these tests only need matching contents).
     fn logged_acquire(
         table: &mut LeaseTable,
         wal: &LeaseWal,
@@ -367,29 +554,32 @@ mod tests {
     }
 
     #[test]
-    fn torn_ascii_tail_is_dropped_and_intact_prefix_kept() {
+    fn torn_ascii_tail_is_truncated_at_open_and_prefix_kept() {
         let dir = tempfile::tempdir().unwrap();
         let mut table = LeaseTable::new();
         let wal = LeaseWal::new(dir.path()).unwrap();
 
         logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
         logged_acquire(&mut table, &wal, "journal", "echo-b", secs(30), t0());
-        append_raw(&wal, br#"{"v":1,"e":{"event":"acquired","ts":"2026-"#);
+        let intact_len = fs::metadata(wal.path()).unwrap().len();
+        append_raw(wal.path(), br#"{"v":1,"e":{"event":"acquired","ts":"2026-"#);
         drop(wal);
 
-        let recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
-        assert_eq!(recovered, table);
+        let wal = LeaseWal::new(dir.path()).unwrap();
+        // The torn bytes are gone from disk, not just skipped.
+        assert_eq!(fs::metadata(wal.path()).unwrap().len(), intact_len);
+        assert_eq!(wal.replay().unwrap(), table);
     }
 
     #[test]
-    fn torn_multibyte_utf8_tail_is_dropped_not_fatal() {
+    fn torn_multibyte_utf8_tail_is_truncated_not_fatal() {
         let dir = tempfile::tempdir().unwrap();
         let mut table = LeaseTable::new();
         let wal = LeaseWal::new(dir.path()).unwrap();
 
         logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
         // First two bytes of a 3-byte UTF-8 char ("€"): invalid as UTF-8.
-        append_raw(&wal, &[b'{', b'"', 0xE2, 0x82]);
+        append_raw(wal.path(), &[b'{', b'"', 0xE2, 0x82]);
         drop(wal);
 
         let recovered = LeaseWal::new(dir.path()).unwrap().replay().unwrap();
@@ -397,14 +587,48 @@ mod tests {
     }
 
     #[test]
-    fn corrupt_mid_file_line_is_fatal_not_skipped() {
+    fn crash_mid_append_then_two_restarts_never_loses_an_acked_grant() {
+        // The round-2 SEC-011 scenario: without tail repair, the append after
+        // a torn tail glues onto it, and the *acked* grant in the glued line
+        // is silently dropped by the next recovery — reissuing its token.
+        use super::super::durable::DurableLeaseTable;
+
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut durable = DurableLeaseTable::open(dir.path()).unwrap();
+            durable.acquire("wal", "echo-a", secs(30), t0()).unwrap();
+        }
+        // Crash mid-append leaves torn, unterminated bytes.
+        append_raw(
+            &dir.path().join("leases.jsonl"),
+            br#"{"v":1,"e":{"event":"acq"#,
+        );
+        let granted;
+        {
+            let mut durable = DurableLeaseTable::open(dir.path()).unwrap();
+            granted = durable
+                .acquire("wal", "echo-b", secs(30), t0() + secs(31))
+                .unwrap();
+            assert_eq!(granted.fencing_token, FencingToken(2));
+        }
+        // Second restart: the acked grant must still be there, token intact.
+        let mut durable = DurableLeaseTable::open(dir.path()).unwrap();
+        assert_eq!(durable.get("wal"), Some(&granted));
+        let next = durable
+            .acquire("wal", "echo-c", secs(30), t0() + secs(120))
+            .unwrap();
+        assert!(next.fencing_token > granted.fencing_token);
+    }
+
+    #[test]
+    fn newline_terminated_garbage_at_tail_is_fatal() {
+        // A complete (terminated) line that fails to parse is corruption,
+        // not a torn append — refuse to guess.
         let dir = tempfile::tempdir().unwrap();
         let mut table = LeaseTable::new();
         let wal = LeaseWal::new(dir.path()).unwrap();
-
         logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
-        append_raw(&wal, b"garbage-not-json\n");
-        logged_acquire(&mut table, &wal, "journal", "echo-b", secs(30), t0());
+        append_raw(wal.path(), b"garbage-not-json\n");
         drop(wal);
 
         let err = LeaseWal::new(dir.path()).unwrap().replay().unwrap_err();
@@ -412,11 +636,40 @@ mod tests {
     }
 
     #[test]
+    fn corrupt_mid_file_line_is_fatal_with_physical_line_number() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut table = LeaseTable::new();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+
+        logged_acquire(&mut table, &wal, "wal", "echo-a", secs(30), t0());
+        append_raw(wal.path(), b"\ngarbage-not-json\n");
+        logged_acquire(&mut table, &wal, "journal", "echo-b", secs(30), t0());
+        drop(wal);
+
+        // Physical numbering: line 1 event, line 2 blank, line 3 garbage.
+        let err = LeaseWal::new(dir.path()).unwrap().replay().unwrap_err();
+        assert!(matches!(err, ReplayError::Corrupt { line: 3 }));
+    }
+
+    #[test]
+    fn oversized_line_is_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal = LeaseWal::new(dir.path()).unwrap();
+        let mut big = vec![b'x'; MAX_LINE_BYTES + 10];
+        big.push(b'\n');
+        append_raw(wal.path(), &big);
+        drop(wal);
+
+        let err = LeaseWal::new(dir.path()).unwrap().replay().unwrap_err();
+        assert!(matches!(err, ReplayError::Corrupt { line: 1 }));
+    }
+
+    #[test]
     fn unknown_version_is_fatal() {
         let dir = tempfile::tempdir().unwrap();
         let wal = LeaseWal::new(dir.path()).unwrap();
         append_raw(
-            &wal,
+            wal.path(),
             br#"{"v":2,"e":{"event":"released","ts":"2026-08-07T12:00:00Z","resource_id":"wal","holder_id":"echo-a"}}
 "#,
         );
@@ -459,14 +712,45 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn log_file_and_dir_are_private() {
+    fn symlinked_log_path_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("victim.txt");
+        fs::write(&target, b"").unwrap();
+        let wal_dir = dir.path().join("wal");
+        fs::create_dir_all(&wal_dir).unwrap();
+        std::os::unix::fs::symlink(&target, wal_dir.join("leases.jsonl")).unwrap();
+
+        let err = LeaseWal::new(&wal_dir).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn log_file_and_dir_are_private_and_loose_modes_are_tightened() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();
         let sub = dir.path().join("leases");
+
+        // Fresh creation is private.
+        {
+            let wal = LeaseWal::new(&sub).unwrap();
+            let dir_mode = fs::metadata(&sub).unwrap().permissions().mode() & 0o777;
+            let file_mode = fs::metadata(wal.path()).unwrap().permissions().mode() & 0o777;
+            assert_eq!(dir_mode, 0o700);
+            assert_eq!(file_mode, 0o600);
+        }
+
+        // Loosened pre-existing modes are repaired on open.
+        fs::set_permissions(&sub, fs::Permissions::from_mode(0o777)).unwrap();
+        fs::set_permissions(sub.join("leases.jsonl"), fs::Permissions::from_mode(0o666)).unwrap();
         let wal = LeaseWal::new(&sub).unwrap();
-        let dir_mode = fs::metadata(&sub).unwrap().permissions().mode() & 0o777;
-        let file_mode = fs::metadata(wal.path()).unwrap().permissions().mode() & 0o777;
-        assert_eq!(dir_mode, 0o700);
-        assert_eq!(file_mode, 0o600);
+        assert_eq!(
+            fs::metadata(&sub).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            fs::metadata(wal.path()).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 }

--- a/src/events/listener.rs
+++ b/src/events/listener.rs
@@ -112,6 +112,11 @@ pub async fn event_listener(
                     }
                 }
 
+                // Shed while isolated: translating events writes intent and
+                // evaluator state.
+                if crate::server::isolation::is_active(&root_dir) {
+                    continue;
+                }
                 if let Some(intent) = translate_event(&event, &events_config) {
                     // Delta against disk (reconcile) + refresh the shared copy,
                     // so this push survives a concurrent daemon write and vice versa.

--- a/src/events/listener.rs
+++ b/src/events/listener.rs
@@ -113,12 +113,20 @@ pub async fn event_listener(
                 }
 
                 if let Some(intent) = translate_event(&event, &events_config) {
-                    let mut q = intent_queue.write().await;
-                    if q.push(intent.clone(), max_queue_size) {
-                        tracing::info!("Event → intent queued: '{}'", intent.description);
-                        if let Err(e) = q.save() {
-                            tracing::error!("Failed to persist intent queue: {}", e);
-                        }
+                    // Delta against disk (reconcile) + refresh the shared copy,
+                    // so this push survives a concurrent daemon write and vice versa.
+                    let mut pushed = false;
+                    let description = intent.description.clone();
+                    let merged =
+                        crate::scheduler::intent::IntentQueue::save_delta(&root_dir, |q| {
+                            pushed = q.push(intent, max_queue_size);
+                        });
+                    match merged {
+                        Ok(merged) => *intent_queue.write().await = merged,
+                        Err(e) => tracing::error!("Failed to persist intent queue: {}", e),
+                    }
+                    if pushed {
+                        tracing::info!("Event → intent queued: '{}'", description);
 
                         // Record fire in evaluator state via trait
                         if let Some(ref eval) = evaluator {
@@ -140,12 +148,12 @@ pub async fn event_listener(
                         if is_post_conversation {
                             tracing::warn!(
                                 "PostInteraction intent rejected (queue full or duplicate): '{}'",
-                                intent.description
+                                description
                             );
                         } else {
                             tracing::debug!(
                                 "Event intent not queued (full or duplicate): '{}'",
-                                intent.description
+                                description
                             );
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,25 @@ enum Commands {
     },
     /// Verify and repair Claude Code integration (symlinks, hooks, config)
     Repair,
+    /// Isolation mode — the minimal-core diagnostic retreat
+    Isolate {
+        #[command(subcommand)]
+        action: IsolateAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum IsolateAction {
+    /// Enter isolation mode (sticky until 'off')
+    On {
+        /// Optional reason, recorded in the marker
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Exit isolation mode
+    Off,
+    /// Show isolation status
+    Status,
 }
 
 #[derive(Subcommand)]
@@ -431,6 +450,17 @@ async fn main() {
         }
         Commands::Repair => {
             if let Err(e) = cli::repair::run().await {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        }
+        Commands::Isolate { action } => {
+            let result = match action {
+                IsolateAction::On { reason } => cli::isolate::on(reason).await,
+                IsolateAction::Off => cli::isolate::off().await,
+                IsolateAction::Status => cli::isolate::status().await,
+            };
+            if let Err(e) = result {
                 eprintln!("Error: {e}");
                 std::process::exit(1);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod cli;
 mod config;
 mod context;
 mod context_buffer;
+mod coordinator;
 mod discovery;
 mod errors;
 mod events;

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -28,10 +28,16 @@ pub fn create_provider(config: &Config) -> Result<Box<dyn LmProvider>, ProviderE
             config.llm.model.clone(),
             config.llm.base_url.clone(),
         ))),
-        "claude-code" => Ok(Box::new(ClaudeCodeProvider::new(
-            config.llm.model.clone(),
-            config.llm.claude_bin.clone(),
-        ))),
+        "claude-code" => {
+            let mut provider =
+                ClaudeCodeProvider::new(config.llm.model.clone(), config.llm.claude_bin.clone());
+            // Isolation awareness (spec Stage 2): the CLI subprocess brings
+            // its own tools, so the marker must reach the spawn itself.
+            if let Ok(root) = config.root_dir() {
+                provider = provider.with_isolation_root(root);
+            }
+            Ok(Box::new(provider))
+        }
         other => Err(ProviderError::Unknown(other.to_string())),
     }
 }
@@ -57,10 +63,16 @@ pub fn create_streaming_provider(
             config.llm.model.clone(),
             config.llm.base_url.clone(),
         ))),
-        "claude-code" => Ok(Box::new(ClaudeCodeProvider::new(
-            config.llm.model.clone(),
-            config.llm.claude_bin.clone(),
-        ))),
+        "claude-code" => {
+            let mut provider =
+                ClaudeCodeProvider::new(config.llm.model.clone(), config.llm.claude_bin.clone());
+            // Isolation awareness (spec Stage 2): the CLI subprocess brings
+            // its own tools, so the marker must reach the spawn itself.
+            if let Ok(root) = config.root_dir() {
+                provider = provider.with_isolation_root(root);
+            }
+            Ok(Box::new(provider))
+        }
         other => Err(ProviderError::Unknown(other.to_string())),
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -15,7 +15,7 @@ pub struct RunningEntity {
     pub config: Config,
     pub port: u16,
     pub server_handle: JoinHandle<()>,
-    pub scheduler_handles: Vec<JoinHandle<()>>,
+    pub coordinator: crate::coordinator::control::Coordinator,
     #[allow(dead_code)]
     pub event_bus: Arc<EventBus>,
     pub persist_coordinator: Arc<PersistCoordinator>,
@@ -118,9 +118,7 @@ impl EntityRegistry {
             }
 
             entity.server_handle.abort();
-            for h in entity.scheduler_handles {
-                h.abort();
-            }
+            entity.coordinator.shutdown().await;
         }
     }
 

--- a/src/scheduler/intent.rs
+++ b/src/scheduler/intent.rs
@@ -403,6 +403,12 @@ pub async fn drain_loop(
         };
         tokio::time::sleep(sleep_duration).await;
 
+        // Isolation backstop, independent of the coordinator loop.
+        if crate::server::isolation::is_active(&state.root_dir) {
+            tracing::warn!("Intent drain: ISOLATION active — stopping");
+            return;
+        }
+
         // Tenure liveness: stop if our tenure lost the control plane and
         // nothing aborted us (wedged leadership loop).
         {

--- a/src/scheduler/intent.rs
+++ b/src/scheduler/intent.rs
@@ -177,6 +177,23 @@ impl IntentQueue {
         Some(self.intents.remove(best_idx))
     }
 
+    /// All intents in processing order (priority desc, stable), left in the
+    /// queue. The drain loop claims one via a lease and removes it only on
+    /// fenced completion — so a crash mid-execution never loses the intent,
+    /// no matter who saves the queue in between.
+    pub fn sorted_candidates(&self) -> Vec<Intent> {
+        let mut candidates = self.intents.clone();
+        candidates.sort_by(|a, b| b.priority.cmp(&a.priority));
+        candidates
+    }
+
+    /// Remove an intent by id. Returns true if it was present.
+    pub fn remove_by_id(&mut self, id: &str) -> bool {
+        let before = self.intents.len();
+        self.intents.retain(|i| i.id != id);
+        self.intents.len() < before
+    }
+
     pub fn len(&self) -> usize {
         self.intents.len()
     }
@@ -327,12 +344,14 @@ pub async fn drain_loop(
     state: Arc<AppState>,
     queue: Arc<RwLock<IntentQueue>>,
     schedule: Arc<RwLock<Schedule>>,
+    leases: crate::coordinator::control::SharedLeases,
 ) {
     let config = &state.config.autonomy;
     if !config.enabled {
         tracing::info!("Intent queue disabled (autonomy.enabled = false)");
         return;
     }
+    let holder = crate::coordinator::control::holder_id(&state.config.entity.name);
 
     let poll_interval = Duration::from_secs(config.intent_poll_interval);
     let mut rate_tracker = RateTracker::new(config.max_intents_per_hour);
@@ -354,30 +373,26 @@ pub async fn drain_loop(
         };
         tokio::time::sleep(sleep_duration).await;
 
-        // Pop next intent
-        let intent = {
-            let mut q = queue.write().await;
-            q.pop_next()
-        };
+        // Claim the next processable intent via a lease, leaving it in the
+        // queue. A crash between claim and completion loses nothing: the
+        // intent is still queued and the claim expires on its ttl.
+        let candidates = { queue.read().await.sorted_candidates() };
+        if candidates.is_empty() {
+            continue;
+        }
+        let claimed = claim_next_intent(&leases, &holder, &candidates).await;
+        let Some(intent) = claimed else { continue };
 
-        let intent = match intent {
-            Some(i) => i,
-            None => continue,
-        };
-
-        // Rate limit check
+        // Rate limit check — release the claim and re-check later; the
+        // intent never left the queue, so there is nothing to re-queue.
         if !rate_tracker.record_and_check() {
             tracing::info!(
-                "Intent rate limit reached ({}/hr), re-queuing: {}",
+                "Intent rate limit reached ({}/hr), deferring: {}",
                 config.max_intents_per_hour,
                 intent.description
             );
-            let mut q = queue.write().await;
-            q.push(intent, config.max_queue_size);
-            if let Err(e) = q.save() {
-                tracing::error!("Failed to persist intent queue: {}", e);
-            }
-            // Sleep for a full interval before checking again
+            let resource = intent_resource(&intent.id);
+            let _ = { leases.lock().await.release(&resource, &holder, Utc::now()) };
             tokio::time::sleep(poll_interval).await;
             continue;
         }
@@ -404,12 +419,82 @@ pub async fn drain_loop(
             }
         }
 
-        // Save queue state after processing
-        let q = queue.read().await;
+        // Fenced completion: only the current claim holder may remove the
+        // intent. A stale executor's completion is refused and its intent
+        // re-runs — the at-least-once direction the queue already accepts.
+        commit_intent_completion(&queue, &leases, &holder, &intent.id).await;
+    }
+}
+
+/// Lease resource id for an intent claim.
+fn intent_resource(intent_id: &str) -> String {
+    format!(
+        "intent-{}",
+        crate::coordinator::control::lease_safe(intent_id)
+    )
+}
+
+/// Ttl on an intent claim — covers one execution's side-effect window.
+const INTENT_LEASE_TTL: Duration = Duration::from_secs(30 * 60);
+
+/// Try to claim the highest-priority candidate whose lease is free. A held
+/// lease means a prior claim is still inside its window (e.g. a wedged
+/// predecessor short of its ttl) — skip it and try the next.
+async fn claim_next_intent(
+    leases: &crate::coordinator::control::SharedLeases,
+    holder: &str,
+    candidates: &[Intent],
+) -> Option<Intent> {
+    let mut table = leases.lock().await;
+    for intent in candidates {
+        let resource = intent_resource(&intent.id);
+        match table.acquire(&resource, holder, INTENT_LEASE_TTL, Utc::now()) {
+            Ok(_) => return Some(intent.clone()),
+            Err(crate::coordinator::durable::DurableError::Lease(
+                crate::coordinator::lease::LeaseError::Held { .. },
+            )) => continue,
+            Err(e) => {
+                tracing::warn!("Intent claim failed for '{}': {e}", intent.id);
+                return None;
+            }
+        }
+    }
+    None
+}
+
+/// Prove the claim is still ours (renew), then remove the intent and persist
+/// the queue. Returns false — without touching the queue — when the claim
+/// has expired or been reclaimed: the fenced-stale-executor case.
+pub(crate) async fn commit_intent_completion(
+    queue: &Arc<RwLock<IntentQueue>>,
+    leases: &crate::coordinator::control::SharedLeases,
+    holder: &str,
+    intent_id: &str,
+) -> bool {
+    let resource = intent_resource(intent_id);
+    let renewed = {
+        leases
+            .lock()
+            .await
+            .renew(&resource, holder, INTENT_LEASE_TTL, Utc::now())
+    };
+    if let Err(e) = renewed {
+        tracing::warn!(
+            "Intent '{intent_id}': completion fenced — claim no longer held ({e}); \
+             the intent stays queued and will re-run"
+        );
+        return false;
+    }
+
+    {
+        let mut q = queue.write().await;
+        q.remove_by_id(intent_id);
         if let Err(e) = q.save() {
             tracing::error!("Failed to save intent queue: {}", e);
         }
     }
+    let _ = { leases.lock().await.release(&resource, holder, Utc::now()) };
+    true
 }
 
 /// Execute a single intent with tools.
@@ -877,6 +962,122 @@ fn log_intent_execution(root_dir: &Path, intent: &Intent, summary: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_intent(id: &str, priority: IntentPriority) -> Intent {
+        Intent {
+            id: id.into(),
+            description: format!("Intent {id}"),
+            prompt: "Do something".into(),
+            source: IntentSource::UserCli,
+            priority,
+            created_at: Utc::now(),
+            chain: None,
+            output_routing: IntentOutput::Silent,
+            depth: 0,
+        }
+    }
+
+    fn shared_leases(dir: &Path) -> crate::coordinator::control::SharedLeases {
+        Arc::new(tokio::sync::Mutex::new(
+            crate::coordinator::durable::DurableLeaseTable::open(&dir.join("coordinator")).unwrap(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn claim_skips_held_intent_and_takes_next() {
+        let dir = tempfile::tempdir().unwrap();
+        let leases = shared_leases(dir.path());
+        let candidates = vec![
+            make_intent("i-urgent", IntentPriority::Urgent),
+            make_intent("i-normal", IntentPriority::Normal),
+        ];
+
+        // Another holder is mid-flight on the urgent one.
+        leases
+            .lock()
+            .await
+            .acquire("intent-i-urgent", "other-1", INTENT_LEASE_TTL, Utc::now())
+            .unwrap();
+
+        let claimed = claim_next_intent(&leases, "me-1", &candidates).await;
+        assert_eq!(claimed.unwrap().id, "i-normal");
+    }
+
+    #[tokio::test]
+    async fn crash_between_claim_and_completion_loses_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let leases = shared_leases(dir.path());
+        let mut q = IntentQueue::load(dir.path());
+        q.push(make_intent("i1", IntentPriority::Normal), 20);
+        q.save().unwrap();
+        let queue = Arc::new(RwLock::new(q));
+
+        let claimed = claim_next_intent(&leases, "me-1", &queue.read().await.sorted_candidates())
+            .await
+            .unwrap();
+        assert_eq!(claimed.id, "i1");
+
+        // "Crash": no completion, no release. The intent is still durably
+        // queued — a restart reloads it intact.
+        let reloaded = IntentQueue::load(dir.path());
+        assert_eq!(reloaded.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn stale_completion_is_fenced_and_queue_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let leases = shared_leases(dir.path());
+        let mut q = IntentQueue::load(dir.path());
+        q.push(make_intent("i1", IntentPriority::Normal), 20);
+        q.save().unwrap();
+        let queue = Arc::new(RwLock::new(q));
+
+        // Executor A claims, then stalls past its ttl; B reclaims (the
+        // substrate allows an acquire dated after A's expiry).
+        claim_next_intent(&leases, "exec-a", &queue.read().await.sorted_candidates())
+            .await
+            .unwrap();
+        leases
+            .lock()
+            .await
+            .acquire(
+                "intent-i1",
+                "exec-b",
+                INTENT_LEASE_TTL,
+                Utc::now() + INTENT_LEASE_TTL + Duration::from_secs(1),
+            )
+            .unwrap();
+
+        // A wakes and tries to commit: fenced, queue untouched.
+        let committed = commit_intent_completion(&queue, &leases, "exec-a", "i1").await;
+        assert!(!committed);
+        assert_eq!(queue.read().await.len(), 1);
+        assert_eq!(IntentQueue::load(dir.path()).len(), 1);
+
+        // B commits fine — exactly once overall.
+        let committed = commit_intent_completion(&queue, &leases, "exec-b", "i1").await;
+        assert!(committed);
+        assert_eq!(IntentQueue::load(dir.path()).len(), 0);
+    }
+
+    #[test]
+    fn sorted_candidates_orders_by_priority_and_keeps_queue() {
+        let mut queue = IntentQueue {
+            intents: Vec::new(),
+            root_dir: None,
+        };
+        queue.push(make_intent("low", IntentPriority::Low), 20);
+        queue.push(make_intent("urgent", IntentPriority::Urgent), 20);
+        queue.push(make_intent("normal", IntentPriority::Normal), 20);
+
+        let ids: Vec<String> = queue
+            .sorted_candidates()
+            .into_iter()
+            .map(|i| i.id)
+            .collect();
+        assert_eq!(ids, vec!["urgent", "normal", "low"]);
+        assert_eq!(queue.len(), 3);
+    }
 
     #[test]
     fn intent_queue_push_and_pop() {

--- a/src/scheduler/intent.rs
+++ b/src/scheduler/intent.rs
@@ -582,10 +582,10 @@ async fn execute_intent(
                     new_task.name,
                     new_task.cron
                 );
-                let mut sched = schedule.write().await;
-                sched.add_task(new_task);
-                if let Err(e) = sched.save(&root_dir) {
-                    tracing::error!("Failed to persist schedule: {}", e);
+                // Delta against disk (reconcile) + refresh the shared copy.
+                match Schedule::save_delta(&root_dir, |s| s.add_task(new_task)) {
+                    Ok(merged) => *schedule.write().await = merged,
+                    Err(e) => tracing::error!("Failed to persist schedule: {}", e),
                 }
             }
             Err(e) => tracing::warn!("Invalid [SCHEDULE:] marker from intent: {}", e),

--- a/src/scheduler/intent.rs
+++ b/src/scheduler/intent.rs
@@ -454,7 +454,11 @@ pub async fn drain_loop(
         );
 
         // Execute the intent
-        let result = execute_intent(&intent, &state, &queue, &schedule, config).await;
+        let tenure = crate::coordinator::control::TenureLeases {
+            leases: Arc::clone(&leases),
+            holder: holder.clone(),
+        };
+        let result = execute_intent(&intent, &state, &queue, &schedule, config, &tenure).await;
 
         match result {
             Some(output) if output.trim().is_empty() => {
@@ -555,6 +559,7 @@ async fn execute_intent(
     queue: &Arc<RwLock<IntentQueue>>,
     schedule: &Arc<RwLock<Schedule>>,
     config: &AutonomyConfig,
+    tenure: &crate::coordinator::control::TenureLeases,
 ) -> Option<String> {
     let root_dir = state.root_dir.clone();
 
@@ -623,6 +628,29 @@ async fn execute_intent(
 
     // Parse output for markers
     let parsed = output::parse_output(&result.response_text);
+
+    // [FARM:] — bounded subtask delegation on the lease substrate (Stage 3)
+    for farm_json in &parsed.farm_requests {
+        match crate::coordinator::farm::run_farm_from_marker(farm_json, state, tenure).await {
+            Ok(result) => {
+                tracing::info!(
+                    "Intent '{}' farm complete ({} chars)",
+                    intent.id,
+                    result.len()
+                );
+                crate::logbook::write_task_output(
+                    &root_dir,
+                    &format!("intent-{}-farm", intent.id),
+                    &format!("{} (farm)", intent.description),
+                    &result,
+                    0,
+                    0,
+                    0,
+                );
+            }
+            Err(e) => tracing::warn!("[FARM:] from intent '{}' failed: {e}", intent.id),
+        }
+    }
 
     // Handle [SCHEDULE:] markers
     for schedule_json in &parsed.schedule_requests {

--- a/src/scheduler/intent.rs
+++ b/src/scheduler/intent.rs
@@ -121,14 +121,44 @@ impl IntentQueue {
         queue
     }
 
-    /// Persist to disk.
+    /// Persist to disk, atomically (tmp + rename) so a concurrent reader
+    /// never observes a truncated file.
     pub fn save(&self) -> Result<(), crate::errors::PulseError> {
         if let Some(ref dir) = self.root_dir {
             let path = dir.join(INTENTS_FILE);
+            let tmp = dir.join(format!(".{INTENTS_FILE}.tmp.{}", std::process::id()));
             let content = serde_json::to_string_pretty(self)?;
-            std::fs::write(&path, content)?;
+            std::fs::write(&tmp, content)?;
+            std::fs::rename(&tmp, &path)?;
         }
         Ok(())
+    }
+
+    /// Apply a mutation against the CURRENT on-disk queue and persist the
+    /// result — reconcile (spec decision 2) for intents, same contract as
+    /// `Schedule::save_delta`: a `pulse-null intent add` from the CLI (or an
+    /// event-listener push racing a reconcile) survives every daemon write.
+    /// Serialized in-process by a static mutex and cross-process by an
+    /// exclusive lock on `intents.json.lock`. Returns the merged queue so
+    /// callers can refresh their shared copy.
+    pub fn save_delta(
+        root_dir: &Path,
+        apply: impl FnOnce(&mut IntentQueue),
+    ) -> Result<IntentQueue, crate::errors::PulseError> {
+        static IN_PROCESS: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = IN_PROCESS.lock().unwrap_or_else(|p| p.into_inner());
+
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(root_dir.join(format!("{INTENTS_FILE}.lock")))?;
+        lock_file.lock()?;
+
+        let mut disk = Self::load(root_dir);
+        apply(&mut disk);
+        disk.save()?;
+        Ok(disk)
     }
 
     /// Add an intent. Returns false if queue is at capacity.
@@ -345,13 +375,13 @@ pub async fn drain_loop(
     queue: Arc<RwLock<IntentQueue>>,
     schedule: Arc<RwLock<Schedule>>,
     leases: crate::coordinator::control::SharedLeases,
+    holder: String,
 ) {
     let config = &state.config.autonomy;
     if !config.enabled {
         tracing::info!("Intent queue disabled (autonomy.enabled = false)");
         return;
     }
-    let holder = crate::coordinator::control::holder_id(&state.config.entity.name);
 
     let poll_interval = Duration::from_secs(config.intent_poll_interval);
     let mut rate_tracker = RateTracker::new(config.max_intents_per_hour);
@@ -372,6 +402,19 @@ pub async fn drain_loop(
             poll_interval
         };
         tokio::time::sleep(sleep_duration).await;
+
+        // Tenure liveness: stop if our tenure lost the control plane and
+        // nothing aborted us (wedged leadership loop).
+        {
+            let table = leases.lock().await;
+            let leads = table
+                .get(crate::coordinator::control::CONTROL_PLANE_RESOURCE)
+                .is_some_and(|l| l.holder_id == holder && !l.is_expired(Utc::now()));
+            if !leads {
+                tracing::warn!("Intent drain: tenure '{holder}' no longer leads; stopping");
+                return;
+            }
+        }
 
         // Claim the next processable intent via a lease, leaving it in the
         // queue. A crash between claim and completion loses nothing: the
@@ -422,7 +465,7 @@ pub async fn drain_loop(
         // Fenced completion: only the current claim holder may remove the
         // intent. A stale executor's completion is refused and its intent
         // re-runs — the at-least-once direction the queue already accepts.
-        commit_intent_completion(&queue, &leases, &holder, &intent.id).await;
+        commit_intent_completion(&state.root_dir, &queue, &leases, &holder, &intent.id).await;
     }
 }
 
@@ -466,6 +509,7 @@ async fn claim_next_intent(
 /// the queue. Returns false — without touching the queue — when the claim
 /// has expired or been reclaimed: the fenced-stale-executor case.
 pub(crate) async fn commit_intent_completion(
+    root_dir: &Path,
     queue: &Arc<RwLock<IntentQueue>>,
     leases: &crate::coordinator::control::SharedLeases,
     holder: &str,
@@ -486,12 +530,13 @@ pub(crate) async fn commit_intent_completion(
         return false;
     }
 
-    {
-        let mut q = queue.write().await;
+    // Delta against disk (reconcile): removal must not clobber intents
+    // other writers added while this one executed.
+    match IntentQueue::save_delta(root_dir, |q| {
         q.remove_by_id(intent_id);
-        if let Err(e) = q.save() {
-            tracing::error!("Failed to save intent queue: {}", e);
-        }
+    }) {
+        Ok(merged) => *queue.write().await = merged,
+        Err(e) => tracing::error!("Failed to save intent queue: {}", e),
     }
     let _ = { leases.lock().await.release(&resource, holder, Utc::now()) };
     true
@@ -606,8 +651,12 @@ async fn execute_intent(
                         new_intent.description
                     );
                 } else {
-                    let mut q = queue.write().await;
-                    q.push(new_intent, config.max_queue_size);
+                    match IntentQueue::save_delta(&root_dir, |q| {
+                        q.push(new_intent, config.max_queue_size);
+                    }) {
+                        Ok(merged) => *queue.write().await = merged,
+                        Err(e) => tracing::error!("Failed to persist intent queue: {}", e),
+                    }
                 }
             }
             Err(e) => tracing::warn!("Invalid [INTENT:] marker from intent: {}", e),
@@ -654,8 +703,12 @@ async fn execute_intent(
                         output_routing: chain.output_routing,
                         depth: new_depth,
                     };
-                    let mut q = queue.write().await;
-                    q.push(chain_intent, config.max_queue_size);
+                    match IntentQueue::save_delta(&root_dir, |q| {
+                        q.push(chain_intent, config.max_queue_size);
+                    }) {
+                        Ok(merged) => *queue.write().await = merged,
+                        Err(e) => tracing::error!("Failed to persist intent queue: {}", e),
+                    }
                 }
             }
             Err(e) => tracing::warn!("Invalid [CHAIN:] marker: {}", e),
@@ -682,8 +735,12 @@ async fn execute_intent(
                 output_routing: chain.output_routing.clone(),
                 depth: new_depth,
             };
-            let mut q = queue.write().await;
-            q.push(chain_intent, config.max_queue_size);
+            match IntentQueue::save_delta(&root_dir, |q| {
+                q.push(chain_intent, config.max_queue_size);
+            }) {
+                Ok(merged) => *queue.write().await = merged,
+                Err(e) => tracing::error!("Failed to persist intent queue: {}", e),
+            }
         }
     }
 
@@ -1049,15 +1106,44 @@ mod tests {
             .unwrap();
 
         // A wakes and tries to commit: fenced, queue untouched.
-        let committed = commit_intent_completion(&queue, &leases, "exec-a", "i1").await;
+        let committed = commit_intent_completion(dir.path(), &queue, &leases, "exec-a", "i1").await;
         assert!(!committed);
         assert_eq!(queue.read().await.len(), 1);
         assert_eq!(IntentQueue::load(dir.path()).len(), 1);
 
         // B commits fine — exactly once overall.
-        let committed = commit_intent_completion(&queue, &leases, "exec-b", "i1").await;
+        let committed = commit_intent_completion(dir.path(), &queue, &leases, "exec-b", "i1").await;
         assert!(committed);
         assert_eq!(IntentQueue::load(dir.path()).len(), 0);
+    }
+
+    /// MEDIUM-4 regression: daemon intent writes are deltas against disk, so
+    /// an external add (CLI, event listener) survives a concurrent removal.
+    #[test]
+    fn intent_save_delta_preserves_external_adds() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut q = IntentQueue::load(root);
+        q.push(make_intent("daemon-known", IntentPriority::Normal), 20);
+        q.save().unwrap();
+
+        // External writer (CLI) adds an intent the daemon's memory never saw.
+        IntentQueue::save_delta(root, |q| {
+            q.push(make_intent("cli-added", IntentPriority::Normal), 20);
+        })
+        .unwrap();
+
+        // Daemon commits a removal via save_delta — the CLI's intent survives
+        // (a wholesale q.save() of daemon memory would have erased it).
+        let merged = IntentQueue::save_delta(root, |q| {
+            q.remove_by_id("daemon-known");
+        })
+        .unwrap();
+        assert_eq!(merged.len(), 1);
+
+        let disk = IntentQueue::load(root);
+        assert_eq!(disk.len(), 1);
+        assert_eq!(disk.sorted_candidates()[0].id, "cli-added");
     }
 
     #[test]

--- a/src/scheduler/intent.rs
+++ b/src/scheduler/intent.rs
@@ -629,29 +629,6 @@ async fn execute_intent(
     // Parse output for markers
     let parsed = output::parse_output(&result.response_text);
 
-    // [FARM:] — bounded subtask delegation on the lease substrate (Stage 3)
-    for farm_json in &parsed.farm_requests {
-        match crate::coordinator::farm::run_farm_from_marker(farm_json, state, tenure).await {
-            Ok(result) => {
-                tracing::info!(
-                    "Intent '{}' farm complete ({} chars)",
-                    intent.id,
-                    result.len()
-                );
-                crate::logbook::write_task_output(
-                    &root_dir,
-                    &format!("intent-{}-farm", intent.id),
-                    &format!("{} (farm)", intent.description),
-                    &result,
-                    0,
-                    0,
-                    0,
-                );
-            }
-            Err(e) => tracing::warn!("[FARM:] from intent '{}' failed: {e}", intent.id),
-        }
-    }
-
     // Handle [SCHEDULE:] markers
     for schedule_json in &parsed.schedule_requests {
         match super::dynamic::create_task_from_marker(schedule_json) {
@@ -775,6 +752,37 @@ async fn execute_intent(
                 Ok(merged) => *queue.write().await = merged,
                 Err(e) => tracing::error!("Failed to persist intent queue: {}", e),
             }
+        }
+    }
+
+    // [FARM:] — bounded subtask delegation on the lease substrate (Stage 3).
+    // Routed last; one farm per response.
+    if let Some(farm_json) = parsed.farm_requests.first() {
+        if parsed.farm_requests.len() > 1 {
+            tracing::warn!(
+                "Intent '{}': {} [FARM:] markers — running only the first",
+                intent.id,
+                parsed.farm_requests.len()
+            );
+        }
+        match crate::coordinator::farm::run_farm_from_marker(farm_json, state, tenure).await {
+            Ok(result) => {
+                tracing::info!(
+                    "Intent '{}' farm complete ({} chars)",
+                    intent.id,
+                    result.len()
+                );
+                crate::logbook::write_task_output(
+                    &root_dir,
+                    &format!("intent-{}-farm", intent.id),
+                    &format!("{} (farm)", intent.description),
+                    &result,
+                    0,
+                    0,
+                    0,
+                );
+            }
+            Err(e) => tracing::warn!("[FARM:] from intent '{}' failed: {e}", intent.id),
         }
     }
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -156,12 +156,15 @@ impl Schedule {
     }
 }
 
-/// Start the scheduler alongside the server.
+/// Start the scheduler alongside the server. Called only by the coordinator,
+/// under a held control-plane lease; individual task runs and intent claims
+/// take their own leases from the shared table.
 /// Returns a handle that can be used for graceful shutdown.
 pub async fn start(
     state: Arc<AppState>,
     schedule: Arc<RwLock<Schedule>>,
     intent_queue: Arc<RwLock<intent::IntentQueue>>,
+    leases: crate::coordinator::control::SharedLeases,
 ) -> Result<Vec<tokio::task::JoinHandle<()>>, crate::errors::SchedulerError> {
     if !state.config.scheduler.enabled {
         tracing::info!("Scheduler disabled in config");
@@ -202,9 +205,11 @@ pub async fn start(
         let schedule = Arc::clone(&schedule);
         let queue = Arc::clone(&intent_queue);
         let task_health = Arc::clone(&health);
+        let task_leases = Arc::clone(&leases);
 
         let handle = tokio::spawn(async move {
-            runner::run_task_loop(entry, state, schedule, queue, task_health, tz).await;
+            runner::run_task_loop(entry, state, schedule, queue, task_health, tz, task_leases)
+                .await;
         });
 
         handles.push(handle);
@@ -226,8 +231,9 @@ pub async fn start(
         let drain_state = Arc::clone(&state);
         let drain_queue = Arc::clone(&intent_queue);
         let drain_schedule = Arc::clone(&schedule);
+        let drain_leases = Arc::clone(&leases);
         let drain_handle = tokio::spawn(async move {
-            intent::drain_loop(drain_state, drain_queue, drain_schedule).await;
+            intent::drain_loop(drain_state, drain_queue, drain_schedule, drain_leases).await;
         });
         handles.push(drain_handle);
 

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -83,15 +83,13 @@ pub struct Schedule {
 }
 
 impl Schedule {
-    /// Load schedule from schedule.json in the entity root
+    /// Load schedule from schedule.json in the entity root. Pure read: a
+    /// missing file is an error. Only `load_or_init` (boot) may create the
+    /// defaults — this load runs from task loops and save_delta, where a
+    /// transiently absent file (unlink+rename edit, restore, mount blip)
+    /// must NEVER silently resurrect the full default task set.
     pub fn load(root_dir: &Path) -> Result<Self, crate::errors::SchedulerError> {
         let path = root_dir.join("schedule.json");
-        if !path.exists() {
-            // No schedule file — create with defaults
-            let schedule = Self::with_defaults();
-            schedule.save(root_dir)?;
-            return Ok(schedule);
-        }
         let content = std::fs::read_to_string(&path)?;
         // Accept both {"tasks": [...]} and bare [...]
         let schedule: Schedule = match serde_json::from_str::<Schedule>(&content) {
@@ -104,11 +102,26 @@ impl Schedule {
         Ok(schedule)
     }
 
-    /// Save schedule to schedule.json
+    /// Boot-time load: creates and persists the default schedule if the file
+    /// does not exist yet (fresh entity).
+    pub fn load_or_init(root_dir: &Path) -> Result<Self, crate::errors::SchedulerError> {
+        if !root_dir.join("schedule.json").exists() {
+            let schedule = Self::with_defaults();
+            schedule.save(root_dir)?;
+            return Ok(schedule);
+        }
+        Self::load(root_dir)
+    }
+
+    /// Save schedule to schedule.json, atomically (tmp + rename) so a
+    /// concurrent reader never observes a truncated file and the file is
+    /// never transiently absent.
     pub fn save(&self, root_dir: &Path) -> Result<(), crate::errors::SchedulerError> {
         let path = root_dir.join("schedule.json");
+        let tmp = root_dir.join(format!(".schedule.json.tmp.{}", std::process::id()));
         let content = serde_json::to_string_pretty(self)?;
-        std::fs::write(&path, content)?;
+        std::fs::write(&tmp, content)?;
+        std::fs::rename(&tmp, &path)?;
         Ok(())
     }
 
@@ -162,14 +175,30 @@ impl Schedule {
     /// surfaces — the CLI, the TUI, anything that ran while the coordinator
     /// was down — survive. Returns the merged schedule so the caller can
     /// refresh its shared copy.
+    ///
+    /// The load-apply-save window is serialized against every other
+    /// `save_delta` caller: in-process via a static mutex, cross-process
+    /// (daemon vs CLI) via an exclusive lock on `schedule.json.lock`.
     pub fn save_delta(
         root_dir: &Path,
         apply: impl FnOnce(&mut Schedule),
     ) -> Result<Schedule, crate::errors::SchedulerError> {
+        static IN_PROCESS: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = IN_PROCESS.lock().unwrap_or_else(|p| p.into_inner());
+
+        let lock_path = root_dir.join("schedule.json.lock");
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        lock_file.lock()?;
+
         let mut disk = Self::load(root_dir)?;
         apply(&mut disk);
         disk.save(root_dir)?;
         Ok(disk)
+        // lock_file drop releases the flock
     }
 }
 
@@ -182,6 +211,7 @@ pub async fn start(
     schedule: Arc<RwLock<Schedule>>,
     intent_queue: Arc<RwLock<intent::IntentQueue>>,
     leases: crate::coordinator::control::SharedLeases,
+    tenure_holder: String,
 ) -> Result<Vec<tokio::task::JoinHandle<()>>, crate::errors::SchedulerError> {
     if !state.config.scheduler.enabled {
         tracing::info!("Scheduler disabled in config");
@@ -222,11 +252,13 @@ pub async fn start(
         let schedule = Arc::clone(&schedule);
         let queue = Arc::clone(&intent_queue);
         let task_health = Arc::clone(&health);
-        let task_leases = Arc::clone(&leases);
+        let tenure = crate::coordinator::control::TenureLeases {
+            leases: Arc::clone(&leases),
+            holder: tenure_holder.clone(),
+        };
 
         let handle = tokio::spawn(async move {
-            runner::run_task_loop(entry, state, schedule, queue, task_health, tz, task_leases)
-                .await;
+            runner::run_task_loop(entry, state, schedule, queue, task_health, tz, tenure).await;
         });
 
         handles.push(handle);
@@ -249,8 +281,16 @@ pub async fn start(
         let drain_queue = Arc::clone(&intent_queue);
         let drain_schedule = Arc::clone(&schedule);
         let drain_leases = Arc::clone(&leases);
+        let drain_holder = tenure_holder.clone();
         let drain_handle = tokio::spawn(async move {
-            intent::drain_loop(drain_state, drain_queue, drain_schedule, drain_leases).await;
+            intent::drain_loop(
+                drain_state,
+                drain_queue,
+                drain_schedule,
+                drain_leases,
+                drain_holder,
+            )
+            .await;
         });
         handles.push(drain_handle);
 
@@ -285,6 +325,59 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// MEDIUM-3 regression: concurrent save_delta callers must not lose
+    /// updates (load-apply-save is serialized by the static mutex + flock).
+    #[test]
+    fn concurrent_save_deltas_lose_nothing() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path().to_path_buf();
+        Schedule::load_or_init(&root).unwrap();
+
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let root = root.clone();
+                std::thread::spawn(move || {
+                    let entry = ScheduleEntry::from(ScheduledTask {
+                        id: format!("concurrent-{i}"),
+                        name: format!("Concurrent {i}"),
+                        cron: "0 0 12 * * *".into(),
+                        channel: "system".into(),
+                        prompt: "p".into(),
+                        output_routing: OutputRouting::Silent,
+                        enabled: true,
+                        created_by: TaskCreator::Entity,
+                        evaluator: None,
+                    });
+                    Schedule::save_delta(&root, |s| s.add_task(entry)).unwrap();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let disk = Schedule::load(&root).unwrap();
+        for i in 0..8 {
+            assert!(
+                disk.find_task(&format!("concurrent-{i}")).is_some(),
+                "task concurrent-{i} was lost to a racing save_delta"
+            );
+        }
+    }
+
+    /// HIGH-2 regression: a transiently absent schedule.json must never
+    /// resurrect the default task set from a background path.
+    #[test]
+    fn pure_load_errors_on_missing_file_instead_of_creating_defaults() {
+        let dir = TempDir::new().unwrap();
+        assert!(Schedule::load(dir.path()).is_err());
+        // And it wrote nothing.
+        assert!(!dir.path().join("schedule.json").exists());
+        // Boot path does create.
+        Schedule::load_or_init(dir.path()).unwrap();
+        assert!(dir.path().join("schedule.json").exists());
+    }
+
     /// AC12 fixture: an external edit ("CLI disabled a task while the
     /// coordinator was down / mid-tenure") survives a marker-driven save,
     /// because save_delta re-reads disk instead of writing stale memory.
@@ -294,7 +387,7 @@ mod tests {
         let root = dir.path();
 
         // Boot-time state: defaults on disk, one copy held "in memory".
-        let mut in_memory = Schedule::load(root).unwrap();
+        let mut in_memory = Schedule::load_or_init(root).unwrap();
         assert!(!in_memory.tasks.is_empty());
         let existing_id = in_memory.tasks[0].task.id.clone();
         assert!(in_memory.find_task(&existing_id).unwrap().task.enabled);

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -154,6 +154,23 @@ impl Schedule {
         self.tasks.retain(|t| t.task.id != id);
         self.tasks.len() < len_before
     }
+
+    /// Apply a mutation against the CURRENT on-disk schedule and persist the
+    /// result. This is reconcile (coordinator spec, decision 2) applied to
+    /// every write: the writer re-reads disk at the moment of writing instead
+    /// of assuming its in-memory copy is authoritative, so edits from other
+    /// surfaces — the CLI, the TUI, anything that ran while the coordinator
+    /// was down — survive. Returns the merged schedule so the caller can
+    /// refresh its shared copy.
+    pub fn save_delta(
+        root_dir: &Path,
+        apply: impl FnOnce(&mut Schedule),
+    ) -> Result<Schedule, crate::errors::SchedulerError> {
+        let mut disk = Self::load(root_dir)?;
+        apply(&mut disk);
+        disk.save(root_dir)?;
+        Ok(disk)
+    }
 }
 
 /// Start the scheduler alongside the server. Called only by the coordinator,
@@ -267,6 +284,54 @@ pub fn normalize_cron(expr: &str) -> String {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// AC12 fixture: an external edit ("CLI disabled a task while the
+    /// coordinator was down / mid-tenure") survives a marker-driven save,
+    /// because save_delta re-reads disk instead of writing stale memory.
+    #[test]
+    fn save_delta_preserves_external_edits() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+
+        // Boot-time state: defaults on disk, one copy held "in memory".
+        let mut in_memory = Schedule::load(root).unwrap();
+        assert!(!in_memory.tasks.is_empty());
+        let existing_id = in_memory.tasks[0].task.id.clone();
+        assert!(in_memory.find_task(&existing_id).unwrap().task.enabled);
+
+        // External edit while the holder of `in_memory` isn't looking:
+        // the CLI disables the task on disk.
+        {
+            let mut cli_copy = Schedule::load(root).unwrap();
+            cli_copy.find_task_mut(&existing_id).unwrap().task.enabled = false;
+            cli_copy.save(root).unwrap();
+        }
+
+        // Marker path fires: adds a new task via save_delta. The OLD code
+        // would have saved `in_memory` wholesale, resurrecting the task.
+        let new_task = ScheduleEntry::from(ScheduledTask {
+            id: "self-scheduled".into(),
+            name: "Self Scheduled".into(),
+            cron: "0 0 12 * * *".into(),
+            channel: "system".into(),
+            prompt: "do the thing".into(),
+            output_routing: OutputRouting::Silent,
+            enabled: true,
+            created_by: TaskCreator::Entity,
+            evaluator: None,
+        });
+        in_memory = Schedule::save_delta(root, |s| s.add_task(new_task)).unwrap();
+
+        // Disk has both the external disable AND the new task; the refreshed
+        // in-memory copy agrees with disk.
+        let disk = Schedule::load(root).unwrap();
+        assert!(!disk.find_task(&existing_id).unwrap().task.enabled);
+        assert!(disk.find_task("self-scheduled").is_some());
+        assert_eq!(
+            serde_json::to_string(&disk).unwrap(),
+            serde_json::to_string(&in_memory).unwrap()
+        );
+    }
 
     /// Two tasks, one pinned to a model and one not — the shape an operator
     /// actually ends up with.

--- a/src/scheduler/output.rs
+++ b/src/scheduler/output.rs
@@ -40,11 +40,82 @@ static INTENT_RE: LazyLock<Regex> =
 static CHAIN_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\[CHAIN:\s*(\{[\s\S]*?\})\]").unwrap());
 
-static FARM_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\[FARM:\s*(\{[\s\S]*?\})\]").unwrap());
+/// Extract `[TAG: {json}]` payloads with a brace-balance scan — a lazy regex
+/// stops at the first `}]`, which truncates any payload containing a nested
+/// array of objects (e.g. a farm's `subtasks`). Quote/escape aware.
+fn extract_json_markers(content: &str, tag: &str) -> (Vec<String>, String) {
+    let open = format!("[{tag}:");
+    let mut payloads = Vec::new();
+    let mut clean = String::with_capacity(content.len());
+    let mut rest = content;
+
+    while let Some(start) = rest.find(&open) {
+        clean.push_str(&rest[..start]);
+        let after_tag = &rest[start + open.len()..];
+        let brace_off = after_tag.find('{');
+        let candidate = match brace_off {
+            Some(off) if after_tag[..off].trim().is_empty() => &after_tag[off..],
+            _ => {
+                // Not a JSON marker — emit the tag literally and move on.
+                clean.push_str(&open);
+                rest = after_tag;
+                continue;
+            }
+        };
+
+        let mut depth = 0usize;
+        let mut in_string = false;
+        let mut escaped = false;
+        let mut end = None;
+        for (i, c) in candidate.char_indices() {
+            if in_string {
+                if escaped {
+                    escaped = false;
+                } else if c == '\\' {
+                    escaped = true;
+                } else if c == '"' {
+                    in_string = false;
+                }
+                continue;
+            }
+            match c {
+                '"' => in_string = true,
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = Some(i + 1);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        match end {
+            Some(end) if candidate[end..].trim_start().starts_with(']') => {
+                payloads.push(candidate[..end].to_string());
+                let close = candidate[end..].find(']').unwrap();
+                rest = &candidate[end + close + 1..];
+            }
+            _ => {
+                // Unbalanced or unterminated — emit literally.
+                clean.push_str(&open);
+                rest = after_tag;
+            }
+        }
+    }
+    clean.push_str(rest);
+    (payloads, clean)
+}
 
 /// Parse LLM response for output routing markers.
 pub fn parse_output(content: &str) -> ParsedOutput {
+    // FARM first: its payload legitimately contains `}]`, which the simple
+    // lazy regexes below would mis-slice if they ran across it.
+    let (farm_requests, content_no_farm) = extract_json_markers(content, "FARM");
+    let content = content_no_farm.as_str();
+
     let share_content: Vec<String> = SHARE_RE
         .captures_iter(content)
         .map(|c| c[1].trim().to_string())
@@ -70,11 +141,6 @@ pub fn parse_output(content: &str) -> ParsedOutput {
         .map(|c| c[1].trim().to_string())
         .collect();
 
-    let farm_requests: Vec<String> = FARM_RE
-        .captures_iter(content)
-        .map(|c| c[1].trim().to_string())
-        .collect();
-
     // Strip all markers from content for the clean version
     let mut clean = content.to_string();
     clean = SHARE_RE.replace_all(&clean, "").to_string();
@@ -82,7 +148,6 @@ pub fn parse_output(content: &str) -> ParsedOutput {
     clean = SCHEDULE_RE.replace_all(&clean, "").to_string();
     clean = INTENT_RE.replace_all(&clean, "").to_string();
     clean = CHAIN_RE.replace_all(&clean, "").to_string();
-    clean = FARM_RE.replace_all(&clean, "").to_string();
     let clean_content = clean.trim().to_string();
 
     ParsedOutput {
@@ -244,13 +309,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn farm_marker_is_parsed_and_stripped() {
-        let content =
-            r#"Delegating. [FARM: {"id":"f1","subtasks":[{"id":"a","prompt":"pa"}]}] Done."#;
+    fn farm_marker_round_trips_through_serde_with_nested_arrays() {
+        let content = r#"Delegating. [FARM: {"id":"f1","subtasks":[{"id":"a","prompt":"pa {with} [brackets] and \"quoted }]\""},{"id":"b","prompt":"pb"}],"synthesis":"merge {results}"}] Done."#;
         let parsed = parse_output(content);
         assert_eq!(parsed.farm_requests.len(), 1);
-        assert!(parsed.farm_requests[0].contains("\"id\":\"f1\""));
+        let spec: crate::coordinator::farm::FarmSpec =
+            serde_json::from_str(&parsed.farm_requests[0]).expect("captured JSON must be complete");
+        assert_eq!(spec.subtasks.len(), 2);
+        assert!(spec.subtasks[0].prompt.contains("[brackets]"));
         assert!(!parsed.clean_content.contains("FARM"));
+        assert!(parsed.clean_content.contains("Delegating."));
+        assert!(parsed.clean_content.contains("Done."));
     }
 
     #[test]

--- a/src/scheduler/output.rs
+++ b/src/scheduler/output.rs
@@ -22,6 +22,8 @@ pub struct ParsedOutput {
     pub intent_requests: Vec<String>,
     /// JSON content extracted from [CHAIN:] markers
     pub chain_requests: Vec<String>,
+    /// JSON content extracted from [FARM:] markers (Stage 3 subtask farming)
+    pub farm_requests: Vec<String>,
 }
 
 static SHARE_RE: LazyLock<Regex> =
@@ -37,6 +39,9 @@ static INTENT_RE: LazyLock<Regex> =
 
 static CHAIN_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\[CHAIN:\s*(\{[\s\S]*?\})\]").unwrap());
+
+static FARM_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[FARM:\s*(\{[\s\S]*?\})\]").unwrap());
 
 /// Parse LLM response for output routing markers.
 pub fn parse_output(content: &str) -> ParsedOutput {
@@ -65,6 +70,11 @@ pub fn parse_output(content: &str) -> ParsedOutput {
         .map(|c| c[1].trim().to_string())
         .collect();
 
+    let farm_requests: Vec<String> = FARM_RE
+        .captures_iter(content)
+        .map(|c| c[1].trim().to_string())
+        .collect();
+
     // Strip all markers from content for the clean version
     let mut clean = content.to_string();
     clean = SHARE_RE.replace_all(&clean, "").to_string();
@@ -72,6 +82,7 @@ pub fn parse_output(content: &str) -> ParsedOutput {
     clean = SCHEDULE_RE.replace_all(&clean, "").to_string();
     clean = INTENT_RE.replace_all(&clean, "").to_string();
     clean = CHAIN_RE.replace_all(&clean, "").to_string();
+    clean = FARM_RE.replace_all(&clean, "").to_string();
     let clean_content = clean.trim().to_string();
 
     ParsedOutput {
@@ -81,6 +92,7 @@ pub fn parse_output(content: &str) -> ParsedOutput {
         schedule_requests,
         intent_requests,
         chain_requests,
+        farm_requests,
     }
 }
 
@@ -230,6 +242,16 @@ pub async fn deliver_liveness_alert(content: &str, webhook: Option<&str>) -> Res
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn farm_marker_is_parsed_and_stripped() {
+        let content =
+            r#"Delegating. [FARM: {"id":"f1","subtasks":[{"id":"a","prompt":"pa"}]}] Done."#;
+        let parsed = parse_output(content);
+        assert_eq!(parsed.farm_requests.len(), 1);
+        assert!(parsed.farm_requests[0].contains("\"id\":\"f1\""));
+        assert!(!parsed.clean_content.contains("FARM"));
+    }
 
     #[test]
     fn parse_share_marker() {

--- a/src/scheduler/runner.rs
+++ b/src/scheduler/runner.rs
@@ -31,10 +31,9 @@ pub async fn run_task_loop(
     intent_queue: Arc<RwLock<IntentQueue>>,
     health: SharedTaskHealth,
     tz: chrono_tz::Tz,
-    leases: crate::coordinator::control::SharedLeases,
+    tenure: crate::coordinator::control::TenureLeases,
 ) {
     let task = &entry.task;
-    let lease_holder = crate::coordinator::control::holder_id(&state.config.entity.name);
     let lease_resource = format!("task-{}", crate::coordinator::control::lease_safe(&task.id));
     let normalized_cron = super::normalize_cron(&task.cron);
     let cron_expr = match CronSchedule::from_str(&normalized_cron) {
@@ -151,19 +150,32 @@ pub async fn run_task_loop(
             }
         }
 
+        // Tenure liveness: if our tenure no longer holds the control plane
+        // (the leadership loop died without aborting us — a wedge), stop
+        // rather than keep acting as a stale tenure.
+        if !tenure_still_leads(&tenure.leases, &tenure.holder).await {
+            tracing::warn!(
+                "Task '{}': tenure '{}' no longer leads; stopping loop",
+                task.id,
+                tenure.holder
+            );
+            return;
+        }
+
         // Claim the per-run lease before any side effect. A refusal means a
         // prior run of this task is still inside its side-effect window (or
         // wedged short of its ttl) — skip this fire rather than double-run.
+        // Error level: a skipped fire on a daily cron is a lost day.
         let claim = {
-            leases.lock().await.acquire(
+            tenure.leases.lock().await.acquire(
                 &lease_resource,
-                &lease_holder,
+                &tenure.holder,
                 TASK_LEASE_TTL,
                 chrono::Utc::now(),
             )
         };
         if let Err(e) = claim {
-            tracing::warn!("Task '{}' fire skipped — lease not available: {e}", task.id);
+            tracing::error!("Task '{}' fire SKIPPED — lease not available: {e}", task.id);
             continue;
         }
 
@@ -177,7 +189,7 @@ pub async fn run_task_loop(
         if run_builtin_handler(task, &state, &root_dir).await {
             liveness::record_outcome(&health, &state, &task.id, &task.name, TaskOutcome::Success)
                 .await;
-            release_task_lease(&leases, &lease_resource, &lease_holder, &task.id).await;
+            release_task_lease(&tenure.leases, &lease_resource, &tenure.holder, &task.id).await;
             continue;
         }
 
@@ -190,7 +202,7 @@ pub async fn run_task_loop(
             diagnostics::report_failure(&health, &state, &entry, error).await;
         }
         liveness::record_outcome(&health, &state, &task.id, &task.name, outcome).await;
-        release_task_lease(&leases, &lease_resource, &lease_holder, &task.id).await;
+        release_task_lease(&tenure.leases, &lease_resource, &tenure.holder, &task.id).await;
     }
 }
 
@@ -861,10 +873,12 @@ async fn route_output_markers(
                         task.id,
                         new_intent.description
                     );
-                    let mut q = intent_queue.write().await;
-                    q.push(new_intent, state.config.autonomy.max_queue_size);
-                    if let Err(e) = q.save() {
-                        tracing::error!("Failed to persist intent queue: {}", e);
+                    let max = state.config.autonomy.max_queue_size;
+                    match intent::IntentQueue::save_delta(root_dir, |q| {
+                        q.push(new_intent, max);
+                    }) {
+                        Ok(merged) => *intent_queue.write().await = merged,
+                        Err(e) => tracing::error!("Failed to persist intent queue: {}", e),
                     }
                 }
                 Err(e) => tracing::warn!("Invalid [INTENT:] marker: {}", e),
@@ -895,10 +909,12 @@ async fn route_output_markers(
                         task.id,
                         chain_intent.description
                     );
-                    let mut q = intent_queue.write().await;
-                    q.push(chain_intent, state.config.autonomy.max_queue_size);
-                    if let Err(e) = q.save() {
-                        tracing::error!("Failed to persist intent queue: {}", e);
+                    let max = state.config.autonomy.max_queue_size;
+                    match intent::IntentQueue::save_delta(root_dir, |q| {
+                        q.push(chain_intent, max);
+                    }) {
+                        Ok(merged) => *intent_queue.write().await = merged,
+                        Err(e) => tracing::error!("Failed to persist intent queue: {}", e),
                     }
                 }
                 Err(e) => tracing::warn!("Invalid [CHAIN:] marker: {}", e),
@@ -1003,4 +1019,17 @@ async fn post_process_predictions(
     if let Err(e) = crate::prediction::store::save_async(root_dir.to_path_buf(), stack).await {
         tracing::error!("Failed to save prediction stack: {e}");
     }
+}
+
+/// True while this tenure's holder still owns an unexpired control-plane
+/// lease. Task loops check it before each fire so a wedged coordinator's
+/// orphans stop themselves instead of acting as a stale tenure.
+async fn tenure_still_leads(
+    leases: &crate::coordinator::control::SharedLeases,
+    tenure_holder: &str,
+) -> bool {
+    let table = leases.lock().await;
+    table
+        .get(crate::coordinator::control::CONTROL_PLANE_RESOURCE)
+        .is_some_and(|l| l.holder_id == tenure_holder && !l.is_expired(chrono::Utc::now()))
 }

--- a/src/scheduler/runner.rs
+++ b/src/scheduler/runner.rs
@@ -855,25 +855,6 @@ async fn route_output_markers(
     root_dir: &std::path::Path,
     tenure: &crate::coordinator::control::TenureLeases,
 ) {
-    // [FARM:] — bounded subtask delegation on the lease substrate (Stage 3)
-    for farm_json in &parsed.farm_requests {
-        match crate::coordinator::farm::run_farm_from_marker(farm_json, state, tenure).await {
-            Ok(result) => {
-                tracing::info!("Task '{}' farm complete ({} chars)", task.id, result.len());
-                crate::logbook::write_task_output(
-                    root_dir,
-                    &format!("{}-farm", task.id),
-                    &format!("{} (farm)", task.name),
-                    &result,
-                    0,
-                    0,
-                    0,
-                );
-            }
-            Err(e) => tracing::warn!("[FARM:] from task '{}' failed: {e}", task.id),
-        }
-    }
-
     // [SCHEDULE:] — create new dynamic tasks
     for schedule_json in &parsed.schedule_requests {
         match super::dynamic::create_task_from_marker(schedule_json) {
@@ -966,6 +947,34 @@ async fn route_output_markers(
                 }
                 Err(e) => tracing::warn!("Invalid [CHAIN:] marker: {}", e),
             }
+        }
+    }
+
+    // [FARM:] — bounded subtask delegation on the lease substrate (Stage 3).
+    // Routed LAST so [SHARE:]/[CALL:] in the same response are not delayed
+    // behind a long farm; one farm per response.
+    if let Some(farm_json) = parsed.farm_requests.first() {
+        if parsed.farm_requests.len() > 1 {
+            tracing::warn!(
+                "Task '{}': {} [FARM:] markers in one response — running only the first",
+                task.id,
+                parsed.farm_requests.len()
+            );
+        }
+        match crate::coordinator::farm::run_farm_from_marker(farm_json, state, tenure).await {
+            Ok(result) => {
+                tracing::info!("Task '{}' farm complete ({} chars)", task.id, result.len());
+                crate::logbook::write_task_output(
+                    root_dir,
+                    &format!("{}-farm", task.id),
+                    &format!("{} (farm)", task.name),
+                    &result,
+                    0,
+                    0,
+                    0,
+                );
+            }
+            Err(e) => tracing::warn!("[FARM:] from task '{}' failed: {e}", task.id),
         }
     }
 }

--- a/src/scheduler/runner.rs
+++ b/src/scheduler/runner.rs
@@ -201,7 +201,15 @@ pub async fn run_task_loop(
             continue;
         }
 
-        let outcome = execute_task(&entry, &state, &schedule, &intent_queue, &mut eval_state).await;
+        let outcome = execute_task(
+            &entry,
+            &state,
+            &schedule,
+            &intent_queue,
+            &mut eval_state,
+            &tenure,
+        )
+        .await;
         // Diagnostics before the outcome is recorded: the store must still
         // describe the previous cycle for "is this failure news?" to mean
         // anything. Every failure path converges here, so a failure that never
@@ -280,6 +288,7 @@ async fn execute_task(
     schedule: &Arc<RwLock<Schedule>>,
     intent_queue: &Arc<RwLock<IntentQueue>>,
     eval_state: &mut SchedulerState,
+    tenure: &crate::coordinator::control::TenureLeases,
 ) -> TaskOutcome {
     let task = &entry.task;
     // Use cached root_dir from AppState
@@ -503,7 +512,16 @@ async fn execute_task(
 
     // Parse and route output markers
     let parsed = output::parse_output(&response_text);
-    route_output_markers(&parsed, task, state, schedule, intent_queue, &root_dir).await;
+    route_output_markers(
+        &parsed,
+        task,
+        state,
+        schedule,
+        intent_queue,
+        &root_dir,
+        tenure,
+    )
+    .await;
 
     // Log to LOGBOOK.md
     log_execution(&root_dir, task, &parsed.clean_content);
@@ -827,6 +845,7 @@ async fn handle_provider_error(state: &Arc<AppState>, task_id: &str, error_msg: 
 ///
 /// Handles [SCHEDULE:], [SHARE:], [CALL:], [INTENT:], and [CHAIN:] markers
 /// extracted from the LLM response.
+#[allow(clippy::too_many_arguments)]
 async fn route_output_markers(
     parsed: &output::ParsedOutput,
     task: &ScheduledTask,
@@ -834,7 +853,27 @@ async fn route_output_markers(
     schedule: &Arc<RwLock<Schedule>>,
     intent_queue: &Arc<RwLock<IntentQueue>>,
     root_dir: &std::path::Path,
+    tenure: &crate::coordinator::control::TenureLeases,
 ) {
+    // [FARM:] — bounded subtask delegation on the lease substrate (Stage 3)
+    for farm_json in &parsed.farm_requests {
+        match crate::coordinator::farm::run_farm_from_marker(farm_json, state, tenure).await {
+            Ok(result) => {
+                tracing::info!("Task '{}' farm complete ({} chars)", task.id, result.len());
+                crate::logbook::write_task_output(
+                    root_dir,
+                    &format!("{}-farm", task.id),
+                    &format!("{} (farm)", task.name),
+                    &result,
+                    0,
+                    0,
+                    0,
+                );
+            }
+            Err(e) => tracing::warn!("[FARM:] from task '{}' failed: {e}", task.id),
+        }
+    }
+
     // [SCHEDULE:] — create new dynamic tasks
     for schedule_json in &parsed.schedule_requests {
         match super::dynamic::create_task_from_marker(schedule_json) {

--- a/src/scheduler/runner.rs
+++ b/src/scheduler/runner.rs
@@ -150,6 +150,14 @@ pub async fn run_task_loop(
             }
         }
 
+        // Isolation backstop: independent of the coordinator loop (which may
+        // itself be wedged — the very case isolation exists for), every task
+        // checks the marker before firing.
+        if crate::server::isolation::is_active(&root_dir) {
+            tracing::warn!("Task '{}': ISOLATION active — stopping loop", task.id);
+            return;
+        }
+
         // Tenure liveness: if our tenure no longer holds the control plane
         // (the leadership loop died without aborting us — a wedge), stop
         // rather than keep acting as a stale tenure.

--- a/src/scheduler/runner.rs
+++ b/src/scheduler/runner.rs
@@ -78,17 +78,38 @@ pub async fn run_task_loop(
 
         tokio::time::sleep(duration).await;
 
-        // Check if still enabled (might have been disabled at runtime)
+        // Check if still enabled — against DISK, so a `pulse-null schedule
+        // disable` from the CLI takes effect at the next fire without a
+        // service restart (the in-memory copy can't see external edits).
+        // Falls back to the shared copy if the file is transiently unreadable.
         {
-            let sched = schedule.read().await;
-            if let Some(t) = sched.find_task(&task.id) {
-                if !t.task.enabled {
+            let rd = root_dir.clone();
+            let disk = tokio::task::spawn_blocking(move || Schedule::load(&rd)).await;
+            let entry_enabled = match disk {
+                Ok(Ok(fresh)) => {
+                    let enabled = fresh.find_task(&task.id).map(|t| t.task.enabled);
+                    *schedule.write().await = fresh;
+                    enabled
+                }
+                _ => {
+                    tracing::warn!(
+                        "Task '{}': schedule.json unreadable for enabled-check; using shared copy",
+                        task.id
+                    );
+                    let sched = schedule.read().await;
+                    sched.find_task(&task.id).map(|t| t.task.enabled)
+                }
+            };
+            match entry_enabled {
+                Some(true) => {}
+                Some(false) => {
                     tracing::info!("Task '{}' disabled, stopping loop", task.id);
                     return;
                 }
-            } else {
-                tracing::info!("Task '{}' removed, stopping loop", task.id);
-                return;
+                None => {
+                    tracing::info!("Task '{}' removed, stopping loop", task.id);
+                    return;
+                }
             }
         }
 
@@ -803,10 +824,12 @@ async fn route_output_markers(
                     new_task.name,
                     new_task.cron
                 );
-                let mut sched = schedule.write().await;
-                sched.add_task(new_task);
-                if let Err(e) = sched.save(root_dir) {
-                    tracing::error!("Failed to persist schedule: {}", e);
+                // Delta against disk, never a wholesale write of memory —
+                // concurrent CLI/TUI edits survive; then refresh the shared
+                // copy from the merged result.
+                match Schedule::save_delta(root_dir, |s| s.add_task(new_task)) {
+                    Ok(merged) => *schedule.write().await = merged,
+                    Err(e) => tracing::error!("Failed to persist schedule: {}", e),
                 }
             }
             Err(e) => {

--- a/src/scheduler/runner.rs
+++ b/src/scheduler/runner.rs
@@ -18,6 +18,11 @@ use crate::provider_status;
 use crate::server::prompt;
 use crate::server::AppState;
 
+/// Ttl on a per-run task lease. Covers the full side-effect window of one
+/// execution (LLM rounds included); a run that wedges past this is
+/// reclaimable and its late writes are what fencing exists to reject.
+const TASK_LEASE_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
 /// Run a single task in a loop: calculate next fire time → sleep → execute → repeat.
 pub async fn run_task_loop(
     entry: ScheduleEntry,
@@ -26,8 +31,11 @@ pub async fn run_task_loop(
     intent_queue: Arc<RwLock<IntentQueue>>,
     health: SharedTaskHealth,
     tz: chrono_tz::Tz,
+    leases: crate::coordinator::control::SharedLeases,
 ) {
     let task = &entry.task;
+    let lease_holder = crate::coordinator::control::holder_id(&state.config.entity.name);
+    let lease_resource = format!("task-{}", crate::coordinator::control::lease_safe(&task.id));
     let normalized_cron = super::normalize_cron(&task.cron);
     let cron_expr = match CronSchedule::from_str(&normalized_cron) {
         Ok(c) => c,
@@ -122,6 +130,22 @@ pub async fn run_task_loop(
             }
         }
 
+        // Claim the per-run lease before any side effect. A refusal means a
+        // prior run of this task is still inside its side-effect window (or
+        // wedged short of its ttl) — skip this fire rather than double-run.
+        let claim = {
+            leases.lock().await.acquire(
+                &lease_resource,
+                &lease_holder,
+                TASK_LEASE_TTL,
+                chrono::Utc::now(),
+            )
+        };
+        if let Err(e) = claim {
+            tracing::warn!("Task '{}' fire skipped — lease not available: {e}", task.id);
+            continue;
+        }
+
         tracing::info!(
             model = %entry.effective_model(&state.config.llm.model),
             "Executing scheduled task: {}",
@@ -132,6 +156,7 @@ pub async fn run_task_loop(
         if run_builtin_handler(task, &state, &root_dir).await {
             liveness::record_outcome(&health, &state, &task.id, &task.name, TaskOutcome::Success)
                 .await;
+            release_task_lease(&leases, &lease_resource, &lease_holder, &task.id).await;
             continue;
         }
 
@@ -144,6 +169,25 @@ pub async fn run_task_loop(
             diagnostics::report_failure(&health, &state, &entry, error).await;
         }
         liveness::record_outcome(&health, &state, &task.id, &task.name, outcome).await;
+        release_task_lease(&leases, &lease_resource, &lease_holder, &task.id).await;
+    }
+}
+
+/// Release the per-run lease after the outcome is recorded. A failure here is
+/// survivable — the lease expires on its ttl — but worth a warning because it
+/// delays the next fire of this task by up to the remaining ttl.
+async fn release_task_lease(
+    leases: &crate::coordinator::control::SharedLeases,
+    resource: &str,
+    holder: &str,
+    task_id: &str,
+) {
+    if let Err(e) = leases
+        .lock()
+        .await
+        .release(resource, holder, chrono::Utc::now())
+    {
+        tracing::warn!("Task '{task_id}': lease release failed ({e}); next fire may be delayed");
     }
 }
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -176,6 +176,7 @@ mod tests {
             wal: None,
             alert_queue: tokio::sync::Mutex::new(alert_queue),
             provider_status: crate::provider_status::new_shared(),
+            leadership: std::sync::atomic::AtomicBool::new(false),
         })
     }
 
@@ -347,6 +348,7 @@ mod tests {
             wal: None,
             alert_queue: tokio::sync::Mutex::new(alert_queue),
             provider_status: crate::provider_status::new_shared(),
+            leadership: std::sync::atomic::AtomicBool::new(false),
         })
     }
 

--- a/src/server/boot.rs
+++ b/src/server/boot.rs
@@ -111,7 +111,7 @@ pub async fn boot_entity(
 
     // Scheduler — gated on control-plane leadership (fail-open: the entity's
     // interactive surfaces never wait on the coordinator).
-    let schedule = Schedule::load(&root_dir)?;
+    let schedule = Schedule::load_or_init(&root_dir)?;
     let schedule = Arc::new(RwLock::new(schedule));
     let intent_queue = IntentQueue::load(&root_dir);
     let intent_queue = Arc::new(RwLock::new(intent_queue));

--- a/src/server/boot.rs
+++ b/src/server/boot.rs
@@ -16,7 +16,7 @@ use super::AppState;
 /// Result of booting an entity's server.
 pub struct BootedEntity {
     pub server_handle: JoinHandle<()>,
-    pub scheduler_handles: Vec<JoinHandle<()>>,
+    pub coordinator: crate::coordinator::control::Coordinator,
     pub event_bus: Arc<EventBus>,
     pub actual_port: u16,
     pub persist_coordinator: Arc<PersistCoordinator>,
@@ -109,17 +109,17 @@ pub async fn boot_entity(
     // Pipeline health check
     super::setup::startup_pipeline_check(&root_dir, &config, &state.pipeline_monitor);
 
-    // Scheduler
+    // Scheduler — gated on control-plane leadership (fail-open: the entity's
+    // interactive surfaces never wait on the coordinator).
     let schedule = Schedule::load(&root_dir)?;
     let schedule = Arc::new(RwLock::new(schedule));
     let intent_queue = IntentQueue::load(&root_dir);
     let intent_queue = Arc::new(RwLock::new(intent_queue));
-    let scheduler_handles = crate::scheduler::start(
+    let coordinator = crate::coordinator::control::Coordinator::start(
         Arc::clone(&state),
         Arc::clone(&schedule),
         Arc::clone(&intent_queue),
-    )
-    .await?;
+    );
 
     // Give the plugin manager access to the event bus for runtime state-change events
     {
@@ -153,7 +153,7 @@ pub async fn boot_entity(
 
     Ok(BootedEntity {
         server_handle,
-        scheduler_handles,
+        coordinator,
         event_bus,
         actual_port,
         persist_coordinator: Arc::clone(&state.persist_coordinator),

--- a/src/server/boot.rs
+++ b/src/server/boot.rs
@@ -104,6 +104,7 @@ pub async fn boot_entity(
         wal: None,
         alert_queue: tokio::sync::Mutex::new(alert_queue),
         provider_status: crate::provider_status::new_shared(),
+        leadership: std::sync::atomic::AtomicBool::new(false),
     });
 
     // Pipeline health check

--- a/src/server/e2e_tests.rs
+++ b/src/server/e2e_tests.rs
@@ -639,7 +639,7 @@ async fn e2e_chat_survives_coordinator_wedge() {
     let state = build_state_in(dir.path().to_path_buf(), provider, ToolRegistry::new()).await;
 
     let schedule = Arc::new(RwLock::new(
-        crate::scheduler::Schedule::load(dir.path()).unwrap(),
+        crate::scheduler::Schedule::load_or_init(dir.path()).unwrap(),
     ));
     let intents = Arc::new(RwLock::new(crate::scheduler::intent::IntentQueue::load(
         dir.path(),
@@ -679,7 +679,7 @@ async fn e2e_second_coordinator_locked_out_until_shutdown() {
     let state = build_state_in(dir.path().to_path_buf(), provider, ToolRegistry::new()).await;
 
     let schedule = Arc::new(RwLock::new(
-        crate::scheduler::Schedule::load(dir.path()).unwrap(),
+        crate::scheduler::Schedule::load_or_init(dir.path()).unwrap(),
     ));
     let intents = Arc::new(RwLock::new(crate::scheduler::intent::IntentQueue::load(
         dir.path(),

--- a/src/server/e2e_tests.rs
+++ b/src/server/e2e_tests.rs
@@ -167,6 +167,8 @@ async fn build_state_in(
     tools: ToolRegistry,
 ) -> Arc<AppState> {
     let config = test_config();
+    let wal =
+        crate::wal::WalWriter::new(&root_dir.join("sessions"), crate::wal::WalFsync::None).ok();
     let session_store =
         crate::session_store::SessionStore::new(&root_dir, &config.sessions, &config.entity.name)
             .await;
@@ -186,7 +188,7 @@ async fn build_state_in(
         context_buffer: None,
         persist_coordinator: Arc::new(PersistCoordinator::new()),
         plugin_manager: tokio::sync::Mutex::new(plugin_manager),
-        wal: None,
+        wal,
         alert_queue: tokio::sync::Mutex::new(alert_queue),
         provider_status: crate::provider_status::new_shared(),
         leadership: std::sync::atomic::AtomicBool::new(false),
@@ -708,4 +710,193 @@ async fn e2e_second_coordinator_locked_out_until_shutdown() {
         )
         .expect("lease was not released on shutdown");
     assert!(lease.fencing_token > crate::coordinator::lease::FencingToken(1));
+}
+
+// ---------------------------------------------------------------------------
+// Isolation Mode (Stage 2): AC16-AC19
+// ---------------------------------------------------------------------------
+
+async fn post_chat_on(app: &Router, channel: &str, message: &str) -> (StatusCode, String) {
+    let body = serde_json::json!({ "message": message, "channel": channel });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/chat")
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (status, String::from_utf8(bytes.to_vec()).unwrap())
+}
+
+fn snapshot_dir(dir: &std::path::Path) -> Vec<(String, u64)> {
+    let mut entries = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for e in rd.flatten() {
+            let len = e.metadata().map(|m| m.len()).unwrap_or(0);
+            entries.push((e.file_name().to_string_lossy().to_string(), len));
+        }
+    }
+    entries.sort();
+    entries
+}
+
+/// AC16 + AC17 + AC18: isolation entered and exited over the chat channel
+/// with the coordinator forcibly wedged; banner sticky; no writes while
+/// isolated; writes resume after exit.
+#[tokio::test]
+async fn e2e_isolation_over_chat_with_coordinator_wedged() {
+    let dir = tempfile::tempdir().unwrap();
+    let provider = MockProvider::new(vec![
+        mock_text("diagnosing in isolation"),
+        mock_text("second isolated turn"),
+        mock_text("normal again"),
+    ]);
+    let state = build_state_in(dir.path().to_path_buf(), provider, ToolRegistry::new()).await;
+
+    let schedule = Arc::new(RwLock::new(
+        crate::scheduler::Schedule::load_or_init(dir.path()).unwrap(),
+    ));
+    let intents = Arc::new(RwLock::new(crate::scheduler::intent::IntentQueue::load(
+        dir.path(),
+    )));
+    let coordinator =
+        crate::coordinator::control::Coordinator::start(Arc::clone(&state), schedule, intents);
+    wait_for_leadership(&dir.path().join("coordinator")).await;
+    // The case that matters (spec Stage 2 exit): trigger works with the
+    // coordinator wedged.
+    coordinator.wedge_for_test();
+
+    let app = build_app(Arc::clone(&state));
+
+    // Enter over the interactive channel ("system" resolves to owner).
+    let (status, body) = post_chat_on(&app, "system", "/isolate suspect graph").await;
+    assert_eq!(status, StatusCode::OK);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(json["isolation"], true);
+    assert!(json["response"]
+        .as_str()
+        .unwrap()
+        .starts_with(crate::server::isolation::BANNER));
+
+    // AC18: a normal turn while isolated writes nothing.
+    let sessions_before = snapshot_dir(&dir.path().join("sessions"));
+    let wal_before = snapshot_dir(&dir.path().join("sessions").join("wal"));
+    let archives_before = snapshot_dir(&dir.path().join("archives").join("conversations"));
+
+    let (status, body) = post_chat_on(&app, "system", "what do you see in the journal?").await;
+    assert_eq!(status, StatusCode::OK);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    // AC17: sticky banner on every reply, not just the entry event.
+    assert_eq!(json["isolation"], true);
+    assert!(json["response"]
+        .as_str()
+        .unwrap()
+        .starts_with(crate::server::isolation::BANNER));
+
+    assert_eq!(
+        snapshot_dir(&dir.path().join("sessions")),
+        sessions_before,
+        "session files changed during isolation"
+    );
+    assert_eq!(
+        snapshot_dir(&dir.path().join("sessions").join("wal")),
+        wal_before,
+        "conversation WAL changed during isolation"
+    );
+    assert_eq!(
+        snapshot_dir(&dir.path().join("archives").join("conversations")),
+        archives_before,
+        "archives changed during isolation"
+    );
+
+    // Exit: explicit back-to-normal, banner gone, writes resume.
+    let (status, body) = post_chat_on(&app, "system", "/resume").await;
+    assert_eq!(status, StatusCode::OK);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        json["response"].as_str().unwrap(),
+        crate::server::isolation::BACK_TO_NORMAL
+    );
+    assert!(json.get("isolation").is_none() || json["isolation"] == false);
+
+    let (status, body) = post_chat_on(&app, "system", "hello again").await;
+    assert_eq!(status, StatusCode::OK);
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert!(json.get("isolation").is_none() || json["isolation"] == false);
+    assert!(!json["response"]
+        .as_str()
+        .unwrap()
+        .starts_with(crate::server::isolation::BANNER));
+    let mut resumed_writes = false;
+    for _ in 0..30 {
+        if snapshot_dir(&dir.path().join("sessions").join("wal")) != wal_before {
+            resumed_writes = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(resumed_writes, "writes did not resume after /resume");
+}
+
+/// AC19: entering isolation releases the control-plane lease (provably free)
+/// and the coordinator re-acquires unaided after exit.
+#[tokio::test]
+async fn e2e_isolation_parks_coordinator_and_resumes() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("pulse_null=debug")
+        .try_init();
+    let dir = tempfile::tempdir().unwrap();
+    let provider = MockProvider::new(vec![]);
+    let state = build_state_in(dir.path().to_path_buf(), provider, ToolRegistry::new()).await;
+
+    let schedule = Arc::new(RwLock::new(
+        crate::scheduler::Schedule::load_or_init(dir.path()).unwrap(),
+    ));
+    let intents = Arc::new(RwLock::new(crate::scheduler::intent::IntentQueue::load(
+        dir.path(),
+    )));
+    let coordinator =
+        crate::coordinator::control::Coordinator::start(Arc::clone(&state), schedule, intents);
+    let coord_dir = dir.path().join("coordinator");
+    wait_for_leadership(&coord_dir).await;
+    assert!(state.leadership.load(std::sync::atomic::Ordering::Relaxed));
+
+    // Enter isolation via the file trigger (the CLI path).
+    crate::server::isolation::enter(dir.path(), "test", None).unwrap();
+
+    // Within a few poll ticks the tenure ends and the lease is RELEASED.
+    let wal_path = coord_dir.join("leases.jsonl");
+    let mut released = false;
+    for _ in 0..100 {
+        let content = std::fs::read_to_string(&wal_path).unwrap_or_default();
+        if content.contains(r#""event":"released""#)
+            && !state.leadership.load(std::sync::atomic::Ordering::Relaxed)
+        {
+            released = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(
+        released,
+        "control-plane lease was not released on isolation"
+    );
+
+    // Exit isolation: leadership resumes unaided.
+    crate::server::isolation::exit(dir.path()).unwrap();
+    let mut resumed = false;
+    for _ in 0..100 {
+        if state.leadership.load(std::sync::atomic::Ordering::Relaxed) {
+            resumed = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(resumed, "coordinator did not resume leadership after exit");
+
+    coordinator.shutdown().await;
 }

--- a/src/server/e2e_tests.rs
+++ b/src/server/e2e_tests.rs
@@ -782,7 +782,13 @@ async fn e2e_isolation_over_chat_with_coordinator_wedged() {
         .unwrap()
         .starts_with(crate::server::isolation::BANNER));
 
-    // AC18: a normal turn while isolated writes nothing.
+    // AC18: a normal turn while isolated writes nothing. Flush + settle
+    // first so an un-shed async write would land before the compare.
+    state
+        .persist_coordinator
+        .flush(std::time::Duration::from_secs(2))
+        .await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     let sessions_before = snapshot_dir(&dir.path().join("sessions"));
     let wal_before = snapshot_dir(&dir.path().join("sessions").join("wal"));
     let archives_before = snapshot_dir(&dir.path().join("archives").join("conversations"));
@@ -797,6 +803,11 @@ async fn e2e_isolation_over_chat_with_coordinator_wedged() {
         .unwrap()
         .starts_with(crate::server::isolation::BANNER));
 
+    state
+        .persist_coordinator
+        .flush(std::time::Duration::from_secs(2))
+        .await;
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
     assert_eq!(
         snapshot_dir(&dir.path().join("sessions")),
         sessions_before,

--- a/src/server/e2e_tests.rs
+++ b/src/server/e2e_tests.rs
@@ -34,6 +34,9 @@ use pulse_system_types::llm::{
 struct MockProvider {
     responses: std::sync::Mutex<Vec<LlmResponse>>,
     call_count: AtomicUsize,
+    /// Per-invocation artificial latency — lets a test hold a chat turn
+    /// "in flight" while something else happens to the process.
+    delay: std::time::Duration,
 }
 
 impl MockProvider {
@@ -41,6 +44,14 @@ impl MockProvider {
         Self {
             responses: std::sync::Mutex::new(responses),
             call_count: AtomicUsize::new(0),
+            delay: std::time::Duration::ZERO,
+        }
+    }
+
+    fn with_delay(responses: Vec<LlmResponse>, delay: std::time::Duration) -> Self {
+        Self {
+            delay,
+            ..Self::new(responses)
         }
     }
 }
@@ -71,7 +82,13 @@ impl LmProvider for MockProvider {
                 responses.remove(0)
             }
         };
-        Box::pin(async move { Ok(response) })
+        let delay = self.delay;
+        Box::pin(async move {
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+            Ok(response)
+        })
     }
 
     fn name(&self) -> &str {
@@ -141,7 +158,14 @@ fn build_app(state: Arc<AppState>) -> Router {
 }
 
 async fn build_state(provider: MockProvider, tools: ToolRegistry) -> Arc<AppState> {
-    let root_dir = std::env::temp_dir();
+    build_state_in(std::env::temp_dir(), provider, tools).await
+}
+
+async fn build_state_in(
+    root_dir: std::path::PathBuf,
+    provider: MockProvider,
+    tools: ToolRegistry,
+) -> Arc<AppState> {
     let config = test_config();
     let session_store =
         crate::session_store::SessionStore::new(&root_dir, &config.sessions, &config.entity.name)
@@ -566,4 +590,121 @@ async fn e2e_token_accumulation_across_rounds() {
     let json: serde_json::Value = serde_json::from_str(&body).unwrap();
     assert_eq!(json["input_tokens"], 300); // 100 + 200
     assert_eq!(json["output_tokens"], 125); // 50 + 75
+}
+
+// ---------------------------------------------------------------------------
+// Fail-open: the data plane must not care about the coordinator (AC10, AC11)
+// ---------------------------------------------------------------------------
+
+fn mock_text(text: &str) -> LlmResponse {
+    LlmResponse {
+        content: vec![ContentBlock::Text {
+            text: text.to_string(),
+        }],
+        stop_reason: StopReason::EndTurn,
+        model: "mock-model".to_string(),
+        input_tokens: Some(1),
+        output_tokens: Some(1),
+    }
+}
+
+/// Wait until the coordinator has durably acquired the control-plane lease.
+/// Non-locking: reads the lease WAL's contents instead of opening the table
+/// (an open would steal the file lock out from under the coordinator).
+async fn wait_for_leadership(coord_dir: &std::path::Path) {
+    let wal_path = coord_dir.join("leases.jsonl");
+    for _ in 0..100 {
+        if let Ok(content) = std::fs::read_to_string(&wal_path) {
+            if content.contains("control-plane") {
+                return;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("coordinator never acquired the control-plane lease");
+}
+
+/// AC10: an in-flight chat turn survives the coordinator wedging mid-turn,
+/// and chat keeps serving with the coordinator dead.
+#[tokio::test]
+async fn e2e_chat_survives_coordinator_wedge() {
+    let dir = tempfile::tempdir().unwrap();
+    let provider = MockProvider::with_delay(
+        vec![
+            mock_text("in-flight response"),
+            mock_text("post-wedge response"),
+        ],
+        std::time::Duration::from_millis(400),
+    );
+    let state = build_state_in(dir.path().to_path_buf(), provider, ToolRegistry::new()).await;
+
+    let schedule = Arc::new(RwLock::new(
+        crate::scheduler::Schedule::load(dir.path()).unwrap(),
+    ));
+    let intents = Arc::new(RwLock::new(crate::scheduler::intent::IntentQueue::load(
+        dir.path(),
+    )));
+    let coordinator =
+        crate::coordinator::control::Coordinator::start(Arc::clone(&state), schedule, intents);
+    wait_for_leadership(&dir.path().join("coordinator")).await;
+
+    let app = build_app(Arc::clone(&state));
+
+    // Put a chat turn in flight, then wedge the coordinator mid-turn.
+    let app_inflight = app.clone();
+    let inflight =
+        tokio::spawn(async move { post_chat(&app_inflight, "hello during wedge").await });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    coordinator.wedge_for_test();
+
+    let (status, body) = inflight.await.unwrap();
+    assert_eq!(status, StatusCode::OK, "in-flight turn was interrupted");
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(json["response"], "in-flight response");
+
+    // Fresh turns keep working with the coordinator dead.
+    let (status, body) = post_chat(&app, "anyone home?").await;
+    assert_eq!(status, StatusCode::OK, "chat died with the coordinator");
+    let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(json["response"], "post-wedge response");
+}
+
+/// AC11: while a coordinator holds the control plane, a second one cannot
+/// take it (WAL lock); after a clean shutdown the lease is released and a
+/// successor acquires immediately, without waiting out the ttl.
+#[tokio::test]
+async fn e2e_second_coordinator_locked_out_until_shutdown() {
+    let dir = tempfile::tempdir().unwrap();
+    let provider = MockProvider::new(vec![]);
+    let state = build_state_in(dir.path().to_path_buf(), provider, ToolRegistry::new()).await;
+
+    let schedule = Arc::new(RwLock::new(
+        crate::scheduler::Schedule::load(dir.path()).unwrap(),
+    ));
+    let intents = Arc::new(RwLock::new(crate::scheduler::intent::IntentQueue::load(
+        dir.path(),
+    )));
+    let coordinator =
+        crate::coordinator::control::Coordinator::start(Arc::clone(&state), schedule, intents);
+    let coord_dir = dir.path().join("coordinator");
+    wait_for_leadership(&coord_dir).await;
+
+    // A second coordinator (process) is refused at the WAL lock.
+    assert!(matches!(
+        crate::coordinator::durable::DurableLeaseTable::open(&coord_dir),
+        Err(crate::coordinator::wal::ReplayError::Locked { .. })
+    ));
+
+    // Clean shutdown releases the lease; a successor acquires immediately.
+    coordinator.shutdown().await;
+    let mut successor = crate::coordinator::durable::DurableLeaseTable::open(&coord_dir).unwrap();
+    let lease = successor
+        .acquire(
+            crate::coordinator::control::CONTROL_PLANE_RESOURCE,
+            "successor-1",
+            std::time::Duration::from_secs(90),
+            chrono::Utc::now(),
+        )
+        .expect("lease was not released on shutdown");
+    assert!(lease.fencing_token > crate::coordinator::lease::FencingToken(1));
 }

--- a/src/server/e2e_tests.rs
+++ b/src/server/e2e_tests.rs
@@ -189,6 +189,7 @@ async fn build_state_in(
         wal: None,
         alert_queue: tokio::sync::Mutex::new(alert_queue),
         provider_status: crate::provider_status::new_shared(),
+        leadership: std::sync::atomic::AtomicBool::new(false),
     })
 }
 

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -30,6 +30,11 @@ pub struct ChatResponse {
     pub input_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_tokens: Option<u32>,
+    /// Sticky isolation-mode indicator — present (true) on every response
+    /// while the entity is isolated, so any consumer arriving mid-session
+    /// sees the posture.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub isolation: bool,
 }
 
 fn default_channel() -> String {
@@ -106,6 +111,28 @@ pub async fn chat(
         &state.config.owner,
         &state.config.peers,
     );
+
+    // Isolation commands are handled before ANYTHING else touches the turn —
+    // including the provider, which may itself be the suspect. Owned by the
+    // channel holder (spec decision 5): works with the coordinator wedged.
+    match crate::server::isolation::intercept_command(
+        &state.root_dir,
+        &req.message,
+        &resolved_key,
+        sender_label,
+    ) {
+        crate::server::isolation::Intercept::Handled { response, isolated } => {
+            return Ok(Json(ChatResponse {
+                response,
+                model: "isolation-control".to_string(),
+                input_tokens: None,
+                output_tokens: None,
+                isolation: isolated,
+            }));
+        }
+        crate::server::isolation::Intercept::None => {}
+    }
+    let isolated = crate::server::isolation::is_active(&state.root_dir);
 
     // Build the user message
     let mut user_message = String::new();
@@ -610,10 +637,16 @@ pub async fn chat(
     }
 
     Ok(Json(ChatResponse {
-        response: text,
+        // Sticky banner: every reply while isolated carries the marker.
+        response: if isolated {
+            crate::server::isolation::banner_wrap(text)
+        } else {
+            text
+        },
         model: result.model,
         input_tokens: Some(result.input_tokens),
         output_tokens: Some(result.output_tokens),
+        isolation: isolated,
     }))
 }
 

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -192,10 +192,12 @@ pub async fn chat(
     user_message.push_str("\nUser message: ");
     user_message.push_str(&req.message);
 
-    // Record incoming message to context buffer
-    if let Some(ref cb) = state.context_buffer {
-        cb.record(&req.channel, sender_label, "user", &req.message)
-            .await;
+    // Record incoming message to context buffer (shed in isolation)
+    if !isolated {
+        if let Some(ref cb) = state.context_buffer {
+            cb.record(&req.channel, sender_label, "user", &req.message)
+                .await;
+        }
     }
 
     // Get or create session keyed by resolved identity (Phase 1: Unified Session)
@@ -214,7 +216,9 @@ pub async fn chat(
     // time cap, or hallucination threshold). If so, archive the current conversation
     // with a structured handoff and start fresh before processing this message.
     let limits = state.config.sessions.get_identity_limits(&resolved_key);
-    if session.data.should_reset(&limits) {
+    // Session resets archive to disk — shed in isolation (the in-memory
+    // session simply keeps growing for the duration of the diagnosis).
+    if !isolated && session.data.should_reset(&limits) {
         tracing::info!(
             "[session-reset] auto-reset triggered for {} (msgs={}, cap={}, age_s={}, time_cap={})",
             session_key,
@@ -237,7 +241,9 @@ pub async fn chat(
 
     // WAL: append user message BEFORE adding to session (write-ahead).
     // Only increment wal_seq on success to keep it in sync with the WAL file.
-    if let Some(ref wal) = state.wal {
+    // (Shed in isolation: the diagnostic conversation is deliberately
+    // ephemeral — nothing that writes.)
+    if let Some(wal) = state.wal.as_ref().filter(|_| !isolated) {
         let next_seq = session.data.wal.wal_seq + 1;
         match wal.append(
             &session_key,
@@ -278,88 +284,92 @@ pub async fn chat(
             crate::context::estimate_conversation_tokens(&session.data.messages);
     }
 
-    // Compact conversation if approaching context budget (Tier 2 — Structured AutoCompact)
-    // Extract values before the call to avoid borrow conflicts with &mut messages
-    let recent_files_snapshot = session.data.compaction.recently_accessed_files.clone();
-    let current_compaction_failures = session.data.compaction.compaction_failures;
-    let active_plan_snapshot = session.data.compaction.active_plan.clone();
-    let compaction_result = crate::context::compact_if_needed(
-        &mut session.data.messages,
-        state.provider.as_ref(),
-        state.config.llm.context_budget,
-        state.config.llm.max_tokens,
-        &state.root_dir,
-        &state.config.entity.name,
-        &req.channel,
-        Some(&session_key),
-        current_compaction_failures,
-        &recent_files_snapshot,
-        active_plan_snapshot.as_deref(),
-    )
-    .await;
-    // Write back updated compaction failures from result
-    session.data.compaction.compaction_failures = compaction_result.compaction_failures;
-    if compaction_result.compacted {
-        session.data.compaction.compaction_count += 1;
-        let tokens_recovered = compaction_result
-            .tokens_before
-            .saturating_sub(compaction_result.tokens_after);
-        session.data.compaction.total_tokens_recovered_compact += tokens_recovered;
-        session.data.compaction.last_compaction_at = Some(Utc::now());
-        // Update token estimate after compaction
-        session.data.compaction.estimated_tokens =
-            crate::context::estimate_conversation_tokens(&session.data.messages);
+    // Tier-2 compaction is shed in isolation: it calls the provider and
+    // writes archives — both belong to the subsystems under suspicion.
+    if !isolated {
+        // Compact conversation if approaching context budget (Tier 2 — Structured AutoCompact)
+        // Extract values before the call to avoid borrow conflicts with &mut messages
+        let recent_files_snapshot = session.data.compaction.recently_accessed_files.clone();
+        let current_compaction_failures = session.data.compaction.compaction_failures;
+        let active_plan_snapshot = session.data.compaction.active_plan.clone();
+        let compaction_result = crate::context::compact_if_needed(
+            &mut session.data.messages,
+            state.provider.as_ref(),
+            state.config.llm.context_budget,
+            state.config.llm.max_tokens,
+            &state.root_dir,
+            &state.config.entity.name,
+            &req.channel,
+            Some(&session_key),
+            current_compaction_failures,
+            &recent_files_snapshot,
+            active_plan_snapshot.as_deref(),
+        )
+        .await;
+        // Write back updated compaction failures from result
+        session.data.compaction.compaction_failures = compaction_result.compaction_failures;
+        if compaction_result.compacted {
+            session.data.compaction.compaction_count += 1;
+            let tokens_recovered = compaction_result
+                .tokens_before
+                .saturating_sub(compaction_result.tokens_after);
+            session.data.compaction.total_tokens_recovered_compact += tokens_recovered;
+            session.data.compaction.last_compaction_at = Some(Utc::now());
+            // Update token estimate after compaction
+            session.data.compaction.estimated_tokens =
+                crate::context::estimate_conversation_tokens(&session.data.messages);
 
-        // Record compaction signal for vigil-pulse trend analysis.
-        // Non-blocking — failures are logged but don't affect the chat flow.
-        let compaction_signal = crate::vigil::compaction_signals::CompactionSignalFrame {
-            timestamp: Utc::now().to_rfc3339(),
-            session_key: session_key.clone(),
-            tier: if compaction_result.circuit_breaker_fired {
-                3
-            } else {
-                2
-            },
-            tokens_before: compaction_result.tokens_before,
-            tokens_after: compaction_result.tokens_after,
-            quality_score: session.data.compaction.context_quality_score,
-            circuit_breaker_fired: compaction_result.circuit_breaker_fired,
-            files_reinjected: compaction_result.files_reinjected,
-            had_active_plan: active_plan_snapshot.is_some(),
-        };
-        let root_for_signal = state.root_dir.clone();
-        tokio::task::spawn_blocking(move || {
-            if let Err(e) =
-                crate::vigil::compaction_signals::record(&root_for_signal, compaction_signal)
-            {
-                tracing::warn!("Failed to record compaction signal: {}", e);
-            }
-        });
+            // Record compaction signal for vigil-pulse trend analysis.
+            // Non-blocking — failures are logged but don't affect the chat flow.
+            let compaction_signal = crate::vigil::compaction_signals::CompactionSignalFrame {
+                timestamp: Utc::now().to_rfc3339(),
+                session_key: session_key.clone(),
+                tier: if compaction_result.circuit_breaker_fired {
+                    3
+                } else {
+                    2
+                },
+                tokens_before: compaction_result.tokens_before,
+                tokens_after: compaction_result.tokens_after,
+                quality_score: session.data.compaction.context_quality_score,
+                circuit_breaker_fired: compaction_result.circuit_breaker_fired,
+                files_reinjected: compaction_result.files_reinjected,
+                had_active_plan: active_plan_snapshot.is_some(),
+            };
+            let root_for_signal = state.root_dir.clone();
+            tokio::task::spawn_blocking(move || {
+                if let Err(e) =
+                    crate::vigil::compaction_signals::record(&root_for_signal, compaction_signal)
+                {
+                    tracing::warn!("Failed to record compaction signal: {}", e);
+                }
+            });
 
-        // Structured compaction log for debugging and analysis
-        tracing::info!(
-            "[COMPACTION] tier={} session={} before={}T after={}T recovered={}T \
-             quality={:.2} files_reinjected={} circuit_breaker={} active_plan={}",
-            if compaction_result.circuit_breaker_fired {
-                3
-            } else {
-                2
-            },
-            session_key,
-            compaction_result.tokens_before,
-            compaction_result.tokens_after,
-            tokens_recovered,
-            session.data.compaction.context_quality_score,
-            compaction_result.files_reinjected,
-            compaction_result.circuit_breaker_fired,
-            active_plan_snapshot.is_some(),
-        );
-
-        if compaction_result.circuit_breaker_fired {
-            tracing::error!(
-                session_key = %session_key,
-                "Compaction circuit breaker fired — session compaction frozen"
+            // Structured compaction log for debugging and analysis
+            tracing::info!(
+                "[COMPACTION] tier={} session={} before={}T after={}T recovered={}T \
+                 quality={:.2} files_reinjected={} circuit_breaker={} active_plan={}",
+                if compaction_result.circuit_breaker_fired {
+                    3
+                } else {
+                    2
+                },
+                session_key,
+                compaction_result.tokens_before,
+                compaction_result.tokens_after,
+                tokens_recovered,
+                session.data.compaction.context_quality_score,
+                compaction_result.files_reinjected,
+                compaction_result.circuit_breaker_fired,
+                active_plan_snapshot.is_some(),
             );
+
+            if compaction_result.circuit_breaker_fired {
+                tracing::error!(
+                    session_key = %session_key,
+                    "Compaction circuit breaker fired — session compaction frozen"
+                );
+            }
         }
     }
 
@@ -397,11 +407,23 @@ pub async fn chat(
         )
     };
 
+    // Isolation offers only the read-only introspection tool set — no
+    // file_write, no web_fetch, no plugin tools.
+    let readonly_tools = if isolated {
+        Some(crate::server::setup::register_readonly_tools(
+            &state.root_dir,
+            &state.config,
+        ))
+    } else {
+        None
+    };
+    let active_tools = readonly_tools.as_ref().unwrap_or(&state.tools);
+
     let result = crate::task_context::scope(
         Some(correlation_id.clone()),
         tool_loop::invoke_with_tool_loop(
             state.provider.as_ref(),
-            &state.tools,
+            active_tools,
             &system_prompt,
             &mut session.data.messages,
             state.config.llm.max_tokens,
@@ -425,9 +447,8 @@ pub async fn chat(
         }
     }
 
-    // WAL: append assistant response.
-    // Only increment wal_seq on success to keep it in sync with the WAL file.
-    if let Some(ref wal) = state.wal {
+    // WAL: append assistant response. (Shed in isolation.)
+    if let Some(wal) = state.wal.as_ref().filter(|_| !isolated) {
         let next_seq = session.data.wal.wal_seq + 1;
         match wal.append(
             &session_key,
@@ -535,8 +556,8 @@ pub async fn chat(
     // Enforce hard cap on stored messages (safety backstop — session caps should fire first)
     session.data.enforce_message_cap();
 
-    // Record conversation outcome for caliber-echo
-    if let Some(ref _tracker) = state.outcome_tracker {
+    // Record conversation outcome for caliber-echo (shed in isolation)
+    if let Some(_tracker) = state.outcome_tracker.as_ref().filter(|_| !isolated) {
         let conv_outcome = crate::caliber::runtime::build_conversation_outcome(
             &session_key,
             &channel,
@@ -564,13 +585,17 @@ pub async fn chat(
         .await;
     }
 
-    // Incremental checkpoint (if conditions met)
-    maybe_checkpoint(&state, &session_key, &mut session.data, &channel).await;
+    // Incremental checkpoint (if conditions met; shed in isolation)
+    if !isolated {
+        maybe_checkpoint(&state, &session_key, &mut session.data, &channel).await;
+    }
 
-    // Record entity response to context buffer
-    if let Some(ref cb) = state.context_buffer {
-        cb.record(&channel, &state.config.entity.name, "assistant", &text)
-            .await;
+    // Record entity response to context buffer (shed in isolation)
+    if !isolated {
+        if let Some(ref cb) = state.context_buffer {
+            cb.record(&channel, &state.config.entity.name, "assistant", &text)
+                .await;
+        }
     }
 
     // Build InteractionRecord from the session before dropping the lock.
@@ -596,14 +621,22 @@ pub async fn chat(
     );
     // Drop the session lock before persisting to avoid deadlock
     drop(session);
-    persist_store.persist(&persist_key).await;
-    tracing::debug!("[chat] persist call returned for key={}", persist_key);
+    if isolated {
+        tracing::debug!("[chat] session persist shed (isolation)");
+    } else {
+        persist_store.persist(&persist_key).await;
+        tracing::debug!("[chat] persist call returned for key={}", persist_key);
+    }
 
     // Emit PostInteraction event from the InteractionRecord
     // Chat sessions are persisted separately (session store), so we emit
     // on every request for real-time assessment. Only assessable interactions
     // are worth emitting — trivial health-checks get skipped.
-    if interaction.is_assessable() {
+    if isolated {
+        // Shed in isolation: the event listener downstream writes intent and
+        // evaluator state, and the audit log is itself a write.
+        tracing::debug!("[chat] event emission and intake audit shed (isolation)");
+    } else if interaction.is_assessable() {
         let receivers = state.event_bus.emit(interaction.to_event());
         tracing::debug!(
             "[chat] PostInteraction emitted to {} receivers (source={})",

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -211,10 +211,29 @@ pub async fn chat(
     let mut session = session_arc.write().await;
     session.touch();
 
+    // Ephemeral isolation tail (spec Stage 2: "nothing that writes"): while
+    // isolated, remember where the in-memory conversation stood; the first
+    // normal turn truncates back to it so the isolated exchange never
+    // reaches disk through persist, checkpoint, archive, or eviction.
+    if isolated {
+        if session.data.isolation_ephemeral_from.is_none() {
+            session.data.isolation_ephemeral_from = Some(session.data.messages.len());
+        }
+    } else if let Some(watermark) = session.data.isolation_ephemeral_from.take() {
+        let dropped = session.data.messages.len().saturating_sub(watermark);
+        session.data.messages.truncate(watermark);
+        session.data.compaction.estimated_tokens =
+            crate::context::estimate_conversation_tokens(&session.data.messages);
+        tracing::info!(
+            "[chat] dropped {dropped} ephemeral isolation message(s) on return to normal"
+        );
+    }
+
     // === Session limit check ===
     // Check if the session has exceeded its channel-specific limits (message cap,
     // time cap, or hallucination threshold). If so, archive the current conversation
     // with a structured handoff and start fresh before processing this message.
+    let pre_turn_len = session.data.messages.len();
     let limits = state.config.sessions.get_identity_limits(&resolved_key);
     // Session resets archive to disk — shed in isolation (the in-memory
     // session simply keeps growing for the duration of the diagnosis).
@@ -270,7 +289,9 @@ pub async fn chat(
         }),
     });
     session.data.message_count += 1;
-    session.data.wal.messages_since_checkpoint += 1;
+    if !isolated {
+        session.data.wal.messages_since_checkpoint += 1;
+    }
     // Real human message arrived — reset the autonomous round counter
     session.data.health.rounds_since_human_input = 0;
 
@@ -433,8 +454,22 @@ pub async fn chat(
     .await
     .map_err(|e| {
         tracing::error!("LLM invocation failed: {}", e);
-        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+        // Keep the banner sticky even on the failure path — while isolated
+        // the provider is precisely the suspect.
+        let msg = if crate::server::isolation::is_active(&state.root_dir) {
+            format!("{} {}", crate::server::isolation::BANNER, e)
+        } else {
+            e.to_string()
+        };
+        (StatusCode::INTERNAL_SERVER_ERROR, msg)
     })?;
+
+    // Re-sample: a turn admitted just before the marker appeared must not
+    // write after it. OR of the two samples drives every gate below.
+    let isolated = isolated || crate::server::isolation::is_active(&state.root_dir);
+    if isolated && session.data.isolation_ephemeral_from.is_none() {
+        session.data.isolation_ephemeral_from = Some(pre_turn_len);
+    }
 
     let text = result.text;
 
@@ -610,7 +645,9 @@ pub async fn chat(
     );
 
     // Mark session dirty and persist asynchronously
-    session.mark_dirty();
+    if !isolated {
+        session.mark_dirty();
+    }
     let persist_key = session_key.clone();
     let persist_store = &state.session_store;
     tracing::debug!(
@@ -669,9 +706,11 @@ pub async fn chat(
         );
     }
 
+    // Sticky banner for trusted consumers; concealed from guests (the
+    // operating posture is not their business).
+    let reveal = isolated && !resolved_key.starts_with("guest:");
     Ok(Json(ChatResponse {
-        // Sticky banner: every reply while isolated carries the marker.
-        response: if isolated {
+        response: if reveal {
             crate::server::isolation::banner_wrap(text)
         } else {
             text
@@ -679,7 +718,7 @@ pub async fn chat(
         model: result.model,
         input_tokens: Some(result.input_tokens),
         output_tokens: Some(result.output_tokens),
-        isolation: isolated,
+        isolation: reveal,
     }))
 }
 

--- a/src/server/handlers/health.rs
+++ b/src/server/handlers/health.rs
@@ -17,9 +17,19 @@ pub async fn health(State(state): State<Arc<AppState>>) -> (StatusCode, Json<ser
         ProviderState::Offline => (StatusCode::SERVICE_UNAVAILABLE, "offline"),
     };
 
+    let isolated = crate::server::isolation::is_active(&state.root_dir);
+    let leading = state.leadership.load(std::sync::atomic::Ordering::Relaxed);
     let mut body = serde_json::json!({
         "status": state_str,
         "entity": state.config.entity.name,
+        "isolation": isolated,
+        "control_plane": if isolated {
+            "shed"
+        } else if leading {
+            "leading"
+        } else {
+            "not-leading"
+        },
     });
 
     if status.state != ProviderState::Healthy {

--- a/src/server/handlers/health.rs
+++ b/src/server/handlers/health.rs
@@ -23,13 +23,10 @@ pub async fn health(State(state): State<Arc<AppState>>) -> (StatusCode, Json<ser
         "status": state_str,
         "entity": state.config.entity.name,
         "isolation": isolated,
-        "control_plane": if isolated {
-            "shed"
-        } else if leading {
-            "leading"
-        } else {
-            "not-leading"
-        },
+        // Observed state only — the marker is reported separately as
+        // `isolation`; claiming "shed" from the marker alone would lie
+        // whenever the coordinator is wedged and its tasks still run.
+        "control_plane": if leading { "leading" } else { "not-leading" },
     });
 
     if status.state != ProviderState::Healthy {

--- a/src/server/handlers/sessions.rs
+++ b/src/server/handlers/sessions.rs
@@ -31,6 +31,16 @@ pub async fn reset_session(
     State(state): State<Arc<AppState>>,
     Json(req): Json<ResetRequest>,
 ) -> Result<Json<ResetResponse>, (StatusCode, String)> {
+    // Resets archive to disk — shed while isolated.
+    if crate::server::isolation::is_active(&state.root_dir) {
+        return Err((
+            StatusCode::CONFLICT,
+            format!(
+                "{} isolation mode active — session reset writes are shed until /resume",
+                crate::server::isolation::BANNER
+            ),
+        ));
+    }
     // Find the session
     let sessions = state.session_store.sessions_map().await;
     let session_arc = match sessions.get(&req.session_key) {

--- a/src/server/isolation.rs
+++ b/src/server/isolation.rs
@@ -48,8 +48,17 @@ fn marker_path(root_dir: &Path) -> std::path::PathBuf {
 }
 
 /// Whether isolation mode is active. One stat — cheap enough per request.
+/// IO errors other than NotFound count as isolated: the failure direction is
+/// INTO the retreat, never silently out of it.
 pub fn is_active(root_dir: &Path) -> bool {
-    marker_path(root_dir).exists()
+    match std::fs::symlink_metadata(marker_path(root_dir)) {
+        Ok(_) => true,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => false,
+        Err(e) => {
+            tracing::warn!("isolation marker unreadable ({e}); treating as ISOLATED");
+            true
+        }
+    }
 }
 
 /// Current marker, if isolated. A marker that exists but doesn't parse still
@@ -110,28 +119,26 @@ pub fn intercept_command(
     sender_label: &str,
 ) -> Intercept {
     let trimmed = message.trim();
-    let (is_enter, is_exit) = (
-        trimmed == ENTER_COMMAND || trimmed.starts_with(&format!("{ENTER_COMMAND} ")),
-        trimmed == EXIT_COMMAND,
-    );
+    let first_token = trimmed.split_whitespace().next().unwrap_or("");
+    let is_enter = first_token.eq_ignore_ascii_case(ENTER_COMMAND);
+    let is_exit = first_token.eq_ignore_ascii_case(EXIT_COMMAND);
     if !is_enter && !is_exit {
         return Intercept::None;
     }
 
-    if resolved_key.starts_with("guest:") {
+    // Owner only — not guests, not peers (a sibling entity must not be able
+    // to /resume this one mid-diagnosis). The refusal conceals the posture.
+    if resolved_key != "owner" {
         return Intercept::Handled {
-            response: "Isolation commands are restricted to trusted senders.".to_string(),
-            isolated: is_active(root_dir),
+            response: "Isolation commands are restricted to the owner.".to_string(),
+            isolated: false,
         };
     }
 
     if is_enter {
-        let reason = trimmed
-            .strip_prefix(ENTER_COMMAND)
-            .map(str::trim)
-            .filter(|r| !r.is_empty())
-            .map(String::from);
-        match enter(root_dir, sender_label, reason) {
+        let reason =
+            Some(sanitize_field(trimmed[first_token.len()..].trim())).filter(|r| !r.is_empty());
+        match enter(root_dir, &sanitize_field(sender_label), reason) {
             Ok(marker) => Intercept::Handled {
                 response: format!(
                     "{BANNER} Isolation mode ACTIVE (entered {} by {}). \
@@ -171,6 +178,16 @@ pub fn intercept_command(
 /// Apply the sticky banner to a normal (non-command) response while isolated.
 pub fn banner_wrap(response: String) -> String {
     format!("{BANNER} {response}")
+}
+
+/// Marker fields are echoed to the operator's terminal — cap length and
+/// strip control characters (ANSI injection via a crafted sender/reason).
+fn sanitize_field(input: &str) -> String {
+    input
+        .chars()
+        .filter(|c| !c.is_control())
+        .take(256)
+        .collect()
 }
 
 #[cfg(test)]
@@ -222,7 +239,7 @@ mod tests {
     #[test]
     fn trusted_sender_enters_and_exits_with_explicit_signals() {
         let dir = tempfile::tempdir().unwrap();
-        match intercept_command(dir.path(), "/isolate suspect graph", "owner:D", "D") {
+        match intercept_command(dir.path(), "/isolate suspect graph", "owner", "D") {
             Intercept::Handled { response, isolated } => {
                 assert!(isolated);
                 assert!(response.starts_with(BANNER));
@@ -235,7 +252,7 @@ mod tests {
             Some("suspect graph")
         );
 
-        match intercept_command(dir.path(), "/resume", "owner:D", "D") {
+        match intercept_command(dir.path(), "/resume", "owner", "D") {
             Intercept::Handled { response, isolated } => {
                 assert!(!isolated);
                 assert_eq!(response, BACK_TO_NORMAL);
@@ -246,14 +263,77 @@ mod tests {
     }
 
     #[test]
+    fn readonly_tool_set_has_no_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = crate::config::test_support::minimal_config();
+        let names = crate::server::setup::register_readonly_tools(dir.path(), &config).names();
+        assert!(!names.iter().any(|n| n.contains("write")), "{names:?}");
+        assert!(!names.iter().any(|n| n.contains("fetch")), "{names:?}");
+    }
+
+    #[test]
+    fn commands_are_owner_only_and_conceal_posture() {
+        let dir = tempfile::tempdir().unwrap();
+        enter(dir.path(), "D", None).unwrap();
+        for key in ["guest:x", "peer:echo2"] {
+            match intercept_command(dir.path(), "/resume", key, "x") {
+                Intercept::Handled { response, isolated } => {
+                    assert!(response.contains("owner"));
+                    assert!(!isolated, "posture leaked to {key}");
+                }
+                Intercept::None => panic!("should intercept"),
+            }
+            assert!(is_active(dir.path()), "{key} flipped isolation");
+        }
+    }
+
+    #[test]
+    fn command_matching_is_tokenized_and_case_insensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        match intercept_command(
+            dir.path(),
+            "  /ISOLATE   graph acting weird  ",
+            "owner",
+            "D",
+        ) {
+            Intercept::Handled { isolated, .. } => assert!(isolated),
+            Intercept::None => panic!("should intercept"),
+        }
+        assert_eq!(
+            status(dir.path()).unwrap().reason.as_deref(),
+            Some("graph acting weird")
+        );
+        match intercept_command(dir.path(), "/Resume", "owner", "D") {
+            Intercept::Handled { isolated, .. } => assert!(!isolated),
+            Intercept::None => panic!("should intercept"),
+        }
+        assert!(!is_active(dir.path()));
+    }
+
+    #[test]
+    fn marker_fields_are_sanitized() {
+        let dir = tempfile::tempdir().unwrap();
+        let long_reason = "x".repeat(5000);
+        let msg = format!("/isolate \u{1b}[31mred\u{1b}[0m {long_reason}");
+        match intercept_command(dir.path(), &msg, "owner", "evil\u{7}bell") {
+            Intercept::Handled { isolated, .. } => assert!(isolated),
+            Intercept::None => panic!("should intercept"),
+        }
+        let marker = status(dir.path()).unwrap();
+        assert!(marker.reason.as_ref().unwrap().len() <= 256 * 4);
+        assert!(!marker.reason.as_ref().unwrap().contains('\u{1b}'));
+        assert!(!marker.by.contains('\u{7}'));
+    }
+
+    #[test]
     fn ordinary_messages_pass_through() {
         let dir = tempfile::tempdir().unwrap();
         assert!(matches!(
-            intercept_command(dir.path(), "tell me about /isolate", "owner:D", "D"),
+            intercept_command(dir.path(), "tell me about /isolate", "owner", "D"),
             Intercept::None
         ));
         assert!(matches!(
-            intercept_command(dir.path(), "hello", "owner:D", "D"),
+            intercept_command(dir.path(), "hello", "owner", "D"),
             Intercept::None
         ));
     }

--- a/src/server/isolation.rs
+++ b/src/server/isolation.rs
@@ -1,0 +1,260 @@
+//! Isolation Mode — the data plane's deliberate retreat (coordinator spec,
+//! Stage 2).
+//!
+//! A bisection tool, not a crash state: Echo sheds every subsystem that
+//! might be lying to it and drops to a known-good minimal core — the
+//! interactive channel, read-only introspection over journal/ and memory/,
+//! and basic reasoning. Nothing that writes.
+//!
+//! Ownership (spec decision 5): the trigger and the banner belong to the
+//! interactive-channel holder — this module lives in the server, NOT under
+//! `src/coordinator/`, precisely so entering, seeing, and exiting isolation
+//! never depend on the thing that might be wedged. State is a marker file
+//! (`{root}/ISOLATION`), so it is sticky across restarts, writable with the
+//! whole control plane dead, and visible to the CLI and a bare `ls` alike.
+//!
+//! The one limit, written down (spec): a clean bill in Isolation Mode means
+//! "healthy in isolation", NOT "healthy" — some failures only manifest
+//! under real load.
+
+use std::io;
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const MARKER_FILE: &str = "ISOLATION";
+pub const ENTER_COMMAND: &str = "/isolate";
+pub const EXIT_COMMAND: &str = "/resume";
+/// Prefixed to every response while isolated — a persistent state indicator,
+/// not a one-shot notification (spec: sticky banner).
+pub const BANNER: &str = "[ISOLATION]";
+/// The explicit exit signal (spec: "a silent return is how you end up
+/// debugging a system you *think* is isolated but isn't").
+pub const BACK_TO_NORMAL: &str =
+    "Back to normal — isolation mode exited; coordinator and subsystems will resume.";
+
+/// Contents of the marker file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IsolationMarker {
+    pub entered_at: DateTime<Utc>,
+    pub by: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+fn marker_path(root_dir: &Path) -> std::path::PathBuf {
+    root_dir.join(MARKER_FILE)
+}
+
+/// Whether isolation mode is active. One stat — cheap enough per request.
+pub fn is_active(root_dir: &Path) -> bool {
+    marker_path(root_dir).exists()
+}
+
+/// Current marker, if isolated. A marker that exists but doesn't parse still
+/// counts as isolated (fail toward the retreat, never silently out of it).
+pub fn status(root_dir: &Path) -> Option<IsolationMarker> {
+    let content = std::fs::read_to_string(marker_path(root_dir)).ok()?;
+    Some(serde_json::from_str(&content).unwrap_or(IsolationMarker {
+        entered_at: DateTime::<Utc>::MIN_UTC,
+        by: "unknown (unparseable marker)".to_string(),
+        reason: None,
+    }))
+}
+
+/// Enter isolation. Idempotent-ish: an existing marker is left untouched
+/// (the original entry time is the honest one).
+pub fn enter(root_dir: &Path, by: &str, reason: Option<String>) -> io::Result<IsolationMarker> {
+    if let Some(existing) = status(root_dir) {
+        return Ok(existing);
+    }
+    let marker = IsolationMarker {
+        entered_at: Utc::now(),
+        by: by.to_string(),
+        reason,
+    };
+    let content = serde_json::to_string_pretty(&marker)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let tmp = root_dir.join(format!(".{MARKER_FILE}.tmp.{}", std::process::id()));
+    std::fs::write(&tmp, content)?;
+    std::fs::rename(&tmp, marker_path(root_dir))?;
+    Ok(marker)
+}
+
+/// Exit isolation. Returns whether we were isolated.
+pub fn exit(root_dir: &Path) -> io::Result<bool> {
+    match std::fs::remove_file(marker_path(root_dir)) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+/// Outcome of checking a chat message for isolation commands.
+pub enum Intercept {
+    /// Not an isolation command — proceed with the normal turn.
+    None,
+    /// An isolation command was handled; respond with this text (already
+    /// banner-prefixed where appropriate) and do not run the LLM turn.
+    Handled { response: String, isolated: bool },
+}
+
+/// Handle `/isolate` / `/resume` before anything else touches the turn —
+/// including the provider, which may itself be the suspect. Trusted senders
+/// only: a guest must not be able to flip the entity's operating posture.
+pub fn intercept_command(
+    root_dir: &Path,
+    message: &str,
+    resolved_key: &str,
+    sender_label: &str,
+) -> Intercept {
+    let trimmed = message.trim();
+    let (is_enter, is_exit) = (
+        trimmed == ENTER_COMMAND || trimmed.starts_with(&format!("{ENTER_COMMAND} ")),
+        trimmed == EXIT_COMMAND,
+    );
+    if !is_enter && !is_exit {
+        return Intercept::None;
+    }
+
+    if resolved_key.starts_with("guest:") {
+        return Intercept::Handled {
+            response: "Isolation commands are restricted to trusted senders.".to_string(),
+            isolated: is_active(root_dir),
+        };
+    }
+
+    if is_enter {
+        let reason = trimmed
+            .strip_prefix(ENTER_COMMAND)
+            .map(str::trim)
+            .filter(|r| !r.is_empty())
+            .map(String::from);
+        match enter(root_dir, sender_label, reason) {
+            Ok(marker) => Intercept::Handled {
+                response: format!(
+                    "{BANNER} Isolation mode ACTIVE (entered {} by {}). \
+                     Minimal core only: this channel, read-only introspection over \
+                     journal/ and memory/, reasoning. Coordinator, scheduler, and all \
+                     state writes are shed. This banner stays on every reply until \
+                     {EXIT_COMMAND}. Remember: clean here means healthy IN ISOLATION, \
+                     not healthy.",
+                    marker.entered_at.format("%Y-%m-%d %H:%M:%SZ"),
+                    marker.by
+                ),
+                isolated: true,
+            },
+            Err(e) => Intercept::Handled {
+                response: format!("Failed to enter isolation mode: {e}"),
+                isolated: is_active(root_dir),
+            },
+        }
+    } else {
+        match exit(root_dir) {
+            Ok(true) => Intercept::Handled {
+                response: BACK_TO_NORMAL.to_string(),
+                isolated: false,
+            },
+            Ok(false) => Intercept::Handled {
+                response: "Not in isolation mode — nothing to resume.".to_string(),
+                isolated: false,
+            },
+            Err(e) => Intercept::Handled {
+                response: format!("{BANNER} Failed to exit isolation mode: {e} — still isolated."),
+                isolated: true,
+            },
+        }
+    }
+}
+
+/// Apply the sticky banner to a normal (non-command) response while isolated.
+pub fn banner_wrap(response: String) -> String {
+    format!("{BANNER} {response}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marker_lifecycle_enter_status_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_active(dir.path()));
+        assert!(status(dir.path()).is_none());
+
+        let marker = enter(dir.path(), "D", Some("suspect graph".into())).unwrap();
+        assert!(is_active(dir.path()));
+        assert_eq!(marker.by, "D");
+
+        // Re-entry keeps the original marker (honest entry time).
+        let again = enter(dir.path(), "someone-else", None).unwrap();
+        assert_eq!(again.by, "D");
+
+        assert!(exit(dir.path()).unwrap());
+        assert!(!is_active(dir.path()));
+        assert!(!exit(dir.path()).unwrap());
+    }
+
+    #[test]
+    fn unparseable_marker_still_counts_as_isolated() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(MARKER_FILE), "not json at all").unwrap();
+        assert!(is_active(dir.path()));
+        let marker = status(dir.path()).unwrap();
+        assert!(marker.by.contains("unparseable"));
+    }
+
+    #[test]
+    fn guest_cannot_flip_isolation() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = intercept_command(dir.path(), "/isolate", "guest:stranger", "stranger");
+        match result {
+            Intercept::Handled { response, isolated } => {
+                assert!(response.contains("restricted"));
+                assert!(!isolated);
+            }
+            Intercept::None => panic!("command should be intercepted"),
+        }
+        assert!(!is_active(dir.path()));
+    }
+
+    #[test]
+    fn trusted_sender_enters_and_exits_with_explicit_signals() {
+        let dir = tempfile::tempdir().unwrap();
+        match intercept_command(dir.path(), "/isolate suspect graph", "owner:D", "D") {
+            Intercept::Handled { response, isolated } => {
+                assert!(isolated);
+                assert!(response.starts_with(BANNER));
+            }
+            Intercept::None => panic!("should intercept"),
+        }
+        assert!(is_active(dir.path()));
+        assert_eq!(
+            status(dir.path()).unwrap().reason.as_deref(),
+            Some("suspect graph")
+        );
+
+        match intercept_command(dir.path(), "/resume", "owner:D", "D") {
+            Intercept::Handled { response, isolated } => {
+                assert!(!isolated);
+                assert_eq!(response, BACK_TO_NORMAL);
+            }
+            Intercept::None => panic!("should intercept"),
+        }
+        assert!(!is_active(dir.path()));
+    }
+
+    #[test]
+    fn ordinary_messages_pass_through() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            intercept_command(dir.path(), "tell me about /isolate", "owner:D", "D"),
+            Intercept::None
+        ));
+        assert!(matches!(
+            intercept_command(dir.path(), "hello", "owner:D", "D"),
+            Intercept::None
+        ));
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -266,17 +266,17 @@ pub async fn start(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     // Startup pipeline health check
     setup::startup_pipeline_check(&root_dir, &config, &state.pipeline_monitor);
 
-    // Load schedule and intent queue, start scheduler
+    // Load schedule and intent queue; the coordinator gates the scheduler on
+    // control-plane leadership (fail-open: chat/voice never wait on this).
     let schedule = Schedule::load(&root_dir)?;
     let schedule = Arc::new(RwLock::new(schedule));
     let intent_queue = IntentQueue::load(&root_dir);
     let intent_queue = Arc::new(RwLock::new(intent_queue));
-    let scheduler_handles = crate::scheduler::start(
+    let coordinator = crate::coordinator::control::Coordinator::start(
         Arc::clone(&state),
         Arc::clone(&schedule),
         Arc::clone(&intent_queue),
-    )
-    .await?;
+    );
 
     // Recover orphaned conversations from WAL (post-init: provider + plugins ready)
     if let Some(ref wal) = state.wal {
@@ -349,12 +349,10 @@ pub async fn start(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     // === Post-signal sequence ===
     // These run immediately after SIGTERM, while axum is still draining.
 
-    // 1. Abort scheduler tasks — they call the provider directly and may hold
-    //    long-running LLM requests that block the runtime.
-    tracing::info!("Aborting {} scheduler task(s)", scheduler_handles.len());
-    for handle in scheduler_handles {
-        handle.abort();
-    }
+    // 1. Stop the coordinator — aborts scheduler tasks (they call the provider
+    //    directly and may hold long-running LLM requests) and releases the
+    //    control-plane lease so a successor need not wait out the ttl.
+    coordinator.shutdown().await;
 
     // 2. Stop plugins (Discord bot, etc.) so they stop generating new requests.
     state.plugin_manager.lock().await.stop_all().await;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -63,6 +63,10 @@ pub struct AppState {
 /// Shared by both the event-driven rebuild and the lagged-channel fallback
 /// to eliminate logic duplication.
 async fn rebuild_awareness(state: &Arc<AppState>) {
+    // AWARENESS.md is a write — shed while isolated.
+    if crate::server::isolation::is_active(&state.root_dir) {
+        return;
+    }
     let pm = state.plugin_manager.lock().await;
     let plugin_descriptions = pm.collect_platform_descriptions();
     let tool_names = state.tools.names();
@@ -380,11 +384,18 @@ pub async fn start(config: Config) -> Result<(), Box<dyn std::error::Error>> {
         tracing::warn!("Some persistence tasks did not complete before shutdown");
     }
 
-    // 5. Archive all sessions on shutdown and persist to disk
-    let archived_paths = state
-        .session_store
-        .archive_all(&root_dir, &config.entity.name)
-        .await;
+    // 5. Archive all sessions on shutdown and persist to disk. Shed while
+    // isolated: sessions may carry the ephemeral isolation tail, which must
+    // never reach disk (spec Stage 2 — nothing that writes).
+    let archived_paths = if crate::server::isolation::is_active(&root_dir) {
+        tracing::warn!("shutdown during ISOLATION — session archive/persist shed");
+        Vec::new()
+    } else {
+        state
+            .session_store
+            .archive_all(&root_dir, &config.entity.name)
+            .await
+    };
 
     // 6. Clean up WAL and checkpoint files for archived sessions
     if let Some(ref wal) = state.wal {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -268,7 +268,7 @@ pub async fn start(config: Config) -> Result<(), Box<dyn std::error::Error>> {
 
     // Load schedule and intent queue; the coordinator gates the scheduler on
     // control-plane leadership (fail-open: chat/voice never wait on this).
-    let schedule = Schedule::load(&root_dir)?;
+    let schedule = Schedule::load_or_init(&root_dir)?;
     let schedule = Arc::new(RwLock::new(schedule));
     let intent_queue = IntentQueue::load(&root_dir);
     let intent_queue = Arc::new(RwLock::new(intent_queue));

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,6 +5,7 @@ pub mod capability;
 mod e2e_tests;
 mod handlers;
 pub mod injection;
+pub mod isolation;
 pub mod prompt;
 pub mod rate_limit;
 pub mod setup;
@@ -51,6 +52,10 @@ pub struct AppState {
     /// Tasks push alerts here; consumers (Discord plugin, API) drain them.
     pub alert_queue: tokio::sync::Mutex<crate::scheduler::alerts::AlertQueue>,
     pub provider_status: SharedProviderStatus,
+    /// True while this process's coordinator holds the control-plane lease.
+    /// Written by the coordinator, read by /health — the data plane never
+    /// depends on it.
+    pub leadership: std::sync::atomic::AtomicBool,
 }
 
 /// Rebuild AWARENESS.md from the current plugin and tool state.
@@ -261,6 +266,7 @@ pub async fn start(config: Config) -> Result<(), Box<dyn std::error::Error>> {
         wal,
         alert_queue: tokio::sync::Mutex::new(alert_queue),
         provider_status: crate::provider_status::new_shared(),
+        leadership: std::sync::atomic::AtomicBool::new(false),
     });
 
     // Startup pipeline health check

--- a/src/server/prompt.rs
+++ b/src/server/prompt.rs
@@ -1392,7 +1392,8 @@ pub fn build_autonomy_context(root_dir: &Path, _config: &Config) -> String {
         - [CALL: <reason>] — Request a call with the owner\n\
         - [SCHEDULE: {\"name\": \"...\", \"cron\": \"...\", \"prompt\": \"...\"}] — Create a recurring scheduled task\n\
         - [INTENT: {\"description\": \"...\", \"prompt\": \"...\", \"priority\": \"low|normal|high|urgent\"}] — Queue a one-shot task for later\n\
-        - [CHAIN: {\"description\": \"...\", \"prompt\": \"Based on: {result}\"}] — Queue a follow-up that receives this task's output\n\n\
+        - [CHAIN: {\"description\": \"...\", \"prompt\": \"Based on: {result}\"}] — Queue a follow-up that receives this task's output\n\
+        - [FARM: {\"id\": \"...\", \"description\": \"...\", \"subtasks\": [{\"id\": \"...\", \"prompt\": \"...\"}], \"synthesis\": \"Merge: {results}\"}] — Delegate up to 8 bounded subtasks to run concurrently (no tools); one farm per response\n\n\
         Use markers sparingly. Only share content worth surfacing. Only queue intents for genuine follow-up work."
             .to_string(),
     );

--- a/src/server/prompt.rs
+++ b/src/server/prompt.rs
@@ -1995,8 +1995,7 @@ mod tests {
 
         std::fs::write(dir.path().join("CLAUDE.md"), "# Entity").unwrap();
         let line = "t".repeat(4096);
-        let stack: String = std::iter::repeat(line.as_str())
-            .take(2560)
+        let stack: String = std::iter::repeat_n(line.as_str(), 2560)
             .collect::<Vec<_>>()
             .join("\n");
         assert!(stack.len() > 10 * 1024 * 1024);

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -69,6 +69,28 @@ pub fn register_builtin_tools(root_dir: &Path, config: &Config) -> ToolRegistry 
     tools
 }
 
+/// The read-only introspection tool set for Isolation Mode (coordinator
+/// spec, Stage 2): journal/ and memory/ are readable, nothing is writable,
+/// and nothing reaches outside the entity root. No plugin tools.
+pub fn register_readonly_tools(root_dir: &Path, config: &Config) -> ToolRegistry {
+    let mut tools = ToolRegistry::new();
+    tools.register(Box::new(crate::tools::file_read::FileReadTool::new(
+        root_dir.to_path_buf(),
+    )));
+    tools.register(Box::new(crate::tools::file_list::FileListTool::new(
+        root_dir.to_path_buf(),
+    )));
+    tools.register(Box::new(crate::tools::grep::GrepTool::new(
+        root_dir.to_path_buf(),
+    )));
+    if config.graph.enabled {
+        tools.register(Box::new(crate::tools::graph_query::GraphQueryTool::new(
+            root_dir.to_path_buf(),
+        )));
+    }
+    tools
+}
+
 /// Initialize and start plugins, collecting their tools into the registry.
 ///
 /// Returns the plugin manager and any plugin-contributed routes.

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -226,6 +226,11 @@ pub fn spawn_session_cleanup(config: &Config, state: &Arc<super::AppState>) {
             interval.tick().await; // Skip first immediate tick
             loop {
                 interval.tick().await;
+                // Shed while isolated: cleanup archives, persists, and graph-
+                // ingests — all writes (coordinator spec, Stage 2).
+                if crate::server::isolation::is_active(&cleanup_state.root_dir) {
+                    continue;
+                }
                 let archived_paths = cleanup_state
                     .session_store
                     .cleanup_expired(&cleanup_state.root_dir, &cleanup_state.config.entity.name)

--- a/src/session.rs
+++ b/src/session.rs
@@ -170,8 +170,13 @@ pub fn archive_conversation(
         entity = meta.entity_name,
     );
 
-    file.write_all(content.as_bytes())
-        .map_err(|e| format!("Failed to write conversation archive: {e}"))?;
+    if let Err(e) = file.write_all(content.as_bytes()) {
+        // Don't let a failed write permanently consume this number as an
+        // empty file.
+        drop(file);
+        let _ = fs::remove_file(&log_path);
+        return Err(format!("Failed to write conversation archive: {e}"));
+    }
     drop(file);
 
     append_index(

--- a/src/session.rs
+++ b/src/session.rs
@@ -134,7 +134,6 @@ pub fn archive_conversation(
     fs::create_dir_all(&conv_dir)
         .map_err(|e| format!("Failed to create conversations archive dir: {e}"))?;
 
-    let next_num = highest_log_number(&conv_dir) + 1;
     let now = Utc::now();
     let date_full = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
     let date_short = now.format("%Y-%m-%d").to_string();
@@ -147,6 +146,23 @@ pub fn archive_conversation(
         None => String::new(),
     };
 
+    // Claim the log number with O_EXCL: chat and scheduler paths both archive
+    // here, and a scan-then-write would let two writers pick the same number
+    // and silently overwrite one conversation with another.
+    let mut next_num = highest_log_number(&conv_dir) + 1;
+    let (mut file, log_path, next_num) = loop {
+        let candidate = conv_dir.join(format!("conversation-{next_num:03}.md"));
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(f) => break (f, candidate, next_num),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => next_num += 1,
+            Err(e) => return Err(format!("Failed to create conversation archive: {e}")),
+        }
+    };
+
     let content = format!(
         "---\nlog: {next_num}\ndate: \"{date_full}\"\ntrigger: {trigger}\nchannel: {channel}\nentity: \"{entity}\"\n{session_key_line}message_count: {message_count}\n---\n\n# Conversation {next_num:03}\n\n{conversation_md}",
         trigger = meta.trigger,
@@ -154,9 +170,9 @@ pub fn archive_conversation(
         entity = meta.entity_name,
     );
 
-    let log_path = conv_dir.join(format!("conversation-{next_num:03}.md"));
-    fs::write(&log_path, &content)
+    file.write_all(content.as_bytes())
         .map_err(|e| format!("Failed to write conversation archive: {e}"))?;
+    drop(file);
 
     append_index(
         root_dir,
@@ -805,6 +821,42 @@ mod tests {
     fn empty_conversation_produces_empty_markdown() {
         let md = conversation_to_markdown(&[]);
         assert!(md.is_empty());
+    }
+
+    /// AC14: allocation is O_EXCL-claimed, so a competing writer that already
+    /// took the next number can never be overwritten — the archiver skips
+    /// forward instead.
+    #[test]
+    fn conversation_numbering_never_overwrites_a_competing_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let conversation = vec![Message {
+            role: Role::User,
+            content: MessageContent::Text("hello".into()),
+            source: None,
+        }];
+        let meta = ArchiveMeta {
+            trigger: "test".into(),
+            channel: "chat".into(),
+            entity_name: "echo".into(),
+            session_key: None,
+        };
+
+        let first = archive_conversation(root, &conversation, &meta).unwrap();
+        assert!(first.ends_with("conversation-001.md"));
+
+        // A competing writer (scheduler path) claims 002 between our scan
+        // and our write.
+        let conv_dir = root.join("archives").join("conversations");
+        std::fs::write(conv_dir.join("conversation-002.md"), "claimed by other").unwrap();
+
+        let second = archive_conversation(root, &conversation, &meta).unwrap();
+        assert!(second.ends_with("conversation-003.md"));
+        // The competitor's file is intact.
+        assert_eq!(
+            std::fs::read_to_string(conv_dir.join("conversation-002.md")).unwrap(),
+            "claimed by other"
+        );
     }
 
     #[test]

--- a/src/session_health.rs
+++ b/src/session_health.rs
@@ -238,6 +238,7 @@ mod tests {
             wal: WalState::default(),
             health: HealthCounters::default(),
             compaction: CompactionMetrics::default(),
+            isolation_ephemeral_from: None,
         }
     }
 

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -142,6 +142,11 @@ pub struct SessionData {
     pub health: HealthCounters,
     #[serde(flatten)]
     pub compaction: CompactionMetrics,
+    /// Index of the first message added while isolated (coordinator spec,
+    /// Stage 2). Never serialized: the isolated tail is ephemeral by design —
+    /// the first normal turn truncates back to this watermark.
+    #[serde(skip)]
+    pub isolation_ephemeral_from: Option<usize>,
 }
 
 impl SessionData {
@@ -471,6 +476,7 @@ impl Session {
                 },
                 health: HealthCounters::default(),
                 compaction: CompactionMetrics::default(),
+                isolation_ephemeral_from: None,
             },
             dirty: false,
         }

--- a/src/tools/graph_query.rs
+++ b/src/tools/graph_query.rs
@@ -109,12 +109,16 @@ impl Tool for GraphQueryTool {
                     // Best-effort, no-op for non-retrieval modes (empty ids).
                     // The write goes through `spawn_blocking` so it never
                     // stalls the async runtime.
-                    crate::graph_feedback::emit_manifest(
-                        entity_root,
-                        correlation_id,
-                        retrieved_ids,
-                    )
-                    .await;
+                    // Shed while isolated: the retrieval manifest is a write
+                    // into archives/ — and the graph is a likely suspect.
+                    if !crate::server::isolation::is_active(&entity_root) {
+                        crate::graph_feedback::emit_manifest(
+                            entity_root,
+                            correlation_id,
+                            retrieved_ids,
+                        )
+                        .await;
+                    }
                     Ok(output)
                 }
                 Ok(Err(e)) => Err(ToolError::ExecutionFailed(e)),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -573,7 +573,7 @@ async fn boot_and_enter(
             config: config.clone(),
             port: booted.actual_port,
             server_handle: booted.server_handle,
-            scheduler_handles: booted.scheduler_handles,
+            coordinator: booted.coordinator,
             event_bus: booted.event_bus,
             persist_coordinator: booted.persist_coordinator,
         });

--- a/src/tui/tabs/entity.rs
+++ b/src/tui/tabs/entity.rs
@@ -174,12 +174,13 @@ impl EntityTab {
         let Some(ref root) = self.schedule_root else {
             return;
         };
-        if let Ok(mut schedule) = Schedule::load(root) {
-            if let Some(entry) = schedule.find_task_mut(&task.id) {
-                entry.task.enabled = task.enabled;
+        let enabled = task.enabled;
+        let task_id = task.id.clone();
+        let _ = Schedule::save_delta(root, |s| {
+            if let Some(entry) = s.find_task_mut(&task_id) {
+                entry.task.enabled = enabled;
             }
-            let _ = schedule.save(root);
-        }
+        });
 
         // Update summary
         if let Some(ref mut summary) = self.schedule_summary {
@@ -205,10 +206,9 @@ impl EntityTab {
         let Some(ref root) = self.schedule_root else {
             return;
         };
-        if let Ok(mut schedule) = Schedule::load(root) {
-            schedule.remove_task(&task_id);
-            let _ = schedule.save(root);
-        }
+        let _ = Schedule::save_delta(root, |s| {
+            s.remove_task(&task_id);
+        });
 
         self.schedule_tasks.retain(|t| t.id != task_id);
         if self.schedule_selected >= self.schedule_tasks.len() && self.schedule_selected > 0 {

--- a/src/vigil/analyze.rs
+++ b/src/vigil/analyze.rs
@@ -97,7 +97,7 @@ pub fn run(history: &[SignalVector], config: &Config) -> Analysis {
         match trend {
             Trend::Improving => {
                 improving += 1;
-                if best_delta.as_ref().map_or(true, |(_, bd)| delta > *bd) {
+                if best_delta.as_ref().is_none_or(|(_, bd)| delta > *bd) {
                     best_delta = Some((name.to_string(), delta));
                 }
             }


### PR DESCRIPTION
Closes #80

Umbrella PR: all four coordinator stages land here (D's call), each stage as a reviewable commit group, every increment gated red/green.

## Stage 0 — lease + fencing substrate (increments 1–5)
Lease primitive with per-resource monotonic fencing tokens, enforced at the resource (`FencedResource`). `DurableLeaseTable` makes grants durable-before-visible (write-ahead by construction); the lease WAL is versioned, exclusively locked, 0700/0600, tail-repaired at open, failure-atomic on append, and replays fail-closed through `LeaseTable::apply`. Hardened across two audit rounds (3 parallel auditors + adversarial verification; both HIGHs and the round-2 torn-tail glue race fixed, with regression tests including crash-mid-append-then-two-restarts).

## Stage 1 — fail-open faculties + reconcile (increments 6–10)
- **Coordinator** (`src/coordinator/control.rs`) owns exactly the control plane: the scheduler starts only under a held `control-plane` lease (ttl 90s, renew 30s), with tenure-scoped holder ids, stale-claim sweep at every leadership acquisition, and handles owned by the Coordinator (aborted on tenure end, shutdown, and Drop). Chat/voice are wired independently and never consult it.
- **Fail-open proven e2e**: an in-flight chat turn survives the coordinator wedging mid-turn; chat keeps serving with it dead. A second coordinator is refused at the WAL lock (`ReplayError::Locked`); clean shutdown hands over without a ttl wait. Scheduler-start failure releases the control plane instead of aborting boot (previously it took chat down with it).
- **Per-task + intent leases**: each task run claims `task-{id}` for its side-effect window; the intent drain peeks/claims/executes with the intent still durably queued and commits fenced (renew-then-remove) — crash loses nothing, stale executors can't commit, at-least-once with exactly-once removal.
- **Reconcile-on-reconnect**: shared Schedule/IntentQueue replaced with disk truth at every leadership acquisition; ALL schedule and intent writes (daemon markers, CLI, TUI, event listener) are `save_delta` — re-read disk, apply delta, atomic save, serialized in-process and cross-process. **`pulse-null schedule disable` now takes effect at the task's next fire without a restart, and marker saves can no longer clobber CLI edits** (the June thinking-loop incident class). `Schedule::load` is pure; only boot creates defaults.
- **O_EXCL conversation numbering** — chat and scheduler archives can no longer overwrite each other.
- Renewals are memory-only (safe direction: forgotten renewals mean faster reclaim with a higher token); WAL grows per grant, not per 30s renewal.

## Verification
- 738 tests (56 coordinator incl. 192-case proptest with restart + torn-append ops); clippy `-D warnings` clean; miri green over lease/fenced (manual — no CI job; module has no unsafe)
- Spec audit: Stage 0 ACs 1–9 and Stage 1 ACs 10–15, all with direct test evidence
- Three-auditor review (Stage 0) + adversarial verification + adversarial Stage 1 diff review; every HIGH fixed, deferrals documented in module docs and the plan

## Notable decisions
- MSRV 1.80 → 1.89 (`File::try_lock` / `File::lock` — single-writer enforcement and save_delta cross-process locking without new deps); fixed the two clippy lints the bump unlocked
- Base branch `main`; CONTRIBUTING corrected (`development` doesn't exist)
- Deferred by design (documented): WAL snapshot+truncate compaction and lease-actor/group-commit (Stage 3, when farming multiplies traffic); guard persistence + token cross-check (Stage 2/3 wiring); leadership state in /health (Stage 2 banner)

## Remaining stages
- [x] Stage 2 — isolation mode: sticky ISOLATION marker owned by the data plane (src/server/isolation.rs); /isolate + /resume (owner-only) and pulse-null isolate CLI, both proven with the coordinator wedged; sticky banner + explicit back-to-normal; full write-shed — coordinator parks and releases the lease, chat writes gated with the isolated conversation truly ephemeral (watermark + truncate), claude-code subprocess spawned with --disallowedTools, read-only introspection tools only, per-loop marker backstops independent of the coordinator; /health reports isolation + observed leadership. Hardened per adversarial review (1 CRITICAL + 4 HIGH closed; TUI surface documented as deferred).
- [ ] Stage 3 — subtask farming

Deploy note: after merge, `/update-pulse` will put the coordinator in front of Echo's scheduler; behavior change is scheduler-side only (leadership gate + live disable), chat path untouched.