### PR TITLE
feat(PN-88): refusal fallback with context quarantine (fable→opus-5)

### DIFF
--- a/src/claude_code_provider.rs
+++ b/src/claude_code_provider.rs
@@ -627,7 +627,10 @@ mod tests {
     #[test]
     fn classify_is_case_insensitive_on_policy_text() {
         let json = r#"{"is_error":true,"result":"violates our usage policy"}"#;
-        matches!(classify_nonzero_exit(json), RefusalCheck::Refusal(_));
+        assert!(matches!(
+            classify_nonzero_exit(json),
+            RefusalCheck::Refusal(_)
+        ));
     }
 
     #[test]

--- a/src/claude_code_provider.rs
+++ b/src/claude_code_provider.rs
@@ -38,7 +38,7 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 /// What a CLI without the flag prints when it parses `--system-prompt-file`.
 const UNKNOWN_OPTION_MARKER: &str = "unknown option";
 
-use crate::errors::ClaudeCliError;
+use crate::errors::{ClaudeCliError, RefusalError};
 use crate::session::strip_system_prefixes;
 use crate::streaming::{self, StreamResult, StreamingProvider};
 
@@ -330,6 +330,27 @@ impl LmProvider for ClaudeCodeProvider {
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 let stdout = String::from_utf8_lossy(&output.stdout);
 
+                // An AUP refusal is a distinct, recoverable signal: the chat
+                // handler falls back to another model on it. Everything else
+                // (network, timeout, empty) stays a generic error.
+                match classify_nonzero_exit(&stdout) {
+                    RefusalCheck::Refusal(detail) => {
+                        return Err(Box::new(RefusalError {
+                            model: model.clone(),
+                            detail: truncate(&detail, 500).to_string(),
+                        })
+                            as Box<dyn std::error::Error + Send + Sync>);
+                    }
+                    RefusalCheck::ErrorFlagButNoPolicyMatch => {
+                        warn!(
+                            model = %model,
+                            "claude -p exited non-zero with is_error=true but did not match \
+                             the AUP Usage-Policy signature — refusal detection may have drifted"
+                        );
+                    }
+                    RefusalCheck::NotRefusal => {}
+                }
+
                 // Build the most informative error message possible.
                 // claude -p often puts errors in stdout (JSON) rather than stderr.
                 let detail = if !stderr.trim().is_empty() {
@@ -444,6 +465,38 @@ fn serialize_messages(messages: &[Message]) -> String {
 }
 
 /// Parse the JSON response from `claude -p --output-format json`.
+/// Classification of a non-zero `claude -p` exit body.
+#[derive(Debug, PartialEq, Eq)]
+enum RefusalCheck {
+    /// An AUP Usage-Policy refusal; carries the refusal detail body.
+    Refusal(String),
+    /// The body reported `is_error == true` but did not match the AUP
+    /// signature — logged at WARN so a future signature drift is visible.
+    ErrorFlagButNoPolicyMatch,
+    /// Not a structured refusal (non-JSON, `is_error` absent/false, etc.).
+    NotRefusal,
+}
+
+/// Classify a non-zero-exit stdout body as an AUP refusal or a plain error.
+///
+/// A refusal is valid JSON with `is_error == true` **and** a `result` body
+/// containing the Usage-Policy signature. Anything else (non-JSON stderr,
+/// `is_error` absent/false) is a generic error and must not trigger fallback.
+fn classify_nonzero_exit(stdout: &str) -> RefusalCheck {
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(stdout.trim()) else {
+        return RefusalCheck::NotRefusal;
+    };
+    if parsed["is_error"].as_bool() != Some(true) {
+        return RefusalCheck::NotRefusal;
+    }
+    let result = parsed["result"].as_str().unwrap_or("");
+    if result.to_lowercase().contains("usage policy") {
+        RefusalCheck::Refusal(result.to_string())
+    } else {
+        RefusalCheck::ErrorFlagButNoPolicyMatch
+    }
+}
+
 fn parse_response(
     stdout: &str,
     model: &str,
@@ -525,6 +578,67 @@ mod tests {
     fn parse_empty_result_is_error() {
         let json = r#"{"result": "", "session_id": "abc"}"#;
         assert!(parse_response(json, "opus").is_err());
+    }
+
+    // The real refusal body captured from prod on 2026-08-09.
+    const REAL_REFUSAL_JSON: &str = r#"{"type":"result","subtype":"success","is_error":true,"duration_ms":3047,"num_turns":1,"result":"API Error: Claude Code is unable to respond to this request, which appears to violate our Usage Policy (https://www.anthropic.com/legal/aup). Try rephrasing...","stop_reason":"stop_sequence","session_id":"abc-123"}"#;
+
+    #[test]
+    fn classify_detects_real_aup_refusal() {
+        match classify_nonzero_exit(REAL_REFUSAL_JSON) {
+            RefusalCheck::Refusal(detail) => {
+                assert!(detail.contains("Usage Policy"));
+            }
+            other => panic!("expected Refusal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_ignores_plain_json_error() {
+        // is_error present but false — a normal non-refusal failure.
+        let json = r#"{"is_error":false,"result":"some transient failure"}"#;
+        assert_eq!(classify_nonzero_exit(json), RefusalCheck::NotRefusal);
+    }
+
+    #[test]
+    fn classify_ignores_missing_is_error() {
+        let json = r#"{"result":"boom"}"#;
+        assert_eq!(classify_nonzero_exit(json), RefusalCheck::NotRefusal);
+    }
+
+    #[test]
+    fn classify_ignores_non_json() {
+        assert_eq!(
+            classify_nonzero_exit("error: connection reset by peer"),
+            RefusalCheck::NotRefusal
+        );
+    }
+
+    #[test]
+    fn classify_flags_error_without_policy_text_for_drift() {
+        // is_error true but no Usage-Policy signature: drift-catch branch.
+        let json = r#"{"is_error":true,"result":"API Error: overloaded"}"#;
+        assert_eq!(
+            classify_nonzero_exit(json),
+            RefusalCheck::ErrorFlagButNoPolicyMatch
+        );
+    }
+
+    #[test]
+    fn classify_is_case_insensitive_on_policy_text() {
+        let json = r#"{"is_error":true,"result":"violates our usage policy"}"#;
+        matches!(classify_nonzero_exit(json), RefusalCheck::Refusal(_));
+    }
+
+    #[test]
+    fn refusal_error_displays_model_and_detail() {
+        let err = RefusalError {
+            model: "claude-fable-5".to_string(),
+            detail: "violates our Usage Policy".to_string(),
+        };
+        let s = err.to_string();
+        assert!(s.contains("claude-fable-5"));
+        assert!(s.contains("Usage Policy"));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -85,6 +85,33 @@ pub struct LlmConfig {
     /// Maximum estimated tokens in conversation before compaction triggers (0 = default 150k).
     #[serde(default)]
     pub context_budget: usize,
+    /// Model to fall back to when the default `model` refuses a turn on an
+    /// Anthropic Usage-Policy (AUP) refusal. Empty/absent disables the
+    /// fallback. Typically `"claude-opus-5"` — matches the scheduled-task pins.
+    #[serde(default)]
+    pub fallback_model: Option<String>,
+    /// Master switch for the reactive refusal fallback (default true). When
+    /// false, a refusal returns the normal error path (with turn rollback).
+    #[serde(default = "default_fallback_on_refusal")]
+    pub fallback_on_refusal: bool,
+}
+
+impl LlmConfig {
+    /// The model to retry a refused turn on, or `None` when the fallback is
+    /// disabled or unconfigured.
+    ///
+    /// Returns `Some(model)` only when `fallback_on_refusal` is true **and**
+    /// `fallback_model` is a non-empty, non-whitespace string.
+    #[must_use]
+    pub fn fallback_target(&self) -> Option<&str> {
+        if !self.fallback_on_refusal {
+            return None;
+        }
+        self.fallback_model
+            .as_deref()
+            .map(str::trim)
+            .filter(|m| !m.is_empty())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -334,6 +361,10 @@ fn default_max_tokens() -> u32 {
 }
 
 fn default_true() -> bool {
+    true
+}
+
+fn default_fallback_on_refusal() -> bool {
     true
 }
 
@@ -966,6 +997,8 @@ pub mod test_support {
                 base_url: None,
                 claude_bin: None,
                 context_budget: 0,
+                fallback_model: None,
+                fallback_on_refusal: true,
             },
             security: SecurityConfig {
                 secret: None,
@@ -989,5 +1022,74 @@ pub mod test_support {
             peers: HashMap::new(),
             plugins: HashMap::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod fallback_tests {
+    use super::*;
+
+    fn llm(model: Option<&str>, on: bool) -> LlmConfig {
+        LlmConfig {
+            provider: default_provider(),
+            api_key: None,
+            model: default_model(),
+            max_tokens: default_max_tokens(),
+            base_url: None,
+            claude_bin: None,
+            context_budget: 0,
+            fallback_model: model.map(str::to_string),
+            fallback_on_refusal: on,
+        }
+    }
+
+    #[test]
+    fn enabled_with_model_returns_target() {
+        assert_eq!(
+            llm(Some("claude-opus-5"), true).fallback_target(),
+            Some("claude-opus-5")
+        );
+    }
+
+    #[test]
+    fn disabled_returns_none_even_with_model() {
+        assert_eq!(llm(Some("claude-opus-5"), false).fallback_target(), None);
+    }
+
+    #[test]
+    fn enabled_without_model_returns_none() {
+        assert_eq!(llm(None, true).fallback_target(), None);
+    }
+
+    #[test]
+    fn enabled_with_empty_model_returns_none() {
+        assert_eq!(llm(Some(""), true).fallback_target(), None);
+    }
+
+    #[test]
+    fn enabled_with_whitespace_model_returns_none() {
+        assert_eq!(llm(Some("   "), true).fallback_target(), None);
+    }
+
+    #[test]
+    fn target_is_trimmed() {
+        assert_eq!(
+            llm(Some("  claude-opus-5  "), true).fallback_target(),
+            Some("claude-opus-5")
+        );
+    }
+
+    #[test]
+    fn serde_defaults_disable_fallback_when_absent() {
+        // A [llm] block without the new fields: fallback_on_refusal defaults
+        // true but no model ⇒ fallback disabled.
+        let toml = r#"
+            provider = "claude-code"
+            model = "claude-fable-5"
+        "#;
+        let cfg: LlmConfig = toml::from_str(toml).unwrap();
+        assert!(cfg.fallback_on_refusal);
+        assert_eq!(cfg.fallback_model, None);
+        assert_eq!(cfg.fallback_target(), None);
     }
 }

--- a/src/context/compact.rs
+++ b/src/context/compact.rs
@@ -927,6 +927,7 @@ mod tests {
             health: crate::session_store::HealthCounters::default(),
             compaction: crate::session_store::CompactionMetrics::default(),
             isolation_ephemeral_from: None,
+            quarantine: Vec::new(),
         }
     }
 

--- a/src/context/compact.rs
+++ b/src/context/compact.rs
@@ -927,6 +927,7 @@ mod tests {
             health: crate::session_store::HealthCounters::default(),
             compaction: crate::session_store::CompactionMetrics::default(),
             isolation_ephemeral_from: None,
+            isolation_quarantine_from: None,
             quarantine: Vec::new(),
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -149,6 +149,22 @@ pub struct RefusalError {
     pub detail: String,
 }
 
+/// The reactive refusal fallback itself failed — either the fallback provider
+/// could not be built or its invocation errored (PN-88, SEC-007).
+///
+/// Its [`Display`](std::fmt::Display) is deliberately generic ("upstream model
+/// error") so provider internals — binary paths, model names, subprocess
+/// diagnostics — never reach the HTTP client on this path. The underlying
+/// `detail` is carried for server-side logging at ERROR only. Kept distinct from
+/// [`RefusalError`], whose Display is Anthropic's canned, non-sensitive AUP text.
+#[derive(Debug, Error)]
+#[error("upstream model error")]
+pub struct FallbackFailedError {
+    /// The underlying failure detail — logged server-side, never returned to the
+    /// client.
+    pub detail: String,
+}
+
 /// Top-level error type for CLI and binary boundaries.
 #[derive(Debug, Error)]
 pub enum PulseError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -132,6 +132,23 @@ pub enum ClaudeCliError {
     },
 }
 
+/// An Anthropic Usage-Policy (AUP) refusal from the underlying model.
+///
+/// Emitted by the claude-code provider when `claude -p` exits non-zero with an
+/// `is_error: true` result body matching the Usage-Policy signature. It is boxed
+/// into the provider's `Box<dyn Error + Send + Sync>` error channel and
+/// downcast by the chat handler to decide whether to fall back to another model.
+/// It is deliberately distinct from generic provider failures (network,
+/// timeout, empty result), which must never trigger a fallback.
+#[derive(Debug, Error)]
+#[error("model '{model}' refused the turn (Usage Policy): {detail}")]
+pub struct RefusalError {
+    /// The model that issued the refusal (e.g. `claude-fable-5`).
+    pub model: String,
+    /// The refusal body reported by the CLI, truncated for logging.
+    pub detail: String,
+}
+
 /// Top-level error type for CLI and binary boundaries.
 #[derive(Debug, Error)]
 pub enum PulseError {

--- a/src/plugins/manager.rs
+++ b/src/plugins/manager.rs
@@ -337,6 +337,8 @@ mod tests {
                 base_url: None,
                 claude_bin: None,
                 context_budget: 0,
+                fallback_model: None,
+                fallback_on_refusal: true,
             },
             security: SecurityConfig {
                 secret: None,

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -122,6 +122,8 @@ mod tests {
             base_url: None,
             claude_bin: Some("/usr/bin/claude".into()),
             context_budget: 4096,
+            fallback_model: None,
+            fallback_on_refusal: true,
         };
         config
     }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -125,6 +125,8 @@ mod tests {
                 base_url: None,
                 claude_bin: None,
                 context_budget: 0,
+                fallback_model: None,
+                fallback_on_refusal: true,
             },
             security: SecurityConfig {
                 secret,
@@ -297,6 +299,8 @@ mod tests {
                 base_url: None,
                 claude_bin: None,
                 context_budget: 0,
+                fallback_model: None,
+                fallback_on_refusal: true,
             },
             security: SecurityConfig {
                 secret: global_secret,

--- a/src/server/e2e_tests.rs
+++ b/src/server/e2e_tests.rs
@@ -112,9 +112,7 @@ impl LmProvider for FailingProvider {
         _max_tokens: u32,
         _tools: Option<&[serde_json::Value]>,
     ) -> LlmResult<'_> {
-        Box::pin(async {
-            Err("network drop while calling the model".into())
-        })
+        Box::pin(async { Err("network drop while calling the model".into()) })
     }
 
     fn name(&self) -> &str {
@@ -984,7 +982,11 @@ async fn e2e_isolation_parks_coordinator_and_resumes() {
 
 /// The trunk length of the "chat"/anonymous session (0 when absent).
 async fn trunk_len(state: &Arc<AppState>) -> usize {
-    match state.session_store.get_existing_by_key("guest:anonymous").await {
+    match state
+        .session_store
+        .get_existing_by_key("guest:anonymous")
+        .await
+    {
         Some(arc) => arc.read().await.data.messages.len(),
         None => 0,
     }
@@ -1016,7 +1018,11 @@ async fn e2e_generic_error_rolls_back_user_turn() {
     // A second failed turn must also not accumulate anything.
     let (status, _body) = post_chat(&app, "still there?").await;
     assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-    assert_eq!(trunk_len(&state).await, 0, "second failed turn poisoned the session");
+    assert_eq!(
+        trunk_len(&state).await,
+        0,
+        "second failed turn poisoned the session"
+    );
 }
 
 /// AC5: an AUP refusal with the fallback disabled (no `fallback_model`) takes

--- a/src/server/e2e_tests.rs
+++ b/src/server/e2e_tests.rs
@@ -121,6 +121,8 @@ fn test_config() -> Config {
             base_url: None,
             claude_bin: None,
             context_budget: 0,
+            fallback_model: None,
+            fallback_on_refusal: true,
         },
         security: SecurityConfig {
             secret: None,

--- a/src/server/e2e_tests.rs
+++ b/src/server/e2e_tests.rs
@@ -100,6 +100,60 @@ impl LmProvider for MockProvider {
     }
 }
 
+/// A provider that always fails with a generic (non-refusal) error — models a
+/// network drop / timeout / empty result. Must trigger rollback, never fallback.
+struct FailingProvider;
+
+impl LmProvider for FailingProvider {
+    fn invoke(
+        &self,
+        _system_prompt: &str,
+        _messages: &[Message],
+        _max_tokens: u32,
+        _tools: Option<&[serde_json::Value]>,
+    ) -> LlmResult<'_> {
+        Box::pin(async {
+            Err("network drop while calling the model".into())
+        })
+    }
+
+    fn name(&self) -> &str {
+        "failing"
+    }
+
+    fn supports_tools(&self) -> bool {
+        false
+    }
+}
+
+/// A provider that always issues an AUP refusal (the fable classifier firing).
+struct RefusingProvider;
+
+impl LmProvider for RefusingProvider {
+    fn invoke(
+        &self,
+        _system_prompt: &str,
+        _messages: &[Message],
+        _max_tokens: u32,
+        _tools: Option<&[serde_json::Value]>,
+    ) -> LlmResult<'_> {
+        Box::pin(async {
+            Err(Box::new(crate::errors::RefusalError {
+                model: "mock-fable".to_string(),
+                detail: "appears to violate our Usage Policy".to_string(),
+            }) as Box<dyn std::error::Error + Send + Sync>)
+        })
+    }
+
+    fn name(&self) -> &str {
+        "refusing"
+    }
+
+    fn supports_tools(&self) -> bool {
+        false
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -168,7 +222,17 @@ async fn build_state_in(
     provider: MockProvider,
     tools: ToolRegistry,
 ) -> Arc<AppState> {
-    let config = test_config();
+    build_state_boxed_with_config(root_dir, Box::new(provider), tools, test_config()).await
+}
+
+/// Build an `AppState` around an arbitrary boxed provider and config — used by
+/// the rollback / refusal tests that need a provider which returns an error.
+async fn build_state_boxed_with_config(
+    root_dir: std::path::PathBuf,
+    provider: Box<dyn LmProvider>,
+    tools: ToolRegistry,
+    config: Config,
+) -> Arc<AppState> {
     let wal =
         crate::wal::WalWriter::new(&root_dir.join("sessions"), crate::wal::WalFsync::None).ok();
     let session_store =
@@ -178,7 +242,7 @@ async fn build_state_in(
     let alert_queue = crate::scheduler::alerts::AlertQueue::load(&root_dir);
     Arc::new(AppState {
         config,
-        provider: Box::new(provider),
+        provider,
         session_store,
         system_prompt: RwLock::new("You are a test entity.".to_string()),
         tools,
@@ -912,4 +976,69 @@ async fn e2e_isolation_parks_coordinator_and_resumes() {
     assert!(resumed, "coordinator did not resume leadership after exit");
 
     coordinator.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// Refusal fallback / turn rollback (PN-88): AC5, AC7
+// ---------------------------------------------------------------------------
+
+/// The trunk length of the "chat"/anonymous session (0 when absent).
+async fn trunk_len(state: &Arc<AppState>) -> usize {
+    match state.session_store.get_existing_by_key("guest:anonymous").await {
+        Some(arc) => arc.read().await.data.messages.len(),
+        None => 0,
+    }
+}
+
+/// AC7: a non-refusal provider error rolls the user turn back — the session is
+/// left exactly as pre-turn (regression test for the 2026-08-09 poisoning bug,
+/// where a failed turn left a half-appended user message behind).
+#[tokio::test]
+async fn e2e_generic_error_rolls_back_user_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = build_state_boxed_with_config(
+        dir.path().to_path_buf(),
+        Box::new(FailingProvider),
+        ToolRegistry::new(),
+        test_config(),
+    )
+    .await;
+    let app = build_app(Arc::clone(&state));
+
+    let (status, _body) = post_chat(&app, "hello").await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        trunk_len(&state).await,
+        0,
+        "failed turn left the user message in the trunk (session poisoned)"
+    );
+
+    // A second failed turn must also not accumulate anything.
+    let (status, _body) = post_chat(&app, "still there?").await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(trunk_len(&state).await, 0, "second failed turn poisoned the session");
+}
+
+/// AC5: an AUP refusal with the fallback disabled (no `fallback_model`) takes
+/// the error path with the user turn rolled back — no opus call, no poison.
+#[tokio::test]
+async fn e2e_refusal_without_fallback_rolls_back() {
+    let dir = tempfile::tempdir().unwrap();
+    // Default test_config has fallback_model = None ⇒ fallback disabled.
+    let state = build_state_boxed_with_config(
+        dir.path().to_path_buf(),
+        Box::new(RefusingProvider),
+        ToolRegistry::new(),
+        test_config(),
+    )
+    .await;
+    let app = build_app(Arc::clone(&state));
+
+    let (status, _body) = post_chat(&app, "tell me something spicy").await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        trunk_len(&state).await,
+        0,
+        "refused turn (fallback disabled) poisoned the session"
+    );
 }

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -44,6 +44,11 @@ fn default_channel() -> String {
 /// Maximum number of tool-use round trips before we force a text response.
 const MAX_TOOL_ROUNDS: u32 = 25;
 
+/// Maximum number of refusal-fallback invocations per session (SEC-002).
+/// Once reached, further refusals take the ordinary rollback + error path
+/// rather than spawning more expensive opus tool-loops. Reset on session reset.
+const MAX_FALLBACKS_PER_SESSION: u32 = 25;
+
 const MAX_MESSAGE_LEN: usize = 100_000;
 const MAX_CHANNEL_LEN: usize = 64;
 const MAX_SENDER_LEN: usize = 64;
@@ -435,12 +440,14 @@ pub async fn chat(
     // `resolve_sender` maps the owner's configured phone/discord-id/name and the
     // tui/system/reflection channels to "owner", so D's voice calls still get
     // the fallback while guests and peers never do. `gated_fallback` enforces
-    // the owner gate (and the isolation shed) and drops the builder unbuilt for
-    // everyone else.
+    // the owner gate, the isolation shed, and the per-session invocation cap
+    // (SEC-002), dropping the builder unbuilt otherwise.
+    let fallback_capped =
+        session.data.health.fallback_count_this_session >= MAX_FALLBACKS_PER_SESSION;
     let config_for_fallback = &state.config;
     let build_fallback = state.config.llm.fallback_target().and_then(|model| {
         let model = model.to_string();
-        gated_fallback(&resolved_key, isolated, move || {
+        gated_fallback(&resolved_key, isolated, !fallback_capped, move || {
             crate::providers::create_provider_with_model(config_for_fallback, &model)
         })
     });
@@ -471,6 +478,16 @@ pub async fn chat(
         } else {
             tracing::error!("LLM turn failed: {}", e);
         }
+        // SEC-002: a refusal that was denied the fallback because the session
+        // hit the invocation cap took this error path deliberately — surface it
+        // so the cap is visible in the logs.
+        if fallback_capped && e.downcast_ref::<crate::errors::RefusalError>().is_some() {
+            tracing::warn!(
+                session_key = %session_key,
+                cap = MAX_FALLBACKS_PER_SESSION,
+                "refusal fallback cap reached — refusal took the error path without invoking the fallback model"
+            );
+        }
         // Keep the banner sticky even on the failure path — while isolated
         // the provider is precisely the suspect.
         let msg = if crate::server::isolation::is_active(&state.root_dir) {
@@ -498,6 +515,11 @@ pub async fn chat(
     session.data.message_count += 1;
     if !isolated {
         session.data.wal.messages_since_checkpoint += 1;
+    }
+    // SEC-002: count a fallback invocation once it actually committed to
+    // quarantine, so the per-session cap bounds real opus tool-loops.
+    if committed_to_quarantine {
+        session.data.health.fallback_count_this_session += 1;
     }
 
     // Track recently accessed files from tool use (for post-compaction re-injection).
@@ -793,16 +815,21 @@ impl std::fmt::Debug for TurnResult {
     }
 }
 
-/// Owner-only, non-isolated gate for the reactive refusal fallback (SEC-001).
+/// Gate for the reactive refusal fallback (SEC-001, SEC-002).
 ///
-/// Returns `Some(build)` — arming the fallback — only for the owner and only
-/// when not isolated; otherwise the builder is dropped unbuilt and a refusal
-/// takes the ordinary rollback + error path. The fallback re-runs a refused turn
-/// on the more permissive opus model, so letting a guest or peer trigger it
-/// would make fable-5's AUP classifier bypassable by any untrusted caller who
-/// can reach `/chat`. This is the intended default, not a config knob.
-fn gated_fallback<F>(resolved_key: &str, isolated: bool, build: F) -> Option<F> {
-    (!isolated && resolved_key == "owner").then_some(build)
+/// Returns `Some(build)` — arming the fallback — only when ALL of:
+/// - the caller is the owner (SEC-001): the fallback re-runs a refused turn on
+///   the more permissive opus model, so letting a guest or peer trigger it would
+///   make fable-5's AUP classifier bypassable by any untrusted caller who can
+///   reach `/chat`. Owner-only is the intended default, not a config knob.
+/// - we are not isolated: while isolated the provider is itself the suspect.
+/// - the session is under the per-session invocation cap (SEC-002): bounds
+///   runaway or repeated refusals from driving unbounded opus tool-loops.
+///
+/// Otherwise the builder is dropped unbuilt and a refusal takes the ordinary
+/// rollback + error path.
+fn gated_fallback<F>(resolved_key: &str, isolated: bool, under_cap: bool, build: F) -> Option<F> {
+    (!isolated && resolved_key == "owner" && under_cap).then_some(build)
 }
 
 /// Run one interactive turn with reactive refusal fallback (PN-88).
@@ -1499,30 +1526,60 @@ mod tests {
         assert!(data.quarantine.is_empty());
     }
 
-    /// SEC-001: the fallback gate is owner-only, and shed while isolated.
+    /// A convenience builder for gate tests — an owner+under_cap combination
+    /// should arm, everything else should not.
+    fn dummy_build() -> Result<Box<dyn LmProvider>, ProviderError> {
+        Ok(Box::new(FailingMock) as Box<dyn LmProvider>)
+    }
+
+    /// SEC-001 + SEC-002: the fallback gate is owner-only, shed while isolated,
+    /// and shed once the per-session cap is hit.
     #[test]
-    fn fallback_gate_is_owner_only() {
-        // Owner, not isolated → armed.
-        assert!(gated_fallback("owner", false, || Ok(Box::new(FailingMock) as Box<dyn LmProvider>))
-            .is_some());
+    fn fallback_gate_is_owner_only_and_capped() {
+        // Owner, not isolated, under cap → armed.
+        assert!(gated_fallback("owner", false, true, dummy_build).is_some());
         // Guests and peers never arm the fallback.
-        assert!(
-            gated_fallback("guest:stranger", false, || Ok(
-                Box::new(FailingMock) as Box<dyn LmProvider>
-            ))
-            .is_none()
-        );
-        assert!(
-            gated_fallback("peer:Nova", false, || Ok(
-                Box::new(FailingMock) as Box<dyn LmProvider>
-            ))
-            .is_none()
-        );
+        assert!(gated_fallback("guest:stranger", false, true, dummy_build).is_none());
+        assert!(gated_fallback("peer:Nova", false, true, dummy_build).is_none());
         // Even the owner is shed while isolated (the provider is the suspect).
+        assert!(gated_fallback("owner", true, true, dummy_build).is_none());
+        // SEC-002: even the owner is shed once over the cap.
+        assert!(gated_fallback("owner", false, false, dummy_build).is_none());
+    }
+
+    /// SEC-002: the (N+1)th refusal in a session does not build the fallback —
+    /// the over-cap gate drops the builder even for the owner.
+    #[tokio::test]
+    async fn capped_owner_refusal_does_not_build_fallback() {
+        let mut data = session_with(&["earlier turn"], "spicy question");
+        let trunk_before = data.messages.len();
+        let tools = ToolRegistry::new();
+        let called = Arc::new(AtomicBool::new(false));
+        let called_in_build = Arc::clone(&called);
+
+        let build = move || {
+            called_in_build.store(true, Ordering::SeqCst);
+            Ok(Box::new(RecordingProvider {
+                reply: "should not happen".to_string(),
+                seen: Arc::new(Mutex::new(Vec::new())),
+            }) as Box<dyn LmProvider>)
+        };
+        // Owner, not isolated, but OVER the cap (under_cap = false).
+        let gated = gated_fallback("owner", false, false, build);
+
+        let err = invoke_turn_with_refusal_fallback(
+            &mut data, &RefusingMock, gated, &tools, "sys", 1024, "corr",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.downcast_ref::<RefusalError>().is_some());
         assert!(
-            gated_fallback("owner", true, || Ok(Box::new(FailingMock) as Box<dyn LmProvider>))
-                .is_none()
+            !called.load(Ordering::SeqCst),
+            "fallback built for an over-cap owner refusal"
         );
+        assert_eq!(data.messages.len(), trunk_before - 1);
+        assert!(data.quarantine.is_empty());
     }
 
     /// SEC-001: a guest refusal never builds the fallback provider and rolls the
@@ -1544,7 +1601,7 @@ mod tests {
             }) as Box<dyn LmProvider>)
         };
         // The owner-only gate drops the builder for a guest.
-        let gated = gated_fallback("guest:stranger", false, build);
+        let gated = gated_fallback("guest:stranger", false, true, build);
 
         let err = invoke_turn_with_refusal_fallback(
             &mut data, &RefusingMock, gated, &tools, "sys", 1024, "corr",
@@ -1577,7 +1634,7 @@ mod tests {
                 seen: Arc::new(Mutex::new(Vec::new())),
             }) as Box<dyn LmProvider>)
         };
-        let gated = gated_fallback("peer:Nova", false, build);
+        let gated = gated_fallback("peer:Nova", false, true, build);
 
         let err = invoke_turn_with_refusal_fallback(
             &mut data, &RefusingMock, gated, &tools, "sys", 1024, "corr",

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -224,14 +224,27 @@ pub async fn chat(
         if session.data.isolation_ephemeral_from.is_none() {
             session.data.isolation_ephemeral_from = Some(session.data.messages.len());
         }
-    } else if let Some(watermark) = session.data.isolation_ephemeral_from.take() {
-        let dropped = session.data.messages.len().saturating_sub(watermark);
-        session.data.messages.truncate(watermark);
-        session.data.compaction.estimated_tokens =
-            crate::context::estimate_conversation_tokens(&session.data.messages);
-        tracing::info!(
-            "[chat] dropped {dropped} ephemeral isolation message(s) on return to normal"
-        );
+        // SEC-004: track the quarantine lane the same way, so a fallback tangent
+        // created during this isolation window is shed on return to normal.
+        if session.data.isolation_quarantine_from.is_none() {
+            session.data.isolation_quarantine_from = Some(session.data.quarantine.len());
+        }
+    } else {
+        if let Some(watermark) = session.data.isolation_ephemeral_from.take() {
+            let dropped = session.data.messages.len().saturating_sub(watermark);
+            session.data.messages.truncate(watermark);
+            session.data.compaction.estimated_tokens =
+                crate::context::estimate_conversation_tokens(&session.data.messages);
+            tracing::info!(
+                "[chat] dropped {dropped} ephemeral isolation message(s) on return to normal"
+            );
+        }
+        let dropped_q = shed_isolation_quarantine(&mut session.data);
+        if dropped_q > 0 {
+            tracing::info!(
+                "[chat] dropped {dropped_q} ephemeral isolation quarantine entry(ies) on return to normal"
+            );
+        }
     }
 
     // === Session limit check ===
@@ -239,6 +252,7 @@ pub async fn chat(
     // time cap, or hallucination threshold). If so, archive the current conversation
     // with a structured handoff and start fresh before processing this message.
     let pre_turn_len = session.data.messages.len();
+    let pre_turn_quarantine_len = session.data.quarantine.len();
     let limits = state.config.sessions.get_identity_limits(&resolved_key);
     // Session resets archive to disk — shed in isolation (the in-memory
     // session simply keeps growing for the duration of the diagnosis).
@@ -504,8 +518,25 @@ pub async fn chat(
     // Re-sample: a turn admitted just before the marker appeared must not
     // write after it. OR of the two samples drives every gate below.
     let isolated = isolated || crate::server::isolation::is_active(&state.root_dir);
-    if isolated && session.data.isolation_ephemeral_from.is_none() {
-        session.data.isolation_ephemeral_from = Some(pre_turn_len);
+    if isolated {
+        if session.data.isolation_ephemeral_from.is_none() {
+            session.data.isolation_ephemeral_from = Some(pre_turn_len);
+        }
+        // SEC-004: a turn that flipped to isolated mid-flight must not commit its
+        // fallback tangent to the quarantine lane. Anchor the watermark at this
+        // turn's pre-turn quarantine length (if not already anchored earlier in
+        // the isolation window) and drop anything the fallback just pushed —
+        // don't wait for the next normal turn to shed it.
+        if session.data.isolation_quarantine_from.is_none() {
+            session.data.isolation_quarantine_from = Some(pre_turn_quarantine_len);
+        }
+        if committed_to_quarantine {
+            let from = session
+                .data
+                .isolation_quarantine_from
+                .unwrap_or(pre_turn_quarantine_len);
+            session.data.quarantine.truncate(from);
+        }
     }
 
     let text = result.text.clone();
@@ -832,6 +863,21 @@ fn gated_fallback<F>(resolved_key: &str, isolated: bool, under_cap: bool, build:
     (!isolated && resolved_key == "owner" && under_cap).then_some(build)
 }
 
+/// Shed the quarantine entries added during an isolation window, truncating the
+/// lane back to its entry-time watermark and clearing the watermark (SEC-004).
+/// Mirrors the message-lane ephemeral shed. Returns the number of entries
+/// dropped (0 when no isolation window was open).
+fn shed_isolation_quarantine(data: &mut crate::session_store::SessionData) -> usize {
+    match data.isolation_quarantine_from.take() {
+        Some(watermark) => {
+            let dropped = data.quarantine.len().saturating_sub(watermark);
+            data.quarantine.truncate(watermark);
+            dropped
+        }
+        None => 0,
+    }
+}
+
 /// Run one interactive turn with reactive refusal fallback (PN-88).
 ///
 /// The default (fable) model runs first, appending to the trunk (`data.messages`).
@@ -865,11 +911,7 @@ where
     // integer underflow panic / out-of-bounds index (SEC-005).
     let user_index = match data.messages.len().checked_sub(1) {
         Some(index) => index,
-        None => {
-            return Err(
-                "invoke_turn_with_refusal_fallback called with an empty trunk".into(),
-            )
-        }
+        None => return Err("invoke_turn_with_refusal_fallback called with an empty trunk".into()),
     };
 
     let default_outcome = crate::task_context::scope(
@@ -1526,6 +1568,38 @@ mod tests {
         assert!(data.quarantine.is_empty());
     }
 
+    /// SEC-004: the quarantine-lane shed drops exactly the entries added during
+    /// an isolation window (back to the entry-time watermark) and clears the
+    /// watermark, leaving anything present before isolation intact.
+    #[test]
+    fn shed_isolation_quarantine_drops_only_in_window_entries() {
+        let mut data = session_with(&[], "current turn");
+        // A quarantine tangent that predates the isolation window.
+        data.quarantine.push(user("pre-isolation q"));
+        // Isolation begins here.
+        data.isolation_quarantine_from = Some(data.quarantine.len());
+        // Two entries pushed while isolated (e.g. a mid-flight fallback commit).
+        data.quarantine.push(user("in-isolation spicy"));
+        data.quarantine.push(user("in-isolation opus reply"));
+
+        let dropped = shed_isolation_quarantine(&mut data);
+
+        assert_eq!(dropped, 2);
+        assert_eq!(data.quarantine.len(), 1);
+        assert!(
+            data.isolation_quarantine_from.is_none(),
+            "watermark not cleared after shedding"
+        );
+        match &data.quarantine[0].content {
+            MessageContent::Text(t) => assert_eq!(t, "pre-isolation q"),
+            _ => panic!("unexpected content"),
+        }
+
+        // A second shed with no open window is a no-op.
+        assert_eq!(shed_isolation_quarantine(&mut data), 0);
+        assert_eq!(data.quarantine.len(), 1);
+    }
+
     /// A convenience builder for gate tests — an owner+under_cap combination
     /// should arm, everything else should not.
     fn dummy_build() -> Result<Box<dyn LmProvider>, ProviderError> {
@@ -1568,7 +1642,13 @@ mod tests {
         let gated = gated_fallback("owner", false, false, build);
 
         let err = invoke_turn_with_refusal_fallback(
-            &mut data, &RefusingMock, gated, &tools, "sys", 1024, "corr",
+            &mut data,
+            &RefusingMock,
+            gated,
+            &tools,
+            "sys",
+            1024,
+            "corr",
         )
         .await
         .unwrap_err();
@@ -1604,7 +1684,13 @@ mod tests {
         let gated = gated_fallback("guest:stranger", false, true, build);
 
         let err = invoke_turn_with_refusal_fallback(
-            &mut data, &RefusingMock, gated, &tools, "sys", 1024, "corr",
+            &mut data,
+            &RefusingMock,
+            gated,
+            &tools,
+            "sys",
+            1024,
+            "corr",
         )
         .await
         .unwrap_err();
@@ -1637,7 +1723,13 @@ mod tests {
         let gated = gated_fallback("peer:Nova", false, true, build);
 
         let err = invoke_turn_with_refusal_fallback(
-            &mut data, &RefusingMock, gated, &tools, "sys", 1024, "corr",
+            &mut data,
+            &RefusingMock,
+            gated,
+            &tools,
+            "sys",
+            1024,
+            "corr",
         )
         .await
         .unwrap_err();

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -491,17 +491,18 @@ pub async fn chat(
     // Commit the turn to the WAL now that it succeeded. Write-ahead is deferred
     // until success (see the user-message push above) so a refused or failed
     // turn leaves no entry — "user-message-not-committed-until-success"
-    // ordering keeps WAL replay consistent with the in-memory trunk. User
-    // first, then assistant. (Shed in isolation.) A quarantined turn is not on
-    // the trunk, so it must not be replayed into it — its WAL commit lands on
-    // the quarantine lane in a later step.
-    if let Some(wal) = state
-        .wal
-        .as_ref()
-        .filter(|_| !isolated && !committed_to_quarantine)
-    {
+    // ordering keeps WAL replay consistent with the in-memory lanes. A
+    // quarantined turn carries the quarantine lane marker so replay
+    // reconstructs the split and never poisons the trunk. User first, then
+    // assistant. (Shed in isolation.)
+    if let Some(wal) = state.wal.as_ref().filter(|_| !isolated) {
+        let lane = if committed_to_quarantine {
+            crate::wal::WalLane::Quarantine
+        } else {
+            crate::wal::WalLane::Trunk
+        };
         let user_seq = session.data.wal.wal_seq + 1;
-        match wal.append(
+        match wal.append_with_lane(
             &session_key,
             user_seq,
             Role::User,
@@ -510,17 +511,19 @@ pub async fn chat(
                 channel: Some(req.channel.clone()),
                 sender: req.sender.clone(),
             }),
+            lane,
         ) {
             Ok(()) => session.data.wal.wal_seq = user_seq,
             Err(e) => tracing::warn!("WAL append failed for user message: {}", e),
         }
         let asst_seq = session.data.wal.wal_seq + 1;
-        match wal.append(
+        match wal.append_with_lane(
             &session_key,
             asst_seq,
             Role::Assistant,
             &MessageContent::Text(text.clone()),
             None,
+            lane,
         ) {
             Ok(()) => session.data.wal.wal_seq = asst_seq,
             Err(e) => tracing::warn!("WAL append failed for assistant message: {}", e),
@@ -791,7 +794,8 @@ async fn invoke_turn_with_refusal_fallback<F>(
     correlation_id: &str,
 ) -> Result<TurnResult, Box<dyn std::error::Error + Send + Sync>>
 where
-    F: FnOnce() -> Result<Box<dyn pulse_system_types::llm::LmProvider>, crate::errors::ProviderError>,
+    F: FnOnce()
+        -> Result<Box<dyn pulse_system_types::llm::LmProvider>, crate::errors::ProviderError>,
 {
     // The user message is the trunk tail: compaction only rewrites older
     // messages, never the newest turn.
@@ -1125,9 +1129,7 @@ mod tests {
     use crate::errors::{ProviderError, RefusalError};
     use crate::session_store::{Session, SessionData};
     use crate::tools::ToolRegistry;
-    use pulse_system_types::llm::{
-        ContentBlock, LlmResponse, LlmResult, LmProvider, StopReason,
-    };
+    use pulse_system_types::llm::{ContentBlock, LlmResponse, LlmResult, LmProvider, StopReason};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Mutex;
 
@@ -1188,7 +1190,8 @@ mod tests {
                 Err(Box::new(RefusalError {
                     model: "fable".to_string(),
                     detail: "violates our Usage Policy".to_string(),
-                }) as Box<dyn std::error::Error + Send + Sync>)
+                })
+                    as Box<dyn std::error::Error + Send + Sync>)
             })
         }
         fn name(&self) -> &str {
@@ -1240,7 +1243,9 @@ mod tests {
         data
     }
 
-    fn no_fallback() -> Option<fn() -> Result<Box<dyn LmProvider>, ProviderError>> {
+    type FallbackBuilder = fn() -> Result<Box<dyn LmProvider>, ProviderError>;
+
+    fn no_fallback() -> Option<FallbackBuilder> {
         None
     }
 

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -273,6 +273,12 @@ pub async fn chat(
         }),
     });
 
+    // A real human message just arrived — reset the autonomous round counter
+    // now, pre-turn, so that even a turn that later refuses or errors still
+    // counts as human input for the autonomy / hallucination gates. (Resetting
+    // only on success would let a run of failed human turns keep climbing.)
+    session.data.health.rounds_since_human_input = 0;
+
     // MicroCompact (Tier 1): cheap mechanical compaction before checking
     // whether expensive LLM-based summarization is needed.
     let mc_result = crate::context::micro_compact(&mut session.data.messages);
@@ -487,9 +493,6 @@ pub async fn chat(
     if !isolated {
         session.data.wal.messages_since_checkpoint += 1;
     }
-    // Real human message arrived and was answered — reset the autonomous
-    // round counter.
-    session.data.health.rounds_since_human_input = 0;
 
     // Track recently accessed files from tool use (for post-compaction re-injection).
     // Scan all messages (the tool loop may have added tool-use/tool-result pairs).

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -418,41 +418,47 @@ pub async fn chat(
     };
     let active_tools = readonly_tools.as_ref().unwrap_or(&state.tools);
 
-    // Index of the just-pushed user message: it is always the trunk tail here
-    // (compaction only ever rewrites older messages, never the newest turn).
-    let user_index = session.data.messages.len() - 1;
-
-    let turn_outcome = crate::task_context::scope(
-        Some(correlation_id.clone()),
-        tool_loop::invoke_with_tool_loop(
-            state.provider.as_ref(),
-            active_tools,
-            &system_prompt,
-            &mut session.data.messages,
-            state.config.llm.max_tokens,
-            MAX_TOOL_ROUNDS,
-        ),
-    )
-    .await;
-
-    let result = match turn_outcome {
-        Ok(r) => r,
-        Err(e) => {
-            // Roll the turn back to the pre-turn trunk: drop the user message
-            // and anything the tool loop appended, and commit nothing to the
-            // WAL. The session is left exactly as it was pre-turn (AC7).
-            session.data.messages.truncate(user_index);
-            tracing::error!("LLM invocation failed: {}", e);
-            // Keep the banner sticky even on the failure path — while isolated
-            // the provider is precisely the suspect.
-            let msg = if crate::server::isolation::is_active(&state.root_dir) {
-                format!("{} {}", crate::server::isolation::BANNER, e)
-            } else {
-                e.to_string()
-            };
-            return Err((StatusCode::INTERNAL_SERVER_ERROR, msg));
-        }
+    // The default (fable) model always runs first; on an AUP refusal, and only
+    // if a fallback is configured and we are not isolated, the same turn is
+    // re-run on the fallback model and the exchange is quarantined out of the
+    // default model's context. `create_provider_with_model` is called lazily —
+    // the fallback provider is built on demand, only when a refusal fires.
+    let fallback_model = if isolated {
+        None
+    } else {
+        state.config.llm.fallback_target().map(str::to_string)
     };
+    let config_for_fallback = &state.config;
+    let build_fallback = fallback_model.as_deref().map(|model| {
+        move || crate::providers::create_provider_with_model(config_for_fallback, model)
+    });
+
+    let turn = invoke_turn_with_refusal_fallback(
+        &mut session.data,
+        state.provider.as_ref(),
+        build_fallback,
+        active_tools,
+        &system_prompt,
+        state.config.llm.max_tokens,
+        &correlation_id,
+    )
+    .await
+    .map_err(|e| {
+        // The turn failed even after any fallback — the helper has already
+        // rolled the trunk back to its pre-turn state (AC7, AC8).
+        tracing::error!("LLM turn failed: {}", e);
+        // Keep the banner sticky even on the failure path — while isolated
+        // the provider is precisely the suspect.
+        let msg = if crate::server::isolation::is_active(&state.root_dir) {
+            format!("{} {}", crate::server::isolation::BANNER, e)
+        } else {
+            e.to_string()
+        };
+        (StatusCode::INTERNAL_SERVER_ERROR, msg)
+    })?;
+
+    let committed_to_quarantine = turn.quarantined;
+    let result = turn.result;
 
     // Re-sample: a turn admitted just before the marker appeared must not
     // write after it. OR of the two samples drives every gate below.
@@ -486,8 +492,14 @@ pub async fn chat(
     // until success (see the user-message push above) so a refused or failed
     // turn leaves no entry — "user-message-not-committed-until-success"
     // ordering keeps WAL replay consistent with the in-memory trunk. User
-    // first, then assistant. (Shed in isolation.)
-    if let Some(wal) = state.wal.as_ref().filter(|_| !isolated) {
+    // first, then assistant. (Shed in isolation.) A quarantined turn is not on
+    // the trunk, so it must not be replayed into it — its WAL commit lands on
+    // the quarantine lane in a later step.
+    if let Some(wal) = state
+        .wal
+        .as_ref()
+        .filter(|_| !isolated && !committed_to_quarantine)
+    {
         let user_seq = session.data.wal.wal_seq + 1;
         match wal.append(
             &session_key,
@@ -740,6 +752,145 @@ pub async fn chat(
     }))
 }
 
+/// Outcome of one interactive turn after the refusal-fallback dance.
+struct TurnResult {
+    /// The response to return to the caller (from the default or fallback model).
+    result: tool_loop::ToolLoopResult,
+    /// True when the turn was handled by the fallback model and quarantined.
+    quarantined: bool,
+}
+
+impl std::fmt::Debug for TurnResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TurnResult")
+            .field("text", &self.result.text)
+            .field("quarantined", &self.quarantined)
+            .finish()
+    }
+}
+
+/// Run one interactive turn with reactive refusal fallback (PN-88).
+///
+/// The default (fable) model runs first, appending to the trunk (`data.messages`).
+/// On an AUP [`RefusalError`](crate::errors::RefusalError) — and only when
+/// `build_fallback` is `Some` — the same turn is re-run on the fallback model
+/// with the full picture (trunk + prior quarantine + this user message), and the
+/// exchange is quarantined so the default model's classifier does not re-trip on
+/// later benign turns. On any unrecovered error (non-refusal, fallback disabled,
+/// fallback-build failure, or the fallback also failing) the trunk is rolled back
+/// to exactly its pre-turn state and the error is surfaced (AC7, AC8).
+///
+/// Precondition: the current user message is the last element of `data.messages`.
+async fn invoke_turn_with_refusal_fallback<F>(
+    data: &mut crate::session_store::SessionData,
+    default_provider: &dyn pulse_system_types::llm::LmProvider,
+    build_fallback: Option<F>,
+    tools: &crate::tools::ToolRegistry,
+    system_prompt: &str,
+    max_tokens: u32,
+    correlation_id: &str,
+) -> Result<TurnResult, Box<dyn std::error::Error + Send + Sync>>
+where
+    F: FnOnce() -> Result<Box<dyn pulse_system_types::llm::LmProvider>, crate::errors::ProviderError>,
+{
+    // The user message is the trunk tail: compaction only rewrites older
+    // messages, never the newest turn.
+    let user_index = data.messages.len() - 1;
+
+    let default_outcome = crate::task_context::scope(
+        Some(correlation_id.to_string()),
+        tool_loop::invoke_with_tool_loop(
+            default_provider,
+            tools,
+            system_prompt,
+            &mut data.messages,
+            max_tokens,
+            MAX_TOOL_ROUNDS,
+        ),
+    )
+    .await;
+
+    let refusal = match default_outcome {
+        Ok(result) => {
+            return Ok(TurnResult {
+                result,
+                quarantined: false,
+            })
+        }
+        Err(e) => e,
+    };
+
+    let is_refusal = refusal
+        .downcast_ref::<crate::errors::RefusalError>()
+        .is_some();
+    let build = match (is_refusal, build_fallback) {
+        (true, Some(build)) => build,
+        _ => {
+            // Not a refusal, or fallback disabled: roll the turn back and
+            // surface the error unchanged.
+            data.messages.truncate(user_index);
+            return Err(refusal);
+        }
+    };
+
+    // Refusal + fallback enabled. Restore the clean trunk before building the
+    // fallback model's view of the conversation.
+    let user_msg = data.messages[user_index].clone();
+    data.messages.truncate(user_index);
+
+    let fallback_provider = match build() {
+        Ok(p) => p,
+        Err(build_err) => {
+            // The trunk is already rolled back — surface one error.
+            return Err(build_err.into());
+        }
+    };
+
+    // The fallback model sees the full conversation: clean trunk + prior
+    // quarantined tangents + the current (refused) user message.
+    let mut fallback_ctx: Vec<Message> =
+        Vec::with_capacity(data.messages.len() + data.quarantine.len() + 1);
+    fallback_ctx.extend(data.messages.iter().cloned());
+    fallback_ctx.extend(data.quarantine.iter().cloned());
+    fallback_ctx.push(user_msg.clone());
+
+    let fallback_outcome = crate::task_context::scope(
+        Some(correlation_id.to_string()),
+        tool_loop::invoke_with_tool_loop(
+            fallback_provider.as_ref(),
+            tools,
+            system_prompt,
+            &mut fallback_ctx,
+            max_tokens,
+            MAX_TOOL_ROUNDS,
+        ),
+    )
+    .await;
+
+    match fallback_outcome {
+        Ok(result) => {
+            // Quarantine the exchange: the trunk stays clean so the default
+            // model does not re-trip on later benign turns.
+            data.quarantine.push(user_msg);
+            data.quarantine.push(Message {
+                role: Role::Assistant,
+                content: MessageContent::Text(result.text.clone()),
+                source: None,
+            });
+            data.enforce_quarantine_cap();
+            Ok(TurnResult {
+                result,
+                quarantined: true,
+            })
+        }
+        Err(fallback_err) => {
+            // AC8: the fallback also failed. The trunk is already rolled back;
+            // surface a single error and leave no partial quarantine entry.
+            Err(fallback_err)
+        }
+    }
+}
+
 /// Map a resolved identity key to the event system's ConversationTrust.
 fn conversation_trust_from_identity(resolved_key: &str) -> crate::events::ConversationTrust {
     if resolved_key == "owner" {
@@ -967,5 +1118,355 @@ mod tests {
             conversation_trust_from_identity("guest:someone"),
             crate::events::ConversationTrust::Public
         ));
+    }
+
+    // ---- PN-88: refusal-fallback orchestration ----------------------------
+
+    use crate::errors::{ProviderError, RefusalError};
+    use crate::session_store::{Session, SessionData};
+    use crate::tools::ToolRegistry;
+    use pulse_system_types::llm::{
+        ContentBlock, LlmResponse, LlmResult, LmProvider, StopReason,
+    };
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Mutex;
+
+    /// Answers every turn, recording the joined message text it was given so a
+    /// test can assert what context the model actually saw.
+    struct RecordingProvider {
+        reply: String,
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl LmProvider for RecordingProvider {
+        fn invoke(
+            &self,
+            _system_prompt: &str,
+            messages: &[Message],
+            _max_tokens: u32,
+            _tools: Option<&[serde_json::Value]>,
+        ) -> LlmResult<'_> {
+            let joined = messages
+                .iter()
+                .filter_map(|m| match &m.content {
+                    MessageContent::Text(t) => Some(t.clone()),
+                    MessageContent::Blocks(_) => None,
+                })
+                .collect::<Vec<_>>()
+                .join("|");
+            self.seen.lock().unwrap().push(joined);
+            let reply = self.reply.clone();
+            Box::pin(async move {
+                Ok(LlmResponse {
+                    content: vec![ContentBlock::Text { text: reply }],
+                    stop_reason: StopReason::EndTurn,
+                    model: "recording".to_string(),
+                    input_tokens: Some(1),
+                    output_tokens: Some(1),
+                })
+            })
+        }
+        fn name(&self) -> &str {
+            "recording"
+        }
+        fn supports_tools(&self) -> bool {
+            false
+        }
+    }
+
+    /// Always issues an AUP refusal.
+    struct RefusingMock;
+    impl LmProvider for RefusingMock {
+        fn invoke(
+            &self,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _max_tokens: u32,
+            _tools: Option<&[serde_json::Value]>,
+        ) -> LlmResult<'_> {
+            Box::pin(async {
+                Err(Box::new(RefusalError {
+                    model: "fable".to_string(),
+                    detail: "violates our Usage Policy".to_string(),
+                }) as Box<dyn std::error::Error + Send + Sync>)
+            })
+        }
+        fn name(&self) -> &str {
+            "refusing"
+        }
+        fn supports_tools(&self) -> bool {
+            false
+        }
+    }
+
+    /// Always fails with a generic (non-refusal) error.
+    struct FailingMock;
+    impl LmProvider for FailingMock {
+        fn invoke(
+            &self,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _max_tokens: u32,
+            _tools: Option<&[serde_json::Value]>,
+        ) -> LlmResult<'_> {
+            Box::pin(async { Err("network drop".into()) })
+        }
+        fn name(&self) -> &str {
+            "failing"
+        }
+        fn supports_tools(&self) -> bool {
+            false
+        }
+    }
+
+    fn user(text: &str) -> Message {
+        Message {
+            role: Role::User,
+            content: MessageContent::Text(text.to_string()),
+            source: Some(MessageSource::Human {
+                channel: "chat".into(),
+                sender: "owner".into(),
+            }),
+        }
+    }
+
+    /// A session whose trunk holds `trunk` then the current user turn `turn`.
+    fn session_with(trunk: &[&str], turn: &str) -> SessionData {
+        let mut data = Session::new("chat:owner".into(), "chat".into(), "owner".into()).data;
+        for t in trunk {
+            data.messages.push(user(t));
+        }
+        data.messages.push(user(turn));
+        data
+    }
+
+    fn no_fallback() -> Option<fn() -> Result<Box<dyn LmProvider>, ProviderError>> {
+        None
+    }
+
+    /// AC2: fable refuses → the same turn is answered by the fallback model and
+    /// the exchange is quarantined out of the trunk.
+    #[tokio::test]
+    async fn refusal_falls_back_and_quarantines() {
+        let mut data = session_with(&["earlier turn"], "spicy question");
+        let trunk_before = data.messages.len();
+        let tools = ToolRegistry::new();
+
+        let turn = invoke_turn_with_refusal_fallback(
+            &mut data,
+            &RefusingMock,
+            Some(|| {
+                Ok(Box::new(RecordingProvider {
+                    reply: "opus answer".to_string(),
+                    seen: Arc::new(Mutex::new(Vec::new())),
+                }) as Box<dyn LmProvider>)
+            }),
+            &tools,
+            "sys",
+            1024,
+            "corr",
+        )
+        .await
+        .unwrap();
+
+        assert!(turn.quarantined);
+        assert_eq!(turn.result.text, "opus answer");
+        // Trunk lost the refused user message (rolled back to pre-turn).
+        assert_eq!(data.messages.len(), trunk_before - 1);
+        // Quarantine holds the user turn + opus reply.
+        assert_eq!(data.quarantine.len(), 2);
+    }
+
+    /// AC3: after a quarantined turn, the default model's next turn does NOT see
+    /// the quarantined tangent (its context is the clean trunk only).
+    #[tokio::test]
+    async fn default_model_context_excludes_quarantine() {
+        let mut data = session_with(&["earlier turn"], "spicy question");
+        let tools = ToolRegistry::new();
+        // First turn: refuse → quarantine.
+        invoke_turn_with_refusal_fallback(
+            &mut data,
+            &RefusingMock,
+            Some(|| {
+                Ok(Box::new(RecordingProvider {
+                    reply: "opus answer".to_string(),
+                    seen: Arc::new(Mutex::new(Vec::new())),
+                }) as Box<dyn LmProvider>)
+            }),
+            &tools,
+            "sys",
+            1024,
+            "corr",
+        )
+        .await
+        .unwrap();
+
+        // Second (benign) turn handled by the default model — record its context.
+        data.messages.push(user("benign hello"));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let default = RecordingProvider {
+            reply: "fable reply".to_string(),
+            seen: Arc::clone(&seen),
+        };
+        let turn = invoke_turn_with_refusal_fallback(
+            &mut data,
+            &default,
+            no_fallback(),
+            &tools,
+            "sys",
+            1024,
+            "corr",
+        )
+        .await
+        .unwrap();
+
+        assert!(!turn.quarantined);
+        let context = seen.lock().unwrap().join("###");
+        assert!(context.contains("benign hello"));
+        assert!(
+            !context.contains("spicy question") && !context.contains("opus answer"),
+            "default model context leaked the quarantined tangent: {context}"
+        );
+    }
+
+    /// AC4: consecutive refusals accumulate in quarantine, and the fallback
+    /// model on the second refusal sees the first tangent.
+    #[tokio::test]
+    async fn consecutive_refusals_accumulate_and_share_context() {
+        let mut data = session_with(&["earlier turn"], "spicy one");
+        let tools = ToolRegistry::new();
+        invoke_turn_with_refusal_fallback(
+            &mut data,
+            &RefusingMock,
+            Some(|| {
+                Ok(Box::new(RecordingProvider {
+                    reply: "opus one".to_string(),
+                    seen: Arc::new(Mutex::new(Vec::new())),
+                }) as Box<dyn LmProvider>)
+            }),
+            &tools,
+            "sys",
+            1024,
+            "corr",
+        )
+        .await
+        .unwrap();
+
+        data.messages.push(user("spicy two"));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let seen_for_build = Arc::clone(&seen);
+        invoke_turn_with_refusal_fallback(
+            &mut data,
+            &RefusingMock,
+            Some(move || {
+                Ok(Box::new(RecordingProvider {
+                    reply: "opus two".to_string(),
+                    seen: seen_for_build,
+                }) as Box<dyn LmProvider>)
+            }),
+            &tools,
+            "sys",
+            1024,
+            "corr",
+        )
+        .await
+        .unwrap();
+
+        // Four quarantined messages: two user turns + two opus replies.
+        assert_eq!(data.quarantine.len(), 4);
+        // The second fallback saw the first tangent (continuity).
+        let context = seen.lock().unwrap().join("###");
+        assert!(context.contains("spicy one"));
+        assert!(context.contains("opus one"));
+        assert!(context.contains("spicy two"));
+    }
+
+    /// AC5: fallback disabled → a refusal rolls the turn back and surfaces the
+    /// error; no fallback is attempted.
+    #[tokio::test]
+    async fn refusal_without_fallback_rolls_back() {
+        let mut data = session_with(&["earlier turn"], "spicy question");
+        let trunk_before = data.messages.len();
+        let tools = ToolRegistry::new();
+
+        let err = invoke_turn_with_refusal_fallback(
+            &mut data,
+            &RefusingMock,
+            no_fallback(),
+            &tools,
+            "sys",
+            1024,
+            "corr",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.downcast_ref::<RefusalError>().is_some());
+        assert_eq!(data.messages.len(), trunk_before - 1);
+        assert!(data.quarantine.is_empty());
+    }
+
+    /// AC7: a non-refusal error rolls the turn back and never attempts fallback.
+    #[tokio::test]
+    async fn generic_error_rolls_back_without_fallback() {
+        let mut data = session_with(&["earlier turn"], "hello");
+        let trunk_before = data.messages.len();
+        let tools = ToolRegistry::new();
+        let called = Arc::new(AtomicBool::new(false));
+        let called_in_build = Arc::clone(&called);
+
+        let err = invoke_turn_with_refusal_fallback(
+            &mut data,
+            &FailingMock,
+            Some(move || {
+                called_in_build.store(true, Ordering::SeqCst);
+                Ok(Box::new(RecordingProvider {
+                    reply: "should not happen".to_string(),
+                    seen: Arc::new(Mutex::new(Vec::new())),
+                }) as Box<dyn LmProvider>)
+            }),
+            &tools,
+            "sys",
+            1024,
+            "corr",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.downcast_ref::<RefusalError>().is_none());
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "fallback provider built for a non-refusal error"
+        );
+        assert_eq!(data.messages.len(), trunk_before - 1);
+        assert!(data.quarantine.is_empty());
+    }
+
+    /// AC8: fable refuses and the fallback also fails → rollback, single error,
+    /// no partial quarantine entry.
+    #[tokio::test]
+    async fn fallback_also_fails_rolls_back_cleanly() {
+        let mut data = session_with(&["earlier turn"], "spicy question");
+        let trunk_before = data.messages.len();
+        let tools = ToolRegistry::new();
+
+        let err = invoke_turn_with_refusal_fallback(
+            &mut data,
+            &RefusingMock,
+            Some(|| Ok(Box::new(FailingMock) as Box<dyn LmProvider>)),
+            &tools,
+            "sys",
+            1024,
+            "corr",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.downcast_ref::<RefusalError>().is_none());
+        assert_eq!(data.messages.len(), trunk_before - 1);
+        assert!(
+            data.quarantine.is_empty(),
+            "a failed fallback left a partial quarantine entry"
+        );
     }
 }

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -424,19 +424,25 @@ pub async fn chat(
     };
     let active_tools = readonly_tools.as_ref().unwrap_or(&state.tools);
 
-    // The default (fable) model always runs first; on an AUP refusal, and only
-    // if a fallback is configured and we are not isolated, the same turn is
-    // re-run on the fallback model and the exchange is quarantined out of the
-    // default model's context. `create_provider_with_model` is called lazily —
-    // the fallback provider is built on demand, only when a refusal fires.
-    let fallback_model = if isolated {
-        None
-    } else {
-        state.config.llm.fallback_target().map(str::to_string)
-    };
+    // The default (fable) model always runs first; on an AUP refusal the same
+    // turn is re-run on the fallback model and the exchange is quarantined out
+    // of the default model's context. The fallback provider is built lazily
+    // (`create_provider_with_model`), only when a refusal actually fires.
+    //
+    // SEC-001: the fallback is OWNER-ONLY. Re-running a refused turn on the more
+    // permissive opus model must not be reachable by an untrusted caller, or
+    // fable-5's AUP classifier becomes bypassable by anyone who can hit /chat.
+    // `resolve_sender` maps the owner's configured phone/discord-id/name and the
+    // tui/system/reflection channels to "owner", so D's voice calls still get
+    // the fallback while guests and peers never do. `gated_fallback` enforces
+    // the owner gate (and the isolation shed) and drops the builder unbuilt for
+    // everyone else.
     let config_for_fallback = &state.config;
-    let build_fallback = fallback_model.as_deref().map(|model| {
-        move || crate::providers::create_provider_with_model(config_for_fallback, model)
+    let build_fallback = state.config.llm.fallback_target().and_then(|model| {
+        let model = model.to_string();
+        gated_fallback(&resolved_key, isolated, move || {
+            crate::providers::create_provider_with_model(config_for_fallback, &model)
+        })
     });
 
     let turn = invoke_turn_with_refusal_fallback(
@@ -785,6 +791,18 @@ impl std::fmt::Debug for TurnResult {
             .field("quarantined", &self.quarantined)
             .finish()
     }
+}
+
+/// Owner-only, non-isolated gate for the reactive refusal fallback (SEC-001).
+///
+/// Returns `Some(build)` — arming the fallback — only for the owner and only
+/// when not isolated; otherwise the builder is dropped unbuilt and a refusal
+/// takes the ordinary rollback + error path. The fallback re-runs a refused turn
+/// on the more permissive opus model, so letting a guest or peer trigger it
+/// would make fable-5's AUP classifier bypassable by any untrusted caller who
+/// can reach `/chat`. This is the intended default, not a config knob.
+fn gated_fallback<F>(resolved_key: &str, isolated: bool, build: F) -> Option<F> {
+    (!isolated && resolved_key == "owner").then_some(build)
 }
 
 /// Run one interactive turn with reactive refusal fallback (PN-88).
@@ -1476,6 +1494,101 @@ mod tests {
         assert!(
             !called.load(Ordering::SeqCst),
             "fallback provider built for a non-refusal error"
+        );
+        assert_eq!(data.messages.len(), trunk_before - 1);
+        assert!(data.quarantine.is_empty());
+    }
+
+    /// SEC-001: the fallback gate is owner-only, and shed while isolated.
+    #[test]
+    fn fallback_gate_is_owner_only() {
+        // Owner, not isolated → armed.
+        assert!(gated_fallback("owner", false, || Ok(Box::new(FailingMock) as Box<dyn LmProvider>))
+            .is_some());
+        // Guests and peers never arm the fallback.
+        assert!(
+            gated_fallback("guest:stranger", false, || Ok(
+                Box::new(FailingMock) as Box<dyn LmProvider>
+            ))
+            .is_none()
+        );
+        assert!(
+            gated_fallback("peer:Nova", false, || Ok(
+                Box::new(FailingMock) as Box<dyn LmProvider>
+            ))
+            .is_none()
+        );
+        // Even the owner is shed while isolated (the provider is the suspect).
+        assert!(
+            gated_fallback("owner", true, || Ok(Box::new(FailingMock) as Box<dyn LmProvider>))
+                .is_none()
+        );
+    }
+
+    /// SEC-001: a guest refusal never builds the fallback provider and rolls the
+    /// turn back (mirrors `generic_error_rolls_back_without_fallback`, but the
+    /// gate — not the error class — is what drops the builder).
+    #[tokio::test]
+    async fn guest_refusal_never_builds_fallback() {
+        let mut data = session_with(&["earlier turn"], "spicy question");
+        let trunk_before = data.messages.len();
+        let tools = ToolRegistry::new();
+        let called = Arc::new(AtomicBool::new(false));
+        let called_in_build = Arc::clone(&called);
+
+        let build = move || {
+            called_in_build.store(true, Ordering::SeqCst);
+            Ok(Box::new(RecordingProvider {
+                reply: "should not happen".to_string(),
+                seen: Arc::new(Mutex::new(Vec::new())),
+            }) as Box<dyn LmProvider>)
+        };
+        // The owner-only gate drops the builder for a guest.
+        let gated = gated_fallback("guest:stranger", false, build);
+
+        let err = invoke_turn_with_refusal_fallback(
+            &mut data, &RefusingMock, gated, &tools, "sys", 1024, "corr",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.downcast_ref::<RefusalError>().is_some());
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "fallback provider built for a guest refusal"
+        );
+        assert_eq!(data.messages.len(), trunk_before - 1);
+        assert!(data.quarantine.is_empty());
+    }
+
+    /// SEC-001: a peer refusal is treated exactly like a guest — no fallback.
+    #[tokio::test]
+    async fn peer_refusal_never_builds_fallback() {
+        let mut data = session_with(&["earlier turn"], "spicy question");
+        let trunk_before = data.messages.len();
+        let tools = ToolRegistry::new();
+        let called = Arc::new(AtomicBool::new(false));
+        let called_in_build = Arc::clone(&called);
+
+        let build = move || {
+            called_in_build.store(true, Ordering::SeqCst);
+            Ok(Box::new(RecordingProvider {
+                reply: "should not happen".to_string(),
+                seen: Arc::new(Mutex::new(Vec::new())),
+            }) as Box<dyn LmProvider>)
+        };
+        let gated = gated_fallback("peer:Nova", false, build);
+
+        let err = invoke_turn_with_refusal_fallback(
+            &mut data, &RefusingMock, gated, &tools, "sys", 1024, "corr",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.downcast_ref::<RefusalError>().is_some());
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "fallback provider built for a peer refusal"
         );
         assert_eq!(data.messages.len(), trunk_before - 1);
         assert!(data.quarantine.is_empty());

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -798,8 +798,17 @@ where
         -> Result<Box<dyn pulse_system_types::llm::LmProvider>, crate::errors::ProviderError>,
 {
     // The user message is the trunk tail: compaction only rewrites older
-    // messages, never the newest turn.
-    let user_index = data.messages.len() - 1;
+    // messages, never the newest turn. Guard the subtraction so a future caller
+    // that invokes this with an empty trunk gets a clean error instead of an
+    // integer underflow panic / out-of-bounds index (SEC-005).
+    let user_index = match data.messages.len().checked_sub(1) {
+        Some(index) => index,
+        None => {
+            return Err(
+                "invoke_turn_with_refusal_fallback called with an empty trunk".into(),
+            )
+        }
+    };
 
     let default_outcome = crate::task_context::scope(
         Some(correlation_id.to_string()),

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -445,7 +445,11 @@ pub async fn chat(
     .await
     .map_err(|e| {
         // The turn failed even after any fallback — the helper has already
-        // rolled the trunk back to its pre-turn state (AC7, AC8).
+        // rolled the user turn (the trunk tail) and its deferred WAL/counter
+        // commit back off (AC7, AC8). Note this is NOT a full pre-turn restore:
+        // compaction ran before the helper, and its side-effects (summarized
+        // older messages, compaction counters, the compaction signal/archive)
+        // are intentionally retained.
         tracing::error!("LLM turn failed: {}", e);
         // Keep the banner sticky even on the failure path — while isolated
         // the provider is precisely the suspect.
@@ -780,8 +784,10 @@ impl std::fmt::Debug for TurnResult {
 /// with the full picture (trunk + prior quarantine + this user message), and the
 /// exchange is quarantined so the default model's classifier does not re-trip on
 /// later benign turns. On any unrecovered error (non-refusal, fallback disabled,
-/// fallback-build failure, or the fallback also failing) the trunk is rolled back
-/// to exactly its pre-turn state and the error is surfaced (AC7, AC8).
+/// fallback-build failure, or the fallback also failing) the user turn (the
+/// trunk tail this helper appended) is rolled back and the error is surfaced
+/// (AC7, AC8). This rolls back only the current turn's tail — any compaction the
+/// caller performed before invoking the helper is not reverted.
 ///
 /// Precondition: the current user message is the last element of `data.messages`.
 async fn invoke_turn_with_refusal_fallback<F>(

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -258,42 +258,20 @@ pub async fn chat(
     // Build user message content
     let user_content = MessageContent::Text(user_message);
 
-    // WAL: append user message BEFORE adding to session (write-ahead).
-    // Only increment wal_seq on success to keep it in sync with the WAL file.
-    // (Shed in isolation: the diagnostic conversation is deliberately
-    // ephemeral — nothing that writes.)
-    if let Some(wal) = state.wal.as_ref().filter(|_| !isolated) {
-        let next_seq = session.data.wal.wal_seq + 1;
-        match wal.append(
-            &session_key,
-            next_seq,
-            Role::User,
-            &user_content,
-            Some(crate::wal::WalMeta {
-                channel: Some(req.channel.clone()),
-                sender: req.sender.clone(),
-            }),
-        ) {
-            Ok(()) => session.data.wal.wal_seq = next_seq,
-            Err(e) => tracing::warn!("WAL append failed for user message: {}", e),
-        }
-    }
-
-    // Add user message to session and reset hallucination guard counter
+    // Push the user message onto the in-memory trunk so compaction and the
+    // provider call see it, but DEFER every commit (WAL entry, counters) until
+    // the turn actually succeeds. A failed or refused turn is rolled back to
+    // this point so it can never poison later turns — the 2026-08-09
+    // session-poisoning bug, where a refused turn left a half-appended user
+    // message that made fable re-trip on every subsequent benign turn.
     session.data.messages.push(Message {
         role: Role::User,
-        content: user_content,
+        content: user_content.clone(),
         source: Some(MessageSource::Human {
             channel: req.channel.clone(),
             sender: resolved_key.clone(),
         }),
     });
-    session.data.message_count += 1;
-    if !isolated {
-        session.data.wal.messages_since_checkpoint += 1;
-    }
-    // Real human message arrived — reset the autonomous round counter
-    session.data.health.rounds_since_human_input = 0;
 
     // MicroCompact (Tier 1): cheap mechanical compaction before checking
     // whether expensive LLM-based summarization is needed.
@@ -440,7 +418,11 @@ pub async fn chat(
     };
     let active_tools = readonly_tools.as_ref().unwrap_or(&state.tools);
 
-    let result = crate::task_context::scope(
+    // Index of the just-pushed user message: it is always the trunk tail here
+    // (compaction only ever rewrites older messages, never the newest turn).
+    let user_index = session.data.messages.len() - 1;
+
+    let turn_outcome = crate::task_context::scope(
         Some(correlation_id.clone()),
         tool_loop::invoke_with_tool_loop(
             state.provider.as_ref(),
@@ -451,18 +433,26 @@ pub async fn chat(
             MAX_TOOL_ROUNDS,
         ),
     )
-    .await
-    .map_err(|e| {
-        tracing::error!("LLM invocation failed: {}", e);
-        // Keep the banner sticky even on the failure path — while isolated
-        // the provider is precisely the suspect.
-        let msg = if crate::server::isolation::is_active(&state.root_dir) {
-            format!("{} {}", crate::server::isolation::BANNER, e)
-        } else {
-            e.to_string()
-        };
-        (StatusCode::INTERNAL_SERVER_ERROR, msg)
-    })?;
+    .await;
+
+    let result = match turn_outcome {
+        Ok(r) => r,
+        Err(e) => {
+            // Roll the turn back to the pre-turn trunk: drop the user message
+            // and anything the tool loop appended, and commit nothing to the
+            // WAL. The session is left exactly as it was pre-turn (AC7).
+            session.data.messages.truncate(user_index);
+            tracing::error!("LLM invocation failed: {}", e);
+            // Keep the banner sticky even on the failure path — while isolated
+            // the provider is precisely the suspect.
+            let msg = if crate::server::isolation::is_active(&state.root_dir) {
+                format!("{} {}", crate::server::isolation::BANNER, e)
+            } else {
+                e.to_string()
+            };
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, msg));
+        }
+    };
 
     // Re-sample: a turn admitted just before the marker appeared must not
     // write after it. OR of the two samples drives every gate below.
@@ -471,7 +461,17 @@ pub async fn chat(
         session.data.isolation_ephemeral_from = Some(pre_turn_len);
     }
 
-    let text = result.text;
+    let text = result.text.clone();
+
+    // The turn succeeded — commit the counters that were deferred from the
+    // user-message push (so a rolled-back turn leaves them untouched).
+    session.data.message_count += 1;
+    if !isolated {
+        session.data.wal.messages_since_checkpoint += 1;
+    }
+    // Real human message arrived and was answered — reset the autonomous
+    // round counter.
+    session.data.health.rounds_since_human_input = 0;
 
     // Track recently accessed files from tool use (for post-compaction re-injection).
     // Scan all messages (the tool loop may have added tool-use/tool-result pairs).
@@ -482,17 +482,35 @@ pub async fn chat(
         }
     }
 
-    // WAL: append assistant response. (Shed in isolation.)
+    // Commit the turn to the WAL now that it succeeded. Write-ahead is deferred
+    // until success (see the user-message push above) so a refused or failed
+    // turn leaves no entry — "user-message-not-committed-until-success"
+    // ordering keeps WAL replay consistent with the in-memory trunk. User
+    // first, then assistant. (Shed in isolation.)
     if let Some(wal) = state.wal.as_ref().filter(|_| !isolated) {
-        let next_seq = session.data.wal.wal_seq + 1;
+        let user_seq = session.data.wal.wal_seq + 1;
         match wal.append(
             &session_key,
-            next_seq,
+            user_seq,
+            Role::User,
+            &user_content,
+            Some(crate::wal::WalMeta {
+                channel: Some(req.channel.clone()),
+                sender: req.sender.clone(),
+            }),
+        ) {
+            Ok(()) => session.data.wal.wal_seq = user_seq,
+            Err(e) => tracing::warn!("WAL append failed for user message: {}", e),
+        }
+        let asst_seq = session.data.wal.wal_seq + 1;
+        match wal.append(
+            &session_key,
+            asst_seq,
             Role::Assistant,
             &MessageContent::Text(text.clone()),
             None,
         ) {
-            Ok(()) => session.data.wal.wal_seq = next_seq,
+            Ok(()) => session.data.wal.wal_seq = asst_seq,
             Err(e) => tracing::warn!("WAL append failed for assistant message: {}", e),
         }
     }

--- a/src/server/handlers/chat.rs
+++ b/src/server/handlers/chat.rs
@@ -450,7 +450,15 @@ pub async fn chat(
         // compaction ran before the helper, and its side-effects (summarized
         // older messages, compaction counters, the compaction signal/archive)
         // are intentionally retained.
-        tracing::error!("LLM turn failed: {}", e);
+        //
+        // SEC-007: on the fallback-also-failed path the full detail is logged
+        // here at ERROR, but the client body (`e.to_string()`, below) is the
+        // generic "upstream model error" — provider internals never leak out.
+        if let Some(ff) = e.downcast_ref::<crate::errors::FallbackFailedError>() {
+            tracing::error!("refusal fallback failed: {}", ff.detail);
+        } else {
+            tracing::error!("LLM turn failed: {}", e);
+        }
         // Keep the banner sticky even on the failure path — while isolated
         // the provider is precisely the suspect.
         let msg = if crate::server::isolation::is_active(&state.root_dir) {
@@ -860,8 +868,12 @@ where
     let fallback_provider = match build() {
         Ok(p) => p,
         Err(build_err) => {
-            // The trunk is already rolled back — surface one error.
-            return Err(build_err.into());
+            // The trunk is already rolled back — surface one error. Wrap the
+            // provider-build detail so its internals never reach the client
+            // (SEC-007); the caller logs `detail` server-side at ERROR.
+            return Err(Box::new(crate::errors::FallbackFailedError {
+                detail: build_err.to_string(),
+            }));
         }
     };
 
@@ -904,8 +916,12 @@ where
         }
         Err(fallback_err) => {
             // AC8: the fallback also failed. The trunk is already rolled back;
-            // surface a single error and leave no partial quarantine entry.
-            Err(fallback_err)
+            // surface a single error and leave no partial quarantine entry. Wrap
+            // the detail so opus provider internals never reach the client
+            // (SEC-007); the caller logs `detail` server-side at ERROR.
+            Err(Box::new(crate::errors::FallbackFailedError {
+                detail: fallback_err.to_string(),
+            }))
         }
     }
 }

--- a/src/server/prompt.rs
+++ b/src/server/prompt.rs
@@ -1440,6 +1440,8 @@ mod tests {
                 base_url: None,
                 claude_bin: None,
                 context_budget: 0,
+                fallback_model: None,
+                fallback_on_refusal: true,
             },
             security: SecurityConfig {
                 secret: None,

--- a/src/server/trust.rs
+++ b/src/server/trust.rs
@@ -98,6 +98,8 @@ mod tests {
                 base_url: None,
                 claude_bin: None,
                 context_budget: 0,
+                fallback_model: None,
+                fallback_on_refusal: true,
             },
             security: SecurityConfig {
                 secret: None,

--- a/src/session.rs
+++ b/src/session.rs
@@ -271,6 +271,80 @@ pub fn end_session(
     archive_path
 }
 
+/// Persist a session's quarantine lane (policy-refused turns re-run on the
+/// fallback model) to a standalone dead-end file under `archives/quarantine/`.
+///
+/// Unlike [`end_session`], this deliberately does NOT feed the durable memory
+/// pipeline (SEC-003): it is never summarized into EPHEMERAL (which auto-loads
+/// into the DEFAULT model's context next session), never written to the
+/// conversation INDEX or LOGBOOK, and never returned for graph ingestion.
+/// Quarantined content is policy-flagged; routing it through those channels
+/// would re-inject it into the default model's context across the session
+/// boundary and defeat the whole point of quarantining it.
+///
+/// Returns the path written, or `None` if the lane was empty or the write failed
+/// (best-effort: a quarantine archive failure must not abort a session reset).
+pub fn archive_quarantine(
+    root_dir: &Path,
+    entity_name: &str,
+    session_key: &str,
+    quarantine: &[Message],
+) -> Option<PathBuf> {
+    if quarantine.is_empty() {
+        return None;
+    }
+
+    let dir = root_dir.join("archives").join("quarantine");
+    if let Err(e) = fs::create_dir_all(&dir) {
+        tracing::warn!("Failed to create quarantine archive dir: {}", e);
+        return None;
+    }
+
+    let safe_key = session_key.replace(':', "--");
+    let now = Utc::now();
+
+    // Claim a filename with O_EXCL so concurrent writers never collide.
+    let mut n = 1u32;
+    let (mut file, path) = loop {
+        let candidate = dir.join(format!("quarantine-{safe_key}-{n:03}.md"));
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(f) => break (f, candidate),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => n += 1,
+            Err(e) => {
+                tracing::warn!("Failed to create quarantine archive: {}", e);
+                return None;
+            }
+        }
+    };
+
+    let body = conversation_to_markdown(quarantine);
+    let content = format!(
+        "---\ndate: \"{date}\"\nentity: \"{entity}\"\nsession_key: \"{key}\"\nlane: quarantine\nmessage_count: {count}\n---\n\n# Quarantine {key} ({n:03})\n\n{body}",
+        date = now.format("%Y-%m-%dT%H:%M:%SZ"),
+        entity = entity_name,
+        key = session_key,
+        count = quarantine.len(),
+    );
+
+    if let Err(e) = file.write_all(content.as_bytes()) {
+        drop(file);
+        let _ = fs::remove_file(&path);
+        tracing::warn!("Failed to write quarantine archive: {}", e);
+        return None;
+    }
+
+    tracing::info!(
+        "Quarantine lane archived to {} ({} message(s))",
+        path.display(),
+        quarantine.len()
+    );
+    Some(path)
+}
+
 /// Archive a comms (peer-to-peer) conversation transcript.
 /// Takes (entity_name, text) pairs and writes to the shared conversation archive.
 pub fn archive_comms_conversation(

--- a/src/session_health.rs
+++ b/src/session_health.rs
@@ -239,6 +239,7 @@ mod tests {
             health: HealthCounters::default(),
             compaction: CompactionMetrics::default(),
             isolation_ephemeral_from: None,
+            quarantine: Vec::new(),
         }
     }
 

--- a/src/session_health.rs
+++ b/src/session_health.rs
@@ -239,6 +239,7 @@ mod tests {
             health: HealthCounters::default(),
             compaction: CompactionMetrics::default(),
             isolation_ephemeral_from: None,
+            isolation_quarantine_from: None,
             quarantine: Vec::new(),
         }
     }

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -158,6 +158,13 @@ pub struct SessionData {
     /// the first normal turn truncates back to this watermark.
     #[serde(skip)]
     pub isolation_ephemeral_from: Option<usize>,
+    /// Index into `quarantine` of the first entry added while isolated (PN-88,
+    /// SEC-004). Parallels `isolation_ephemeral_from` for the quarantine lane:
+    /// never serialized, and the first normal turn truncates the lane back to
+    /// this watermark so a fallback tangent created during an isolation window
+    /// never survives to disk.
+    #[serde(skip)]
+    pub isolation_quarantine_from: Option<usize>,
     /// Quarantine lane (PN-88): refused turns re-run on the fallback model.
     /// This is a genuine record of what was said, but it is excluded from the
     /// default model's context so its safety classifier does not re-trip on
@@ -511,6 +518,7 @@ impl Session {
                 health: HealthCounters::default(),
                 compaction: CompactionMetrics::default(),
                 isolation_ephemeral_from: None,
+                isolation_quarantine_from: None,
                 quarantine: Vec::new(),
             },
             dirty: false,

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -367,19 +367,21 @@ pub fn reset_session(
     let msg_count = data.messages.len();
     let compactions = data.compaction.compaction_count;
 
-    // Archive current session (full end: archive + EPHEMERAL + LOGBOOK). The
-    // quarantine lane is a genuine record of what was said, so it is archived
-    // alongside the trunk (appended after it).
-    let mut archive_messages = data.messages.clone();
-    archive_messages.extend(data.quarantine.iter().cloned());
+    // Archive the CLEAN TRUNK through the full pipeline (archive + EPHEMERAL +
+    // LOGBOOK + later graph ingestion). The quarantine lane is policy-refused
+    // content: it is written to a SEPARATE dead-end file (SEC-003) so it never
+    // reaches EPHEMERAL — which auto-loads into the default model next session —
+    // nor the graph. Passing it to `end_session` here would re-poison fable's
+    // context across the session boundary.
     let archive_path = crate::session::end_session(
         root_dir,
         entity_name,
-        &archive_messages,
+        &data.messages,
         &data.channel,
         "session-reset",
         Some(&data.key),
     );
+    crate::session::archive_quarantine(root_dir, entity_name, &data.key, &data.quarantine);
 
     tracing::info!(
         "[session-reset] key={} msgs={} compactions={} hallucinations={} → fresh session",
@@ -1035,14 +1037,14 @@ impl SessionStore {
                 continue;
             }
 
-            // Full session end: archive + EPHEMERAL + LOGBOOK. The quarantine
-            // lane is archived alongside the trunk (appended after it).
-            let mut archive_messages = session.data.messages.clone();
-            archive_messages.extend(session.data.quarantine.iter().cloned());
+            // Full session end for the CLEAN TRUNK only: archive + EPHEMERAL +
+            // LOGBOOK + later graph ingestion. The quarantine lane is
+            // policy-refused content and goes to a separate dead-end file
+            // (SEC-003) so it never reaches EPHEMERAL or the graph.
             if let Some(path) = crate::session::end_session(
                 root_dir,
                 entity_name,
-                &archive_messages,
+                &session.data.messages,
                 &session.data.channel,
                 "server-shutdown",
                 Some(key),
@@ -1050,6 +1052,12 @@ impl SessionStore {
                 tracing::info!("Archived session {} to {}", key, path.display());
                 archived_paths.push(path);
             }
+            crate::session::archive_quarantine(
+                root_dir,
+                entity_name,
+                key,
+                &session.data.quarantine,
+            );
         }
 
         // Persist all to disk so they can be restored on restart
@@ -1609,5 +1617,76 @@ mod tests {
         );
         // Trunk is cleared, then a handoff message is inserted.
         assert!(session.data.messages.len() <= 1);
+    }
+
+    #[test]
+    fn reset_keeps_quarantine_out_of_ephemeral_but_archives_trunk() {
+        let tmp = tempfile::tempdir().unwrap();
+        // write_ephemeral_summary writes to memory/EPHEMERAL.md — the dir must
+        // exist for the write to land.
+        std::fs::create_dir_all(tmp.path().join("memory")).unwrap();
+
+        let mut session = Session::new("chat:owner".into(), "chat".into(), "owner".into());
+        session
+            .data
+            .messages
+            .push(user_msg("clean trunk question about rust"));
+        session.data.messages.push(asst_msg("a clean answer"));
+        session
+            .data
+            .quarantine
+            .push(user_msg("QUARANTINED_SPICY_SECRET"));
+        session
+            .data
+            .quarantine
+            .push(asst_msg("opus reply to the spicy question"));
+
+        reset_session(&mut session.data, tmp.path(), "TestEntity");
+
+        // EPHEMERAL must contain the clean trunk topic and NOT the quarantined
+        // content (SEC-003) — EPHEMERAL auto-loads into the default model.
+        let ephemeral =
+            std::fs::read_to_string(tmp.path().join("memory").join("EPHEMERAL.md")).unwrap();
+        assert!(
+            ephemeral.contains("clean trunk question"),
+            "trunk topic missing from EPHEMERAL: {ephemeral}"
+        );
+        assert!(
+            !ephemeral.contains("QUARANTINED_SPICY_SECRET"),
+            "quarantined content leaked into EPHEMERAL: {ephemeral}"
+        );
+
+        // The trunk was archived to the conversations pipeline; the quarantine
+        // went to its own dead-end file, not the conversation archive.
+        let conv_dir = tmp.path().join("archives").join("conversations");
+        let conv_dump: String = std::fs::read_dir(&conv_dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                e.path().extension().and_then(|x| x.to_str()) == Some("md")
+                    && e.file_name().to_string_lossy().starts_with("conversation-")
+            })
+            .map(|e| std::fs::read_to_string(e.path()).unwrap_or_default())
+            .collect();
+        assert!(
+            conv_dump.contains("clean trunk question"),
+            "trunk not archived to conversations"
+        );
+        assert!(
+            !conv_dump.contains("QUARANTINED_SPICY_SECRET"),
+            "quarantined content leaked into the conversation archive (graph-ingested)"
+        );
+
+        // The quarantine is preserved as a record in its own dead-end file.
+        let q_dir = tmp.path().join("archives").join("quarantine");
+        let q_dump: String = std::fs::read_dir(&q_dir)
+            .unwrap()
+            .flatten()
+            .map(|e| std::fs::read_to_string(e.path()).unwrap_or_default())
+            .collect();
+        assert!(
+            q_dump.contains("QUARANTINED_SPICY_SECRET"),
+            "quarantine record was not written to archives/quarantine/"
+        );
     }
 }

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -33,6 +33,11 @@ pub const MAX_REINJECTION_FILE_BYTES: usize = 20_000;
 /// When exceeded, the oldest messages are drained to keep the most recent ones.
 pub const MAX_MESSAGES_PER_SESSION: usize = 200;
 
+/// Hard cap on the quarantine lane (refused turns handled by the fallback
+/// model). Bounds growth on a long cybersec/AI-philosophy session; when
+/// exceeded, the oldest quarantined messages are drained.
+pub const MAX_QUARANTINE_MESSAGES: usize = 50;
+
 /// WAL (write-ahead log) tracking state for a session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalState {
@@ -147,6 +152,13 @@ pub struct SessionData {
     /// the first normal turn truncates back to this watermark.
     #[serde(skip)]
     pub isolation_ephemeral_from: Option<usize>,
+    /// Quarantine lane (PN-88): refused turns re-run on the fallback model.
+    /// This is a genuine record of what was said, but it is excluded from the
+    /// default model's context so its safety classifier does not re-trip on
+    /// later benign turns. The fallback model, by contrast, sees the trunk plus
+    /// this lane. `#[serde(default)]` keeps pre-PN-88 session files loadable.
+    #[serde(default)]
+    pub quarantine: Vec<Message>,
 }
 
 impl SessionData {
@@ -155,6 +167,15 @@ impl SessionData {
         if self.messages.len() > MAX_MESSAGES_PER_SESSION {
             let excess = self.messages.len() - MAX_MESSAGES_PER_SESSION;
             self.messages.drain(..excess);
+        }
+    }
+
+    /// Enforce the quarantine cap, draining the oldest quarantined messages
+    /// when exceeded (mirrors [`enforce_message_cap`](Self::enforce_message_cap)).
+    pub fn enforce_quarantine_cap(&mut self) {
+        if self.quarantine.len() > MAX_QUARANTINE_MESSAGES {
+            let excess = self.quarantine.len() - MAX_QUARANTINE_MESSAGES;
+            self.quarantine.drain(..excess);
         }
     }
 
@@ -330,7 +351,7 @@ pub fn reset_session(
     root_dir: &Path,
     entity_name: &str,
 ) -> Option<PathBuf> {
-    if data.messages.is_empty() {
+    if data.messages.is_empty() && data.quarantine.is_empty() {
         return None;
     }
 
@@ -340,11 +361,15 @@ pub fn reset_session(
     let msg_count = data.messages.len();
     let compactions = data.compaction.compaction_count;
 
-    // Archive current session (full end: archive + EPHEMERAL + LOGBOOK)
+    // Archive current session (full end: archive + EPHEMERAL + LOGBOOK). The
+    // quarantine lane is a genuine record of what was said, so it is archived
+    // alongside the trunk (appended after it).
+    let mut archive_messages = data.messages.clone();
+    archive_messages.extend(data.quarantine.iter().cloned());
     let archive_path = crate::session::end_session(
         root_dir,
         entity_name,
-        &data.messages,
+        &archive_messages,
         &data.channel,
         "session-reset",
         Some(&data.key),
@@ -358,8 +383,9 @@ pub fn reset_session(
         data.health.hallucination_count,
     );
 
-    // Clear messages and reset counters
+    // Clear both lanes and reset counters
     data.messages.clear();
+    data.quarantine.clear();
     data.message_count = 0;
     data.created_at = Utc::now();
     data.last_active = Utc::now();
@@ -477,6 +503,7 @@ impl Session {
                 health: HealthCounters::default(),
                 compaction: CompactionMetrics::default(),
                 isolation_ephemeral_from: None,
+                quarantine: Vec::new(),
             },
             dirty: false,
         }
@@ -998,15 +1025,18 @@ impl SessionStore {
 
         for (key, session_arc) in sessions.iter() {
             let session = session_arc.read().await;
-            if session.data.messages.is_empty() {
+            if session.data.messages.is_empty() && session.data.quarantine.is_empty() {
                 continue;
             }
 
-            // Full session end: archive + EPHEMERAL + LOGBOOK
+            // Full session end: archive + EPHEMERAL + LOGBOOK. The quarantine
+            // lane is archived alongside the trunk (appended after it).
+            let mut archive_messages = session.data.messages.clone();
+            archive_messages.extend(session.data.quarantine.iter().cloned());
             if let Some(path) = crate::session::end_session(
                 root_dir,
                 entity_name,
-                &session.data.messages,
+                &archive_messages,
                 &session.data.channel,
                 "server-shutdown",
                 Some(key),
@@ -1477,5 +1507,98 @@ mod tests {
         let s = session.read().await;
         assert_eq!(s.data.messages.len(), 1);
         assert!(s.dirty);
+    }
+
+    fn user_msg(text: &str) -> Message {
+        Message {
+            role: Role::User,
+            content: MessageContent::Text(text.into()),
+            source: Some(MessageSource::Human {
+                channel: "chat".into(),
+                sender: "owner".into(),
+            }),
+        }
+    }
+
+    fn asst_msg(text: &str) -> Message {
+        Message {
+            role: Role::Assistant,
+            content: MessageContent::Text(text.into()),
+            source: None,
+        }
+    }
+
+    #[test]
+    fn quarantine_defaults_empty_on_new_session() {
+        let session = Session::new("chat:owner".into(), "chat".into(), "owner".into());
+        assert!(session.data.quarantine.is_empty());
+    }
+
+    #[test]
+    fn quarantine_survives_serde_round_trip() {
+        let mut session = Session::new("chat:owner".into(), "chat".into(), "owner".into());
+        session.data.messages.push(user_msg("trunk turn"));
+        session.data.quarantine.push(user_msg("spicy question"));
+        session.data.quarantine.push(asst_msg("opus answer"));
+
+        let json = serde_json::to_string(&session.data).unwrap();
+        let restored: SessionData = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.messages.len(), 1);
+        assert_eq!(restored.quarantine.len(), 2);
+    }
+
+    #[test]
+    fn legacy_session_without_quarantine_field_loads_empty() {
+        // A pre-PN-88 session file: no `quarantine` key at all.
+        let legacy = r#"{
+            "key": "chat:owner",
+            "channel": "chat",
+            "sender": "owner",
+            "messages": [],
+            "created_at": "2026-01-01T00:00:00Z",
+            "last_active": "2026-01-01T00:00:00Z",
+            "message_count": 0,
+            "wal_seq": 0,
+            "messages_since_checkpoint": 0,
+            "last_checkpoint_time": "2026-01-01T00:00:00Z"
+        }"#;
+        let data: SessionData = serde_json::from_str(legacy).unwrap();
+        assert!(data.quarantine.is_empty());
+    }
+
+    #[test]
+    fn enforce_quarantine_cap_drains_oldest() {
+        let mut session = Session::new("chat:owner".into(), "chat".into(), "owner".into());
+        for i in 0..(MAX_QUARANTINE_MESSAGES + 10) {
+            session.data.quarantine.push(user_msg(&format!("q{i}")));
+        }
+        session.data.enforce_quarantine_cap();
+        assert_eq!(session.data.quarantine.len(), MAX_QUARANTINE_MESSAGES);
+        // Oldest drained: the surviving head is q10.
+        match &session.data.quarantine[0].content {
+            MessageContent::Text(t) => assert_eq!(t, "q10"),
+            _ => panic!("unexpected content"),
+        }
+    }
+
+    #[test]
+    fn reset_session_archives_and_clears_both_lanes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut session = Session::new("chat:owner".into(), "chat".into(), "owner".into());
+        session.data.messages.push(user_msg("hello"));
+        session.data.messages.push(asst_msg("hi"));
+        session.data.quarantine.push(user_msg("spicy"));
+        session.data.quarantine.push(asst_msg("opus reply"));
+
+        let archive = reset_session(&mut session.data, tmp.path(), "TestEntity");
+
+        assert!(archive.is_some(), "reset should archive when history exists");
+        assert!(
+            session.data.quarantine.is_empty(),
+            "quarantine lane not cleared on reset"
+        );
+        // Trunk is cleared, then a handoff message is inserted.
+        assert!(session.data.messages.len() <= 1);
     }
 }

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -484,7 +484,7 @@ pub struct Session {
 }
 
 impl Session {
-    fn new(key: String, channel: String, sender: String) -> Self {
+    pub(crate) fn new(key: String, channel: String, sender: String) -> Self {
         let now = Utc::now();
         Self {
             data: SessionData {

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -78,6 +78,12 @@ pub struct HealthCounters {
     /// Number of times the circuit breaker fired in this session.
     #[serde(default)]
     pub circuit_breaker_count: u32,
+    /// Number of times a refused turn was re-run on the fallback model in this
+    /// session (PN-88, SEC-002). Capped at `MAX_FALLBACKS_PER_SESSION` to bound
+    /// runaway or repeated refusals from driving unbounded expensive opus
+    /// tool-loops. Reset with the other health counters on session reset.
+    #[serde(default)]
+    pub fallback_count_this_session: u32,
 }
 
 /// Compaction metrics tracking token recovery and context management.

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -1593,7 +1593,10 @@ mod tests {
 
         let archive = reset_session(&mut session.data, tmp.path(), "TestEntity");
 
-        assert!(archive.is_some(), "reset should archive when history exists");
+        assert!(
+            archive.is_some(),
+            "reset should archive when history exists"
+        );
         assert!(
             session.data.quarantine.is_empty(),
             "quarantine lane not cleared on reset"

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -7,6 +7,30 @@ use serde::{Deserialize, Serialize};
 
 use pulse_system_types::llm::{Message, MessageContent, Role};
 
+/// Which conversation lane a WAL entry belongs to (PN-88).
+///
+/// The default `Trunk` is the clean history visible to the default model.
+/// `Quarantine` marks a refused turn that was re-run on the fallback model; on
+/// replay it must be reconstructed into the quarantine lane, never the trunk,
+/// so the default model's classifier does not re-trip on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WalLane {
+    /// The clean trunk visible to the default model.
+    #[default]
+    Trunk,
+    /// A quarantined refusal tangent (fallback-model only).
+    Quarantine,
+}
+
+impl WalLane {
+    /// Whether this is the default trunk lane (used to omit the field for
+    /// ordinary entries, keeping pre-PN-88 WAL files byte-compatible).
+    fn is_trunk(&self) -> bool {
+        matches!(self, WalLane::Trunk)
+    }
+}
+
 /// A single entry in the write-ahead log.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalEntry {
@@ -21,6 +45,10 @@ pub struct WalEntry {
     /// Optional metadata (channel, sender, etc.).
     #[serde(default, skip_serializing_if = "WalMeta::is_empty")]
     pub meta: WalMeta,
+    /// Conversation lane. Omitted for trunk entries (the common case), so
+    /// existing WAL files load unchanged.
+    #[serde(default, skip_serializing_if = "WalLane::is_trunk")]
+    pub lane: WalLane,
 }
 
 /// Optional metadata attached to a WAL entry.
@@ -80,8 +108,8 @@ impl WalWriter {
         self.dir.join(Self::key_to_filename(session_key))
     }
 
-    /// Append a message to the session's WAL. Creates the file if needed.
-    /// Uses O_APPEND for atomicity on single writes.
+    /// Append a message to the session's WAL on the trunk lane. Creates the
+    /// file if needed. Uses O_APPEND for atomicity on single writes.
     pub fn append(
         &self,
         session_key: &str,
@@ -90,12 +118,26 @@ impl WalWriter {
         content: &MessageContent,
         meta: Option<WalMeta>,
     ) -> io::Result<()> {
+        self.append_with_lane(session_key, seq, role, content, meta, WalLane::Trunk)
+    }
+
+    /// Append a message to the session's WAL on an explicit lane (PN-88).
+    pub fn append_with_lane(
+        &self,
+        session_key: &str,
+        seq: u64,
+        role: Role,
+        content: &MessageContent,
+        meta: Option<WalMeta>,
+        lane: WalLane,
+    ) -> io::Result<()> {
         let entry = WalEntry {
             ts: Utc::now(),
             seq,
             role: role.clone(),
             content: content.clone(),
             meta: meta.unwrap_or_default(),
+            lane,
         };
 
         let mut line = serde_json::to_string(&entry)
@@ -185,16 +227,23 @@ impl WalWriter {
         Ok(entries)
     }
 
-    /// Convert WAL entries back into Messages for archiving.
-    pub fn entries_to_messages(entries: &[WalEntry]) -> Vec<Message> {
-        entries
-            .iter()
-            .map(|e| Message {
+    /// Split WAL entries into `(trunk, quarantine)` by lane (PN-88), so replay
+    /// reconstructs the same lane split the session had in memory.
+    pub fn entries_to_lanes(entries: &[WalEntry]) -> (Vec<Message>, Vec<Message>) {
+        let mut trunk = Vec::new();
+        let mut quarantine = Vec::new();
+        for e in entries {
+            let msg = Message {
                 role: e.role.clone(),
                 content: e.content.clone(),
                 source: None,
-            })
-            .collect()
+            };
+            match e.lane {
+                WalLane::Trunk => trunk.push(msg),
+                WalLane::Quarantine => quarantine.push(msg),
+            }
+        }
+        (trunk, quarantine)
     }
 
     /// Check if a WAL file exists for a session.
@@ -310,7 +359,12 @@ pub async fn recover_orphans(
             continue;
         }
 
-        let messages = WalWriter::entries_to_messages(&entries);
+        // Reconstruct the lane split (PN-88): the trunk is archived first, then
+        // the quarantined tangent, so a crash mid-fallback recovers a faithful
+        // record without the quarantined turn poisoning the trunk.
+        let (trunk, quarantine) = WalWriter::entries_to_lanes(&entries);
+        let mut messages = trunk;
+        messages.extend(quarantine);
 
         // Extract channel from the first entry's meta, or from the session key
         let channel = entries[0]
@@ -419,9 +473,82 @@ mod tests {
         assert_eq!(entries[1].seq, 2);
         assert!(matches!(entries[1].role, Role::Assistant));
 
-        // Convert to messages
-        let messages = WalWriter::entries_to_messages(&entries);
-        assert_eq!(messages.len(), 2);
+        // Convert to messages (both on the trunk lane by default).
+        let (trunk, quarantine) = WalWriter::entries_to_lanes(&entries);
+        assert_eq!(trunk.len(), 2);
+        assert!(quarantine.is_empty());
+    }
+
+    #[test]
+    fn lane_marker_survives_write_and_replay_split() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions_dir = tmp.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let wal = WalWriter::new(&sessions_dir, WalFsync::None).unwrap();
+        let key = "chat:owner";
+
+        // A clean trunk turn.
+        wal.append(key, 1, Role::User, &MessageContent::Text("hi".into()), None)
+            .unwrap();
+        wal.append(
+            key,
+            2,
+            Role::Assistant,
+            &MessageContent::Text("hello".into()),
+            None,
+        )
+        .unwrap();
+        // A quarantined (refused → fallback) turn.
+        wal.append_with_lane(
+            key,
+            3,
+            Role::User,
+            &MessageContent::Text("spicy".into()),
+            None,
+            WalLane::Quarantine,
+        )
+        .unwrap();
+        wal.append_with_lane(
+            key,
+            4,
+            Role::Assistant,
+            &MessageContent::Text("opus reply".into()),
+            None,
+            WalLane::Quarantine,
+        )
+        .unwrap();
+
+        let entries = wal.read(key).unwrap();
+        assert_eq!(entries.len(), 4);
+        let (trunk, quarantine) = WalWriter::entries_to_lanes(&entries);
+        assert_eq!(trunk.len(), 2);
+        assert_eq!(quarantine.len(), 2);
+        assert!(matches!(&trunk[0].content, MessageContent::Text(t) if t == "hi"));
+        assert!(matches!(&quarantine[0].content, MessageContent::Text(t) if t == "spicy"));
+    }
+
+    #[test]
+    fn trunk_entries_omit_lane_field_for_backward_compat() {
+        // A trunk entry serializes without a `lane` key; a legacy entry without
+        // the key deserializes as trunk.
+        let entry = WalEntry {
+            ts: Utc::now(),
+            seq: 1,
+            role: Role::User,
+            content: MessageContent::Text("hi".into()),
+            meta: WalMeta::default(),
+            lane: WalLane::Trunk,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !json.contains("lane"),
+            "trunk entry should omit the lane key"
+        );
+
+        // Since trunk entries omit the field, a serialized trunk entry has the
+        // exact shape of a pre-PN-88 WAL line; it must load back as Trunk.
+        let parsed: WalEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.lane, WalLane::Trunk);
     }
 
     #[test]

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -1,3 +1,27 @@
+//! Write-ahead log for crash-resilient conversation persistence.
+//!
+//! # Commit semantics (PN-88)
+//!
+//! Despite the "write-ahead" name, the WAL is now **commit-on-success**
+//! (write-behind): a turn's entries are appended by the chat handler only
+//! *after* the turn succeeds, not before the provider is called. A crash in the
+//! middle of an in-flight turn therefore loses that one turn rather than
+//! replaying a half-written user message onto the trunk — this is the fix for
+//! the 2026-08-09 session-poisoning bug, where a refused turn left a
+//! half-appended user message that re-tripped the classifier on every later
+//! turn. The trade-off is deliberate: durability of the *last* in-flight turn is
+//! given up in exchange for never replaying a partial/poisoned one.
+//!
+//! # Downgrade caveat
+//!
+//! [`WalLane`] is written with `#[serde(skip_serializing_if)]` so trunk entries
+//! stay byte-compatible with pre-PN-88 WAL files. The consequence for a rolling
+//! downgrade (relevant to the shared `/opt/pulse-null` checkout + rolling
+//! restarts): an OLDER binary replaying a NEWER WAL will not recognise the
+//! `lane` field, so it silently drops it and replays quarantined
+//! (policy-refused) turns back onto the trunk — re-poisoning the default model's
+//! context. Do not downgrade across the PN-88 boundary while quarantine WAL
+//! entries may exist.
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write as IoWrite};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Closes #88.

## What & why

Echo's chat/voice path runs on **fable-5**, whose safety classifiers refuse cybersec / AI-philosophy turns (e.g. "could you escape your confinement?"). The refusal also **poisoned the session**: the handler appended the user turn *before* the LLM call and never rolled it back, so fable — which reads the whole history — re-tripped on every later turn, even "Hello?". This is the 2026-08-09 morning incident (conversation-773, reset manually).

This adds a **reactive fallback**: when fable returns an Anthropic Usage-Policy (AUP) refusal, the *same turn* is transparently re-run on **claude-opus-5** and opus's answer is returned. Fable stays the default — opus is a per-turn safety net, not a mode switch. The refused exchange is **quarantined** out of fable's context (but kept in opus's) so fable stops re-tripping. The underlying poisoning bug is fixed as a prerequisite.

Design discussion picked option (b) (quarantine) over a pre-classifier (per-turn latency on live calls) and over sticky-opus (loses fable). Spec: `pulse-vault/pulse-null/specs/in-progress/refusal-fallback-quarantine-spec.md`.

## How it works

- **Detect:** `classify_nonzero_exit` in the claude-code provider flags `is_error==true` + Usage-Policy text → typed `RefusalError` (downcast in the handler; no trait change — `LmProvider` is external). Network/timeout/empty errors are NOT refusals. A near-miss (`is_error` true, no policy text) logs a drift WARN.
- **Fallback:** on `RefusalError`, build the opus provider on demand via existing `create_provider_with_model`, retry with context = trunk + quarantine + current user msg.
- **Quarantine lane:** `SessionData.quarantine` (Message is an external type, so the lane lives on the session, not per-message). Fable context = trunk only; opus context includes quarantine.
- **Rollback:** WAL is now **commit-on-success** (write-behind); any non-fallback error pops the user turn, leaving the session exactly pre-turn.

## Security-hardened after audit (rust-security-auditor + rust-quality-auditor)

- **Owner-only gate (SEC-001, HIGH):** fallback fires only when `resolved_key == "owner"`. Without this, any authenticated guest could weaponize a refusal to route around fable's classifier. D's phone/Discord resolve to `owner`, so it's transparent for him; guests/peers get the normal refusal.
- **Per-session cap (SEC-002, HIGH):** `MAX_FALLBACKS_PER_SESSION = 25` bounds opus cost/rate amplification.
- **Quarantine kept out of EPHEMERAL + graph (SEC-003, MED):** refused content went into EPHEMERAL, which auto-loads into fable next session (re-poisoning across the boundary). Now only the trunk feeds `end_session`; quarantine goes to a separate dead-end archive file.
- **Isolation write-shed race (SEC-004, MED):** quarantine entries created during an isolation window are now shed on return-to-normal.
- Plus: underflow guard, generic client error (no provider internals leaked), accurate rollback comments, WAL-semantics doc, dead-assertion test fixed.

## Testing

- `cargo test --features discord-text,voice` → **822 passed / 0 failed** (35 new; independently re-run).
- `cargo fmt --check` clean. `cargo clippy --all-targets --features discord-text,voice -- -D warnings -A dead_code` → exit 0.
- **Note:** clippy `-D warnings` (without `-A dead_code`) still fails on **5 pre-existing dead-code items** in `coordinator/{durable,farm,wal}.rs` and `scheduler/intent.rs` — none in this diff; they fail on `origin/main` too. Left untouched (out of scope; touching live coordinator internals for a lint isn't worth the risk).
- AC1–AC11 each map to a named test (see plan spec-audit table).

## Deploy

**Not deployed.** Draft for review. When merged, ship via `/update-pulse` and set `[llm] fallback_model = "claude-opus-5"` in the entity config — until that key is set, behavior is unchanged (feature is opt-in). Downgrade caveat: an older binary replaying a newer WAL ignores the `lane` field and would replay quarantined turns onto the trunk (relevant to the shared checkout + rolling restarts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NouyuBNbT7LfXQqUem3CrW
