### PR TITLE
chore(ci): deterministic gate script, single source of truth for CI a…

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Pre-push hook: run the deterministic gate before anything leaves the machine.
+# Installed via scripts/install-hooks.sh (sets core.hooksPath = .githooks).
+set -euo pipefail
+exec "$(git rev-parse --show-toplevel)/scripts/gate.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# CI = the deterministic gate, server-side. The checks themselves live in
+# scripts/gate.sh (single source of truth, shared with the local pre-push
+# hook) so local and CI verdicts cannot drift.
 name: CI
 
 on:
@@ -22,14 +25,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Format
-        run: cargo fmt --check
-
-      - name: Lint
-        run: cargo clippy -- -D warnings -A dead_code
-
-      - name: Test
-        run: cargo test
+      - name: Gate (fmt, clippy, tests)
+        run: scripts/gate.sh
 
       - name: Build (release)
         run: cargo build --release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,11 +68,21 @@ docs(#3): expand configuration reference
 
 ## Code style
 
-- Run `cargo fmt` before submitting
-- Run `cargo clippy -- -D warnings -A dead_code` -- CI's exact lint gate (dead_code from unused trait methods is acceptable during early development)
-- Run `cargo test` to make sure nothing breaks
+- Run `scripts/gate.sh` before submitting -- it is CI's exact gate (fmt, `clippy --all-targets -- -D warnings`, tests), single source of truth for both
+- Optionally run `scripts/install-hooks.sh` once per clone to make the gate a pre-push hook
+- Intentionally unused code gets a targeted `#[allow(dead_code)]` with a comment explaining why -- there is no blanket `-A dead_code`, so unintentional dead code fails the gate
 - Keep your toolchain current (`rustup update stable`) -- CI lints with the latest stable, so new clippy lints apply as Rust releases
 - Keep changes focused -- one issue per PR
+
+### The gate
+
+`scripts/gate.sh` is deterministic by contract: no model and no human
+judgment executes inside it, so it cannot habituate -- it reads PR 500 with
+the same eyes it read PR 1. Human/AI review is for what the gate cannot
+encode: whether the change should exist, collateral behavior, boundary
+drift. Edits to `scripts/gate.sh` or `.github/workflows/ci.yml` are the one
+diff class that deserves the sharpest review, since the gate cannot audit
+changes to itself.
 
 ## Release workflow
 

--- a/scripts/gate.sh
+++ b/scripts/gate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Deterministic quality gate for pulse-null.
+#
+# Contract: no AI model and no human judgment lives in this script's runtime.
+# It runs the same checks with the same eyes on PR 1 and PR 500 — it cannot
+# habituate. Judgment (should this change exist, collateral behavior) belongs
+# to review, not here.
+#
+# Checks, in order (fail fast):
+#   1. cargo fmt --check        — formatting is canonical
+#   2. cargo clippy -D warnings — no warnings, all targets
+#   3. cargo test               — full test suite
+#
+# Usage: scripts/gate.sh
+# Exit codes: 0 = gate passed, non-zero = first failing check's code.
+#
+# Runs locally (pre-push hook, see scripts/install-hooks.sh) and in CI
+# (.github/workflows/ci.yml). Changes to this file are themselves the one
+# diff class that deserves the sharpest human review: the gate cannot audit
+# edits to itself.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Respect an already-configured toolchain; fall back to the standard rustup
+# location so the script behaves identically in CI and on dev machines.
+if ! command -v cargo >/dev/null 2>&1; then
+    export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+run() {
+    local name="$1"
+    shift
+    echo "==> gate: ${name}"
+    if ! "$@"; then
+        echo "!! gate FAILED at: ${name}" >&2
+        exit 1
+    fi
+}
+
+run "fmt"    cargo fmt --all -- --check
+run "clippy" cargo clippy --all-targets -- -D warnings
+run "test"   cargo test
+
+echo "==> gate: PASSED"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Install the repo's git hooks (currently: pre-push -> scripts/gate.sh).
+#
+# One-time setup per clone/worktree:
+#   scripts/install-hooks.sh
+#
+# This points core.hooksPath at .githooks so the gate runs before every
+# push. The server-side copy of the same gate (.github/workflows/ci.yml)
+# is the authoritative one — this hook just saves the round-trip.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+git config core.hooksPath .githooks
+echo "core.hooksPath -> .githooks (pre-push gate active)"

--- a/src/coordinator/durable.rs
+++ b/src/coordinator/durable.rs
@@ -125,6 +125,10 @@ impl DurableLeaseTable {
         self.table.all().cloned().collect()
     }
 
+    /// Direct read access to the underlying table. Not yet called anywhere
+    /// (`leases()` is the consumer path today); kept as the documented public
+    /// read API. Targeted allow per CONTRIBUTING — no blanket `-A dead_code`.
+    #[allow(dead_code)]
     pub fn table(&self) -> &LeaseTable {
         &self.table
     }

--- a/src/coordinator/farm.rs
+++ b/src/coordinator/farm.rs
@@ -106,6 +106,10 @@ impl Default for FarmCaps {
 pub struct SubtaskResult {
     pub sub_id: String,
     pub text: String,
+    /// How many attempts the subtask took. Populated for diagnostics; no
+    /// consumer reads it yet. Targeted allow per CONTRIBUTING — no blanket
+    /// `-A dead_code`.
+    #[allow(dead_code)]
     pub attempts: u32,
 }
 

--- a/src/coordinator/wal.rs
+++ b/src/coordinator/wal.rs
@@ -371,6 +371,10 @@ impl LeaseWal {
 
     /// Read all events, failing closed on anything but an unterminated
     /// (torn) final line.
+    // Not yet called anywhere (replay() is the consumer path today); kept as
+    // the documented public read API. Explicit allow instead of a blanket
+    // `-A dead_code` in CI so future dead code still fails the gate.
+    #[allow(dead_code)]
     pub fn read(&self) -> Result<Vec<LeaseEvent>, ReplayError> {
         Ok(self.read_numbered()?.into_iter().map(|(_, e)| e).collect())
     }
@@ -388,6 +392,10 @@ impl LeaseWal {
         Ok(table)
     }
 
+    /// Filesystem location of the WAL. Not yet called anywhere; kept as the
+    /// documented public accessor. Targeted allow per CONTRIBUTING — no
+    /// blanket `-A dead_code`.
+    #[allow(dead_code)]
     pub fn path(&self) -> &Path {
         &self.path
     }

--- a/src/scheduler/intent.rs
+++ b/src/scheduler/intent.rs
@@ -193,6 +193,10 @@ impl IntentQueue {
     }
 
     /// Pop the highest-priority intent (then FIFO within same priority).
+    // Not yet called anywhere (drain is the consumer path today); kept as the
+    // documented single-pop API. Targeted allow per CONTRIBUTING — no blanket
+    // `-A dead_code`.
+    #[allow(dead_code)]
     pub fn pop_next(&mut self) -> Option<Intent> {
         if self.intents.is_empty() {
             return None;


### PR DESCRIPTION
…nd pre-push

Adds scripts/gate.sh — fmt, clippy --all-targets -D warnings, tests — with the contract that no model or human judgment executes inside it, so the gate cannot habituate. CI now calls the same script the local pre-push hook runs (scripts/install-hooks.sh), so local and server verdicts cannot drift.

Drops the blanket -A dead_code: the four existing dead-code sites get targeted #[allow(dead_code)] with stated reasons, so future unintentional dead code fails the gate.