### PR TITLE
feat(outreach): interest-triggered outreach — salience event, quality gate, feedback loop (PN-94, Phase 1)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ pub mod down;
 pub mod init;
 pub mod intent;
 pub mod isolate;
+pub mod outreach;
 pub mod pipeline;
 pub mod plugin;
 pub mod praxis;

--- a/src/cli/outreach.rs
+++ b/src/cli/outreach.rs
@@ -99,11 +99,10 @@ fn print_kind(status: &KindStatus) {
     };
 
     let rate = match status.response_rate {
-        Some(rate) => format!("{:.0}% over {}", rate * 100.0, status.window_size),
+        Some(rate) => format!("{:.0}% over {}", rate * 100.0, status.window_filled),
         None => format!(
             "n/a ({}/{} messages — window not full)",
-            status.window_size,
-            status.window_size.max(1)
+            status.window_filled, status.window_target
         ),
     };
 

--- a/src/cli/outreach.rs
+++ b/src/cli/outreach.rs
@@ -1,0 +1,259 @@
+//! `pulse-null outreach` — the channel's instrument panel (PN-94).
+//!
+//! Two things live here, and both exist because the outreach channel is
+//! self-triggered and therefore cannot be trusted to report on itself:
+//!
+//! * `status` publishes the caps, the response rates that move them, and the
+//!   rejections. A gate that never rejects is not a gate, and a rejection log
+//!   nobody can read cannot tell anyone whether the gate is calibrated
+//!   (spec §7.2, §8).
+//! * `respond` records D's reaction, which is the only scoring signal in the
+//!   system that the entity did not author (spec §2.4). Without a way to
+//!   record it every cap tightens to half and stays there.
+
+use chrono::Utc;
+use console::style;
+
+use crate::config::Config;
+use crate::events::SalienceKind;
+use crate::outreach::feedback::{self, KindStatus};
+use crate::outreach::store::{self, Rating};
+
+/// How many recent rejections `status` prints.
+const RECENT_REJECTIONS: usize = 10;
+
+/// How many recent messages `status` prints.
+const RECENT_SENT: usize = 5;
+
+/// Show caps, response rates, and recent rejections.
+pub async fn status() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+    let root_dir = config.root_dir()?;
+    let store = store::load(&root_dir);
+    let now = Utc::now();
+    let outreach = &config.outreach;
+
+    println!();
+    println!("  {}", style("Interest-Triggered Outreach").bold());
+    println!();
+
+    let enabled = if outreach.enabled {
+        style("enabled").green()
+    } else {
+        style("disabled").red()
+    };
+    println!("  Channel: {} ({})", outreach.channel, enabled);
+
+    let tz = crate::outreach::resolve_timezone(&config.scheduler.timezone);
+    let local = now.with_timezone(&tz);
+    let quiet_now = crate::outreach::is_quiet_hour(
+        chrono::Timelike::hour(&local),
+        outreach.quiet_hours_start,
+        outreach.quiet_hours_end,
+    );
+    println!(
+        "  Quiet hours: {:02}:00–{:02}:00 {} — {} now ({})",
+        outreach.quiet_hours_start,
+        outreach.quiet_hours_end,
+        config.scheduler.timezone,
+        if quiet_now { "quiet" } else { "open" },
+        local.format("%H:%M"),
+    );
+    println!(
+        "  Call routing: {}",
+        if outreach.allow_call_routing {
+            style("on").yellow()
+        } else {
+            style("off (manual only)").dim()
+        }
+    );
+    println!();
+
+    println!("  {}", style("Budgets").bold());
+    for kind in SalienceKind::ALL {
+        print_kind(&feedback::kind_status(
+            &store,
+            outreach,
+            kind,
+            &config.scheduler.timezone,
+            now,
+        ));
+    }
+    println!();
+
+    print_recent_sent(&store);
+    print_rejections(&store);
+
+    Ok(())
+}
+
+/// One budget line per kind: what it may send, what it has sent, and what
+/// D's behaviour is doing to the cap.
+fn print_kind(status: &KindStatus) {
+    let cap = match (status.base_cap, status.effective_cap) {
+        (None, _) => style("uncapped".to_string()).cyan(),
+        (Some(base), Some(effective)) if effective < base => {
+            style(format!("{effective}/day (halved from {base})")).yellow()
+        }
+        (Some(base), _) => style(format!("{base}/day")).white(),
+    };
+
+    let rate = match status.response_rate {
+        Some(rate) => format!("{:.0}% over {}", rate * 100.0, status.window_size),
+        None => format!(
+            "n/a ({}/{} messages — window not full)",
+            status.window_size,
+            status.window_size.max(1)
+        ),
+    };
+
+    println!(
+        "  {:<12} {} · sent today {} · response {}",
+        style(status.kind.as_str()).cyan().bold(),
+        cap,
+        status.sent_today,
+        rate,
+    );
+
+    if status.tightened && !status.announced {
+        println!(
+            "    {}",
+            style("tightening not yet announced to D — notice will fire on the next candidate")
+                .yellow()
+        );
+    }
+}
+
+/// Recent messages with their response state, so "latency to response"
+/// (spec §2.4) is inspectable and not merely stored.
+fn print_recent_sent(store: &store::OutreachStore) {
+    println!("  {}", style("Recent messages").bold());
+    if store.sent.is_empty() {
+        println!("    none");
+        println!();
+        return;
+    }
+
+    for message in store.sent.iter().rev().take(RECENT_SENT) {
+        let response = match (message.response_latency(), message.rating) {
+            (Some(latency), Some(rating)) => {
+                style(format!("{} after {}", rating, humanize(latency))).green()
+            }
+            (Some(latency), None) => {
+                style(format!("responded after {}", humanize(latency))).green()
+            }
+            (None, _) => style("no response".to_string()).dim(),
+        };
+        println!(
+            "    [{}] {} — {}",
+            style(message.kind.as_str()).cyan(),
+            message.headline,
+            response
+        );
+        println!(
+            "      {} · asked for {} · {}",
+            style(&message.id).dim(),
+            message.cost,
+            style(message.sent_at.format("%Y-%m-%d %H:%M UTC").to_string()).dim(),
+        );
+    }
+    println!();
+}
+
+/// The rejection log — the only evidence about whether the gate is calibrated.
+fn print_rejections(store: &store::OutreachStore) {
+    println!("  {}", style("Recent rejections").bold());
+    if store.rejections.is_empty() {
+        println!(
+            "    {}",
+            style("none — a gate that has never fired has also never been wrong").dim()
+        );
+        println!();
+        return;
+    }
+
+    for rejection in store.rejections.iter().rev().take(RECENT_REJECTIONS) {
+        println!(
+            "    [{}] {} — {}",
+            style(rejection.kind.as_str()).cyan(),
+            rejection.headline,
+            style(rejection.reason.to_string()).yellow(),
+        );
+        println!(
+            "      {}",
+            style(
+                rejection
+                    .rejected_at
+                    .format("%Y-%m-%d %H:%M UTC")
+                    .to_string()
+            )
+            .dim()
+        );
+    }
+    println!("    {} rejection(s) on record", store.rejections.len());
+    println!();
+}
+
+/// Record that D responded to an outreach message.
+///
+/// `rating` is the optional `/useful` or `/noise` from spec §2.4. Passing no
+/// rating still counts as a response — a reply is a reply, and requiring D to
+/// classify it would make the cheap signal expensive.
+pub async fn respond(id: String, rating: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::load()?;
+    let root_dir = config.root_dir()?;
+
+    let rating = match rating.as_deref() {
+        None => None,
+        Some(label) => Some(
+            Rating::from_label(label)
+                .ok_or_else(|| format!("Unknown rating '{label}' (useful|noise)"))?,
+        ),
+    };
+
+    let recorded = feedback::record_response(&root_dir, &id, rating, Utc::now())
+        .map_err(|e| format!("could not record the response: {e}"))?;
+
+    if recorded {
+        println!("  Response recorded for {}.", style(&id).cyan());
+    } else {
+        println!("  No outreach message with id {}.", style(&id).red());
+        let store = store::load(&root_dir);
+        let unanswered = store.unanswered();
+        if !unanswered.is_empty() {
+            println!("  Awaiting a response:");
+            for message in unanswered.iter().take(RECENT_SENT) {
+                println!("    {} — {}", style(&message.id).dim(), message.headline);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Coarse, readable duration — the precision that matters here is "minutes
+/// or days", not seconds.
+fn humanize(duration: chrono::Duration) -> String {
+    let minutes = duration.num_minutes();
+    if minutes < 60 {
+        format!("{minutes}m")
+    } else if minutes < 60 * 24 {
+        format!("{}h", minutes / 60)
+    } else {
+        format!("{}d", minutes / (60 * 24))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn humanize_picks_a_readable_unit() {
+        assert_eq!(humanize(chrono::Duration::minutes(7)), "7m");
+        assert_eq!(humanize(chrono::Duration::minutes(59)), "59m");
+        assert_eq!(humanize(chrono::Duration::minutes(60)), "1h");
+        assert_eq!(humanize(chrono::Duration::hours(23)), "23h");
+        assert_eq!(humanize(chrono::Duration::hours(25)), "1d");
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -34,6 +34,8 @@ pub struct Config {
     #[serde(default)]
     pub prediction: PredictionConfig,
     #[serde(default)]
+    pub outreach: OutreachConfig,
+    #[serde(default)]
     pub sessions: SessionConfig,
     #[serde(default)]
     pub context_buffer: crate::context_buffer::ContextBufferConfig,
@@ -667,6 +669,76 @@ impl Default for PredictionConfig {
     }
 }
 
+/// Configuration for interest-triggered outreach (PN-94).
+///
+/// See `interest-triggered-outreach-spec.md` §5. The caps are deliberately
+/// tighter than feels necessary: under-firing this channel is recoverable,
+/// over-firing it is not — once D starts skimming past unprompted messages,
+/// no config change brings the channel back (spec §6.4).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct OutreachConfig {
+    /// Master switch. When false no salience candidate is ever admitted.
+    pub enabled: bool,
+    /// Discord channel key the outreach lands on.
+    pub channel: String,
+    /// First hour of the quiet window, in `scheduler.timezone` local time.
+    pub quiet_hours_start: u32,
+    /// First hour *after* the quiet window.
+    pub quiet_hours_end: u32,
+    /// Daily cap for `Finding`.
+    pub cap_finding: u32,
+    /// Daily cap for `Development` — the kind most likely to become slop.
+    pub cap_development: u32,
+    /// Daily cap for `Callback`.
+    pub cap_callback: u32,
+    /// Messages per kind the rolling response rate is measured over.
+    pub feedback_window: usize,
+    /// Response rate below which the daily cap is halved and D is told.
+    pub response_rate_floor: f64,
+    /// Cosine similarity at or above which a headline is a restatement.
+    pub novelty_similarity_max: f64,
+    /// Automatic `Call` routing. Stays off until the Discord channel has a
+    /// track record — an unprompted phone call has a wildly different cost
+    /// profile (spec §2.5).
+    pub allow_call_routing: bool,
+}
+
+impl OutreachConfig {
+    /// Daily cap configured for `kind`, or `None` when the kind is uncapped.
+    ///
+    /// `Blocking` is uncapped by design: its failure mode is under-firing,
+    /// which stalls D's work silently (spec §2.2).
+    #[must_use]
+    pub fn cap_for(&self, kind: crate::events::SalienceKind) -> Option<u32> {
+        use crate::events::SalienceKind;
+        match kind {
+            SalienceKind::Finding => Some(self.cap_finding),
+            SalienceKind::Development => Some(self.cap_development),
+            SalienceKind::Callback => Some(self.cap_callback),
+            SalienceKind::Blocking => None,
+        }
+    }
+}
+
+impl Default for OutreachConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            channel: "echo".to_string(),
+            quiet_hours_start: 23,
+            quiet_hours_end: 8,
+            cap_finding: 2,
+            cap_development: 1,
+            cap_callback: 2,
+            feedback_window: 20,
+            response_rate_floor: 0.3,
+            novelty_similarity_max: 0.85,
+            allow_call_routing: false,
+        }
+    }
+}
+
 /// Configuration for session persistence
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -1014,6 +1086,7 @@ pub mod test_support {
             pulse: PulseConfig::default(),
             graph: GraphConfig::default(),
             prediction: PredictionConfig::default(),
+            outreach: OutreachConfig::default(),
             sessions: SessionConfig::default(),
             context_buffer: crate::context_buffer::ContextBufferConfig::default(),
             session_health: crate::session_health::SessionHealthConfig::default(),
@@ -1022,6 +1095,52 @@ pub mod test_support {
             peers: HashMap::new(),
             plugins: HashMap::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod outreach_config_tests {
+    use super::*;
+    use crate::events::SalienceKind;
+
+    #[test]
+    fn defaults_match_the_spec() {
+        let cfg = OutreachConfig::default();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.channel, "echo");
+        assert_eq!(cfg.quiet_hours_start, 23);
+        assert_eq!(cfg.quiet_hours_end, 8);
+        assert_eq!(cfg.cap_finding, 2);
+        assert_eq!(cfg.cap_development, 1);
+        assert_eq!(cfg.cap_callback, 2);
+        assert_eq!(cfg.feedback_window, 20);
+        assert!((cfg.response_rate_floor - 0.3).abs() < f64::EPSILON);
+        assert!((cfg.novelty_similarity_max - 0.85).abs() < f64::EPSILON);
+        assert!(!cfg.allow_call_routing);
+    }
+
+    #[test]
+    fn blocking_is_uncapped_every_other_kind_is_not() {
+        let cfg = OutreachConfig::default();
+        assert_eq!(cfg.cap_for(SalienceKind::Blocking), None);
+        assert_eq!(cfg.cap_for(SalienceKind::Finding), Some(2));
+        assert_eq!(cfg.cap_for(SalienceKind::Development), Some(1));
+        assert_eq!(cfg.cap_for(SalienceKind::Callback), Some(2));
+    }
+
+    #[test]
+    fn absent_section_deserializes_to_defaults() {
+        let cfg: OutreachConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.cap_development, 1);
+        assert!(!cfg.allow_call_routing);
+    }
+
+    #[test]
+    fn partial_section_keeps_unspecified_defaults() {
+        let cfg: OutreachConfig = toml::from_str("cap_development = 0\nenabled = false\n").unwrap();
+        assert_eq!(cfg.cap_development, 0);
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.quiet_hours_start, 23);
     }
 }
 

--- a/src/events/listener.rs
+++ b/src/events/listener.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
 use tokio::sync::RwLock;
 
-use super::{ConversationTrust, EntityEvent, InteractionSource};
-use crate::config::EventsConfig;
+use super::{ConversationTrust, EntityEvent, InteractionSource, SalienceKind};
+use crate::config::{Config, EventsConfig};
+use crate::outreach::{self, Decision, OutreachCandidate};
 use crate::scheduler::evaluator::{
     resolve_docs_dir, CognitiveEval, EvalDecision, Evaluator, PipelineDocEval, PostInteractionEval,
     SchedulerState,
@@ -23,11 +24,13 @@ const MAX_CONSECUTIVE_FIRES: u32 = 3;
 pub async fn event_listener(
     mut rx: tokio::sync::broadcast::Receiver<EntityEvent>,
     intent_queue: Arc<RwLock<IntentQueue>>,
-    events_config: EventsConfig,
-    max_queue_size: usize,
+    config: Arc<Config>,
     root_dir: PathBuf,
 ) {
     tracing::info!("Event listener started");
+
+    let events_config = config.autonomy.events.clone();
+    let max_queue_size = config.autonomy.max_queue_size;
 
     // Circuit breaker state: event_type → (last_queued, consecutive_fires)
     let mut cooldowns: HashMap<String, (DateTime<Utc>, u32)> = HashMap::new();
@@ -45,7 +48,17 @@ pub async fn event_listener(
                 // fire limits since each interaction is a unique trigger
                 let is_post_conversation = matches!(event, EntityEvent::PostInteraction { .. });
 
-                if let Some((last_queued, fires)) = cooldowns.get(&event_type) {
+                // Salience carries its own admission control: the quality
+                // gate, quiet hours and per-kind daily caps (PN-94 §2.2–2.5).
+                // A blanket 60-minute cooldown on top of those would silently
+                // throttle `Blocking`, which the spec requires to be uncapped,
+                // and the circuit breaker would retire the channel after three
+                // messages. The caps are the control; this is not.
+                let self_governed = matches!(event, EntityEvent::Salience { .. });
+
+                if let Some((last_queued, fires)) =
+                    cooldowns.get(&event_type).filter(|_| !self_governed)
+                {
                     let elapsed = Utc::now() - *last_queued;
 
                     // Apply cooldown for all events (5 min for post_conversation, full window for others)
@@ -117,6 +130,14 @@ pub async fn event_listener(
                 if crate::server::isolation::is_active(&root_dir) {
                     continue;
                 }
+
+                // Outreach admission runs after the isolation shed (it writes
+                // outreach.json) and before translation: a candidate that
+                // does not clear the gate never becomes an intent at all.
+                if self_governed && !admit_salience(&event, &config, &root_dir).await {
+                    continue;
+                }
+
                 if let Some(intent) = translate_event(&event, &events_config) {
                     // Delta against disk (reconcile) + refresh the shared copy,
                     // so this push survives a concurrent daemon write and vice versa.
@@ -147,6 +168,16 @@ pub async fn event_listener(
                         let entry = cooldowns.entry(event_type).or_insert((Utc::now(), 0));
                         entry.0 = Utc::now();
                         entry.1 += 1;
+                    } else if self_governed {
+                        // The outreach already counted against the daily cap
+                        // at admission, so a dropped intent spends budget on
+                        // a message D never sees. Loud, not debug: this is
+                        // the channel silently under-delivering.
+                        tracing::warn!(
+                            "Admitted outreach not queued (queue full or duplicate) — \
+                             the send is already counted against today's cap: '{}'",
+                            description
+                        );
                     } else {
                         // PostInteraction rejections are more significant — a real
                         // conversation's self-assessment didn't queue.
@@ -172,6 +203,88 @@ pub async fn event_listener(
                 break;
             }
         }
+    }
+}
+
+/// Run the outreach admission on a `Salience` event (PN-94, spec §2.3–§2.5).
+///
+/// Returns true only when the candidate cleared the quality gate, the quiet
+/// window and its daily cap. Every rejection is logged with its reason and
+/// recorded in `outreach.json`: a gate whose rejections are invisible cannot
+/// be audited by anyone, and the rejection rate is one of the spec's success
+/// criteria (§8).
+///
+/// Any pending cap-tightening notice is delivered here, before the decision
+/// is acted on, and is marked announced only once delivery succeeds — a
+/// notice lost to a failing webhook must be retried, not assumed seen.
+async fn admit_salience(event: &EntityEvent, config: &Arc<Config>, root_dir: &Path) -> bool {
+    let Some(candidate) = OutreachCandidate::from_event(event) else {
+        return false;
+    };
+
+    let admission = outreach::admit_async(
+        root_dir.to_path_buf(),
+        Arc::clone(config),
+        candidate.clone(),
+        Utc::now(),
+    )
+    .await;
+
+    if let Some(ref tightening) = admission.pending_notice {
+        announce_tightening(tightening, config, root_dir).await;
+    }
+
+    match admission.decision {
+        Decision::Admitted { id } => {
+            tracing::info!(
+                outreach_id = %id,
+                kind = %candidate.kind,
+                "Outreach admitted: {}",
+                candidate.headline
+            );
+            true
+        }
+        Decision::Rejected(reason) => {
+            tracing::info!(
+                kind = %candidate.kind,
+                "Outreach rejected ({reason}): {}",
+                candidate.headline
+            );
+            false
+        }
+    }
+}
+
+/// Deliver a cap-tightening notice to D and record that it went out.
+///
+/// Delivery is reported (unlike the fire-and-forget share router) because a
+/// tightening D never learns about is precisely the silent self-throttling
+/// spec §2.4 forbids. A failed delivery leaves the announcement unrecorded,
+/// so the next candidate of that kind tries again.
+async fn announce_tightening(
+    tightening: &crate::outreach::feedback::Tightening,
+    config: &Config,
+    root_dir: &Path,
+) {
+    let notice = crate::outreach::feedback::tightening_notice(tightening);
+    let webhook = config.scheduler.output.share_webhook.as_deref();
+
+    match crate::scheduler::output::deliver_liveness_alert(&notice, webhook).await {
+        Ok(()) => {
+            if let Err(e) =
+                crate::outreach::feedback::mark_announced(root_dir, tightening, Utc::now()).await
+            {
+                tracing::error!(
+                    error = %e,
+                    "Cap tightening announced but not recorded — D may be told twice"
+                );
+            }
+        }
+        Err(e) => tracing::error!(
+            error = %e,
+            kind = %tightening.kind,
+            "Cap tightening notice undelivered — will retry on the next candidate"
+        ),
     }
 }
 
@@ -432,6 +545,94 @@ fn translate_event(event: &EntityEvent, config: &EventsConfig) -> Option<Intent>
         // reflection-window prompt augmentation, not via an autonomous LLM
         // intent. The event exists for vigil-pulse and future listeners.
         EntityEvent::PredictionPressure { .. } => None,
+
+        // Salience has already cleared the outreach admission by the time it
+        // gets here (see `admit_salience`), so this only shapes the message.
+        // Routing is `Share`: `Call` stays manual until the Discord channel
+        // has a track record (spec §2.5, `allow_call_routing = false`).
+        EntityEvent::Salience {
+            kind,
+            thread_id,
+            headline,
+            evidence,
+            confidence,
+        } => Some(salience_intent(SalienceIntentParts {
+            kind: *kind,
+            thread_id: thread_id.as_deref(),
+            headline,
+            evidence,
+            confidence: *confidence,
+        })),
+    }
+}
+
+/// The parts of a `Salience` event that shape its outreach message.
+struct SalienceIntentParts<'a> {
+    kind: SalienceKind,
+    thread_id: Option<&'a str>,
+    headline: &'a str,
+    evidence: &'a str,
+    confidence: f64,
+}
+
+/// Build the intent that writes the admitted outreach message.
+///
+/// The prompt hands the entity the material it already committed to — the
+/// headline, the evidence, the stated cost — and asks it to write the message
+/// around them. It is explicitly not asked to reconsider whether to send:
+/// that judgement was made mechanically and re-opening it here would put the
+/// decision back in the hands of the faculty under audit.
+fn salience_intent(parts: SalienceIntentParts<'_>) -> Intent {
+    let SalienceIntentParts {
+        kind,
+        thread_id,
+        headline,
+        evidence,
+        confidence,
+    } = parts;
+
+    // Blocking means D's work is stalled pending a decision from him; it
+    // jumps the queue for the same reason it is uncapped.
+    let priority = if kind == SalienceKind::Blocking {
+        IntentPriority::Urgent
+    } else {
+        IntentPriority::Normal
+    };
+
+    let thread_note = thread_id.map_or_else(String::new, |id| {
+        format!("\nThis continues thread '{id}' — say so if the continuation is the point.\n")
+    });
+
+    Intent {
+        id: format!("event-salience-{}", &uuid::Uuid::new_v4().to_string()[..8]),
+        description: format!("Outreach ({kind}): {headline}"),
+        prompt: format!(
+            "You raised this as worth telling D unprompted, and it cleared the outreach \
+            quality gate. Write the message.\n\n\
+            Kind: {kind}\n\
+            Headline: {headline}\n\
+            Confidence: {confidence:.2}\n\
+            Evidence you cited:\n{evidence}\n{thread_note}\n\
+            Write it as a short Discord message and emit it with a [SHARE:] marker. \
+            Requirements, all of them load-bearing:\n\
+            1. Lead with the claim itself, not with the fact that you are reaching out. \
+            No preamble, no 'I've been thinking about'.\n\
+            2. Carry the external referent through verbatim — the file and line, URL, \
+            prediction id or measured number. It is the part of this D can check, and \
+            the part you did not author.\n\
+            3. End with the cost line exactly as stated above: what you are asking for \
+            is nothing, a read, or a decision.\n\
+            4. Keep it under 150 words. If it does not fit, the claim is not sharp yet.\n\
+            5. Do not restate the evidence twice, and do not pad with hedging.\n\n\
+            Emit exactly one [SHARE:] marker. Do not queue intents or schedule tasks \
+            from this — it is one message, not a work item.",
+        ),
+        source: IntentSource::Event(format!("salience_{kind}")),
+        priority,
+        created_at: Utc::now(),
+        chain: None,
+        output_routing: IntentOutput::Share,
+        depth: 0,
     }
 }
 
@@ -656,6 +857,82 @@ mod tests {
         let intent = translate_event(&event, &config).unwrap();
         assert!(intent.description.contains("comms with Nova"));
         assert!(intent.prompt.contains("remote peer"));
+    }
+
+    fn salience(kind: SalienceKind) -> EntityEvent {
+        EntityEvent::Salience {
+            kind,
+            thread_id: None,
+            headline: "The gate rejects self-authored evidence".to_string(),
+            evidence: "src/outreach/mod.rs:312\nCost: read".to_string(),
+            confidence: 0.8,
+        }
+    }
+
+    #[test]
+    fn salience_translates_to_a_share_routed_intent() {
+        let intent = translate_event(&salience(SalienceKind::Finding), &EventsConfig::default())
+            .expect("an admitted salience event must produce an intent");
+        assert_eq!(intent.output_routing, IntentOutput::Share);
+        assert!(intent.description.starts_with("Outreach (finding)"));
+        assert!(intent.prompt.contains("[SHARE:]"));
+    }
+
+    #[test]
+    fn salience_carries_the_referent_and_the_cost_into_the_prompt() {
+        // The referent is the part D can check and the entity did not author;
+        // dropping it here would undo gate 2 one step after it passed.
+        let intent =
+            translate_event(&salience(SalienceKind::Callback), &EventsConfig::default()).unwrap();
+        assert!(intent.prompt.contains("src/outreach/mod.rs:312"));
+        assert!(intent.prompt.contains("Cost: read"));
+    }
+
+    #[test]
+    fn blocking_outreach_jumps_the_queue() {
+        let blocking =
+            translate_event(&salience(SalienceKind::Blocking), &EventsConfig::default()).unwrap();
+        assert_eq!(blocking.priority, IntentPriority::Urgent);
+
+        let finding =
+            translate_event(&salience(SalienceKind::Finding), &EventsConfig::default()).unwrap();
+        assert_eq!(finding.priority, IntentPriority::Normal);
+    }
+
+    #[test]
+    fn salience_is_not_gated_by_the_generic_events_config() {
+        // Every toggle off: outreach is governed by [outreach] enabled, not
+        // by the health-event switches, and must not be silently disabled by
+        // an unrelated knob.
+        let all_off = EventsConfig {
+            post_conversation: false,
+            pipeline_alert: false,
+            pipeline_frozen: false,
+            cognitive_decline: false,
+            pipeline_conversion_low: false,
+            provider_error: false,
+        };
+        assert!(translate_event(&salience(SalienceKind::Finding), &all_off).is_some());
+    }
+
+    #[test]
+    fn salience_thread_id_is_mentioned_only_when_present() {
+        let mut event = salience(SalienceKind::Development);
+        assert!(!translate_event(&event, &EventsConfig::default())
+            .unwrap()
+            .prompt
+            .contains("continues thread"));
+
+        if let EntityEvent::Salience {
+            ref mut thread_id, ..
+        } = event
+        {
+            *thread_id = Some("tension-7".to_string());
+        }
+        assert!(translate_event(&event, &EventsConfig::default())
+            .unwrap()
+            .prompt
+            .contains("tension-7"));
     }
 
     #[test]

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -87,6 +87,22 @@ impl SalienceKind {
             Self::Callback => "callback",
         }
     }
+
+    /// Parse a `[SALIENCE:]` marker's `kind` field.
+    ///
+    /// Returns `None` for anything unrecognised rather than defaulting: a
+    /// typo must not silently inherit `Blocking`'s uncapped, quiet-hours
+    /// overriding budget, nor dodge `Development`'s stricter gate.
+    #[must_use]
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label.trim().to_ascii_lowercase().as_str() {
+            "finding" => Some(Self::Finding),
+            "development" => Some(Self::Development),
+            "blocking" => Some(Self::Blocking),
+            "callback" => Some(Self::Callback),
+            _ => None,
+        }
+    }
 }
 
 impl std::fmt::Display for SalienceKind {
@@ -327,6 +343,24 @@ mod tests {
             vec!["finding", "development", "blocking", "callback"]
         );
         assert_eq!(SalienceKind::Development.to_string(), "development");
+    }
+
+    #[test]
+    fn salience_kind_labels_round_trip() {
+        for kind in SalienceKind::ALL {
+            assert_eq!(SalienceKind::from_label(kind.as_str()), Some(kind));
+        }
+        assert_eq!(
+            SalienceKind::from_label("  DEVELOPMENT "),
+            Some(SalienceKind::Development)
+        );
+    }
+
+    #[test]
+    fn salience_kind_rejects_unknown_label() {
+        // Defaulting a typo would hand it Blocking's uncapped budget.
+        assert_eq!(SalienceKind::from_label("blockng"), None);
+        assert_eq!(SalienceKind::from_label(""), None);
     }
 
     #[test]

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -46,6 +46,55 @@ impl std::fmt::Display for PluginStateChange {
     }
 }
 
+/// What an unprompted outreach message is about (PN-94, spec §2.1).
+///
+/// The kinds are not cosmetic. Each carries its own threshold and daily
+/// budget because they fail in opposite directions: `Blocking` under-firing
+/// stalls work silently, so it is uncapped; `Development` over-firing is the
+/// failure that erodes the channel, so it is the tightest and the one whose
+/// external-referent check is strictest (spec §2.2, §6.1).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SalienceKind {
+    /// "I found something you didn't know."
+    Finding,
+    /// "I've been chewing on this and it changed shape."
+    Development,
+    /// "I need a decision from you and I'm blocked without it."
+    Blocking,
+    /// "Something I predicted about your work resolved."
+    Callback,
+}
+
+impl SalienceKind {
+    /// Every kind, in the order `outreach status` reports them.
+    pub const ALL: [Self; 4] = [
+        Self::Finding,
+        Self::Development,
+        Self::Blocking,
+        Self::Callback,
+    ];
+
+    /// Stable lowercase label used on the wire, on disk, and in log lines.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Finding => "finding",
+            Self::Development => "development",
+            Self::Blocking => "blocking",
+            Self::Callback => "callback",
+        }
+    }
+}
+
+impl std::fmt::Display for SalienceKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Internal entity events that can trigger autonomous actions.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -107,6 +156,24 @@ pub enum EntityEvent {
         triggering_prediction_id: String,
         triggering_surprise: f64,
     },
+
+    /// Emitted when the entity's own cognition produces something it judges
+    /// worth telling the owner about, unprompted (PN-94, spec §2.1).
+    ///
+    /// This is the only event in the bus that is about *content* rather than
+    /// the health of the machinery. Raising it is not the same as sending it:
+    /// every candidate goes through the outreach quality gate, quiet hours
+    /// and the per-kind daily cap before it becomes an intent.
+    Salience {
+        kind: SalienceKind,
+        /// Links to the tension store when Phase 2 supplies one.
+        thread_id: Option<String>,
+        /// One sentence — the actual claim.
+        headline: String,
+        /// What makes it non-obvious. Must carry an external referent.
+        evidence: String,
+        confidence: f64,
+    },
 }
 
 impl EntityEvent {
@@ -130,6 +197,7 @@ impl EntityEvent {
             }
             EntityEvent::ProviderError { .. } => "provider_error".into(),
             EntityEvent::PredictionPressure { .. } => "prediction_pressure".into(),
+            EntityEvent::Salience { kind, .. } => format!("salience_{kind}"),
         }
     }
 }
@@ -235,6 +303,30 @@ mod tests {
             output_tokens: 0,
         };
         assert_eq!(event.event_type(), "post_task_reflection");
+    }
+
+    #[test]
+    fn salience_event_type_is_per_kind() {
+        // The cooldown/telemetry key separates kinds, because their budgets
+        // are separate — one noisy Finding must not mask a Blocking.
+        let event = EntityEvent::Salience {
+            kind: SalienceKind::Blocking,
+            thread_id: None,
+            headline: "h".to_string(),
+            evidence: "e".to_string(),
+            confidence: 0.9,
+        };
+        assert_eq!(event.event_type(), "salience_blocking");
+    }
+
+    #[test]
+    fn salience_kind_labels_are_stable_and_distinct() {
+        let labels: Vec<&str> = SalienceKind::ALL.iter().map(|k| k.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec!["finding", "development", "blocking", "callback"]
+        );
+        assert_eq!(SalienceKind::Development.to_string(), "development");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod intake_audit;
 mod interaction;
 mod logbook;
 mod ollama_provider;
+mod outreach;
 mod peer;
 mod persist;
 mod pidfile;
@@ -96,6 +97,11 @@ enum Commands {
     Intent {
         #[command(subcommand)]
         action: IntentAction,
+    },
+    /// Interest-triggered outreach — caps, response rates, rejections
+    Outreach {
+        #[command(subcommand)]
+        action: OutreachAction,
     },
     /// Memory dashboard and tools
     Recall {
@@ -224,6 +230,20 @@ enum IntentAction {
     },
     /// Clear all pending intents
     Clear,
+}
+
+#[derive(Subcommand)]
+enum OutreachAction {
+    /// Show caps, response rates, and recent gate rejections
+    Status,
+    /// Record that D responded to an outreach message
+    Respond {
+        /// Outreach message ID (from `outreach status`)
+        id: String,
+        /// Optional explicit rating: useful or noise
+        #[arg(long)]
+        rating: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -415,6 +435,16 @@ async fn main() {
                 } => cli::intent::add(description, prompt, priority).await,
                 IntentAction::Remove { id } => cli::intent::remove(id).await,
                 IntentAction::Clear => cli::intent::clear().await,
+            };
+            if let Err(e) = result {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        }
+        Commands::Outreach { action } => {
+            let result = match action {
+                OutreachAction::Status => cli::outreach::status().await,
+                OutreachAction::Respond { id, rating } => cli::outreach::respond(id, rating).await,
             };
             if let Err(e) = result {
                 eprintln!("Error: {e}");

--- a/src/outreach/feedback.rs
+++ b/src/outreach/feedback.rs
@@ -175,7 +175,10 @@ pub struct KindStatus {
     pub effective_cap: Option<u32>,
     pub sent_today: u32,
     pub response_rate: Option<f64>,
-    pub window_size: usize,
+    /// Messages of this kind currently in the window.
+    pub window_filled: usize,
+    /// Messages the window needs before the rate is acted on.
+    pub window_target: usize,
     pub tightened: bool,
     pub announced: bool,
 }
@@ -197,7 +200,8 @@ pub fn kind_status(
         effective_cap: effective_cap(store, config, kind),
         sent_today: store.sent_today(kind, tz, now),
         response_rate: response_rate(store, kind, config.feedback_window),
-        window_size: store.recent(kind, config.feedback_window).len(),
+        window_filled: store.recent(kind, config.feedback_window).len(),
+        window_target: config.feedback_window,
         tightened: tightening.is_some(),
         announced: store.announced(kind).is_some(),
     }
@@ -415,6 +419,20 @@ mod tests {
         assert!(status.tightened);
         assert!(!status.announced, "nothing has been announced yet");
         assert_eq!(status.sent_today, 4);
-        assert_eq!(status.window_size, 4);
+        assert_eq!(status.window_filled, 4);
+        assert_eq!(status.window_target, config.feedback_window);
+    }
+
+    #[test]
+    fn status_reports_a_partly_filled_window_against_its_target() {
+        let config = config();
+        let now: DateTime<Utc> = "2026-08-02T12:00:00Z".parse().unwrap();
+        let store = store_with(SalienceKind::Finding, 1, 0);
+        let status = kind_status(&store, &config, SalienceKind::Finding, "UTC", now);
+
+        assert_eq!(status.response_rate, None);
+        assert_eq!(status.window_filled, 1);
+        assert_eq!(status.window_target, 4);
+        assert!(!status.tightened, "one silent message must not halve a cap");
     }
 }

--- a/src/outreach/feedback.rs
+++ b/src/outreach/feedback.rs
@@ -1,0 +1,420 @@
+//! The feedback loop — the part that actually matters (PN-94, spec §2.4).
+//!
+//! An outreach channel with no feedback converges to noise, and it converges
+//! *silently*: the entity's own estimate of message quality is exactly the
+//! faculty that would have to detect the drift. D's response is the only
+//! independent signal, because it is the only one the entity cannot author.
+//!
+//! Two properties here are deliberate and neither is an accident of
+//! implementation:
+//!
+//! * **Fail-closed under neglect.** A message with no recorded response
+//!   counts as unanswered. If nobody looks at the log, caps tighten rather
+//!   than loosen — a control that fails open when unread is not a control.
+//! * **The tightening is announced.** Silent self-throttling would let the
+//!   channel die without D ever learning it did. [`Tightening`] exists so the
+//!   halving has something to say for itself; see
+//!   [`crate::outreach::Admission::pending_notice`] for why the notice fires
+//!   on rejections too.
+//!
+//! Non-response is a weak signal — D may be asleep, busy, on a plane. It is
+//! accepted anyway, because the alternative is a self-assessed quality score,
+//! which is strictly worse: it correlates with the very error it is meant to
+//! detect. The weakness is handled by the window size, not by substituting a
+//! judgement the entity makes about itself.
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+
+use super::store::{self, OutreachStore, Rating};
+use crate::config::OutreachConfig;
+use crate::events::SalienceKind;
+
+/// A cap that is currently halved because the response rate is below floor.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Tightening {
+    pub kind: SalienceKind,
+    pub base_cap: u32,
+    pub tightened_cap: u32,
+    pub response_rate: f64,
+    pub floor: f64,
+    pub window: usize,
+}
+
+/// Rolling response rate for `kind` over the last `window` messages.
+///
+/// `None` until a full window exists. A rate computed from three messages is
+/// noise, and halving a cap on a coin flip would make the control less
+/// trustworthy than no control — the 20-message window *is* the handling of
+/// the signal's weakness.
+#[must_use]
+pub fn response_rate(store: &OutreachStore, kind: SalienceKind, window: usize) -> Option<f64> {
+    if window == 0 {
+        return None;
+    }
+    let recent = store.recent(kind, window);
+    if recent.len() < window {
+        return None;
+    }
+    let responded = recent.iter().filter(|m| m.responded()).count();
+    Some(responded as f64 / recent.len() as f64)
+}
+
+/// The tightening in force for `kind`, if any.
+///
+/// This is a pure function of the current window, not a ratchet: if D starts
+/// responding again the cap comes back on its own. Neglect still holds it
+/// down, because neglect keeps the rate below the floor.
+#[must_use]
+pub fn tightening(
+    store: &OutreachStore,
+    config: &OutreachConfig,
+    kind: SalienceKind,
+) -> Option<Tightening> {
+    let base_cap = config.cap_for(kind)?;
+    let rate = response_rate(store, kind, config.feedback_window)?;
+    if rate >= config.response_rate_floor {
+        return None;
+    }
+    Some(Tightening {
+        kind,
+        base_cap,
+        // Integer halving, floor included: a `Development` cap of 1 halves to
+        // 0 and the kind goes silent. That is the spec's instruction taken
+        // literally, and it is survivable only because it is announced — D
+        // sees the notice and can retune. A `.max(1)` here would be a gate
+        // that never fully fires, which is the failure §2.4 is guarding.
+        tightened_cap: base_cap / 2,
+        response_rate: rate,
+        floor: config.response_rate_floor,
+        window: config.feedback_window,
+    })
+}
+
+/// The daily cap actually in force for `kind`. `None` is uncapped.
+#[must_use]
+pub fn effective_cap(
+    store: &OutreachStore,
+    config: &OutreachConfig,
+    kind: SalienceKind,
+) -> Option<u32> {
+    let base_cap = config.cap_for(kind)?;
+    Some(tightening(store, config, kind).map_or(base_cap, |t| t.tightened_cap))
+}
+
+/// Render the notice D gets when a cap tightens.
+///
+/// Plain and specific on purpose: the number that moved, the rate that moved
+/// it, and what silence now means. A notice D cannot act on is decoration.
+#[must_use]
+pub fn tightening_notice(tightening: &Tightening) -> String {
+    let consequence = if tightening.tightened_cap == 0 {
+        format!(
+            "No further `{}` outreach will be sent until this changes.",
+            tightening.kind
+        )
+    } else {
+        format!(
+            "At most {} `{}` message(s) a day from now on.",
+            tightening.tightened_cap, tightening.kind
+        )
+    };
+    format!(
+        "**Outreach cap tightened — {kind}**\n\
+         Response rate over the last {window} `{kind}` messages: {rate:.0}% \
+         (floor {floor:.0}%).\n\
+         Daily cap halved: {base} → {tightened}. {consequence}\n\
+         If these were useful and I simply did not see a reply, mark them with \
+         `pulse-null outreach respond <id> --rating useful` and the cap restores itself.",
+        kind = tightening.kind,
+        window = tightening.window,
+        rate = tightening.response_rate * 100.0,
+        floor = tightening.floor * 100.0,
+        base = tightening.base_cap,
+        tightened = tightening.tightened_cap,
+        consequence = consequence,
+    )
+}
+
+/// Record that D has been told about a tightening.
+///
+/// Called only after the notice is confirmed delivered. Recording it before
+/// delivery would let a failed webhook produce exactly the silent throttling
+/// §2.4 forbids: the cap halved, the record saying D knows, and D not knowing.
+pub async fn mark_announced(
+    root_dir: &Path,
+    tightening: &Tightening,
+    at: DateTime<Utc>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let (kind, cap) = (tightening.kind, tightening.tightened_cap);
+    store::save_delta_async(root_dir.to_path_buf(), move |s| {
+        s.record_announcement(kind, cap, at);
+    })
+    .await
+}
+
+/// Record D's response to an outreach message.
+///
+/// Returns `Ok(false)` when the id is unknown — a typo must not look like a
+/// recorded response.
+pub fn record_response(
+    root_dir: &Path,
+    id: &str,
+    rating: Option<Rating>,
+    at: DateTime<Utc>,
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    store::save_delta(root_dir, |s| s.mark_responded(id, at, rating))
+}
+
+/// Per-kind reporting line for `outreach status`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct KindStatus {
+    pub kind: SalienceKind,
+    pub base_cap: Option<u32>,
+    pub effective_cap: Option<u32>,
+    pub sent_today: u32,
+    pub response_rate: Option<f64>,
+    pub window_size: usize,
+    pub tightened: bool,
+    pub announced: bool,
+}
+
+/// Summarize one kind's budget and standing.
+#[must_use]
+pub fn kind_status(
+    store: &OutreachStore,
+    config: &OutreachConfig,
+    kind: SalienceKind,
+    timezone: &str,
+    now: DateTime<Utc>,
+) -> KindStatus {
+    let tz = super::resolve_timezone(timezone);
+    let tightening = tightening(store, config, kind);
+    KindStatus {
+        kind,
+        base_cap: config.cap_for(kind),
+        effective_cap: effective_cap(store, config, kind),
+        sent_today: store.sent_today(kind, tz, now),
+        response_rate: response_rate(store, kind, config.feedback_window),
+        window_size: store.recent(kind, config.feedback_window).len(),
+        tightened: tightening.is_some(),
+        announced: store.announced(kind).is_some(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::outreach::test_support::sent;
+    use chrono::Duration;
+
+    /// A store with `count` messages of `kind`, `responded` of them answered.
+    fn store_with(kind: SalienceKind, count: usize, responded: usize) -> OutreachStore {
+        let base: DateTime<Utc> = "2026-08-02T09:00:00Z".parse().unwrap();
+        let mut store = OutreachStore::default();
+        for i in 0..count {
+            store.record_sent(sent(
+                &format!("m{i}"),
+                kind,
+                base + Duration::minutes(i as i64),
+                i < responded,
+            ));
+        }
+        store
+    }
+
+    fn config() -> OutreachConfig {
+        OutreachConfig {
+            feedback_window: 4,
+            ..OutreachConfig::default()
+        }
+    }
+
+    #[test]
+    fn rate_is_none_until_the_window_is_full() {
+        let config = config();
+        let store = store_with(SalienceKind::Finding, 3, 3);
+        assert_eq!(
+            response_rate(&store, SalienceKind::Finding, config.feedback_window),
+            None
+        );
+        // A partial window must not tighten anything either.
+        assert!(tightening(&store, &config, SalienceKind::Finding).is_none());
+        assert_eq!(
+            effective_cap(&store, &config, SalienceKind::Finding),
+            Some(config.cap_finding)
+        );
+    }
+
+    #[test]
+    fn rate_counts_only_the_newest_window() {
+        let config = config();
+        // 8 messages, the first 4 answered and the last 4 not: the window
+        // sees only the recent silence.
+        let store = store_with(SalienceKind::Finding, 8, 4);
+        assert_eq!(
+            response_rate(&store, SalienceKind::Finding, config.feedback_window),
+            Some(0.0)
+        );
+    }
+
+    #[test]
+    fn rate_is_per_kind() {
+        let config = config();
+        let mut store = store_with(SalienceKind::Finding, 4, 0);
+        for i in 0..4 {
+            store.record_sent(sent(
+                &format!("c{i}"),
+                SalienceKind::Callback,
+                Utc::now(),
+                true,
+            ));
+        }
+        assert_eq!(
+            response_rate(&store, SalienceKind::Finding, config.feedback_window),
+            Some(0.0)
+        );
+        assert_eq!(
+            response_rate(&store, SalienceKind::Callback, config.feedback_window),
+            Some(1.0)
+        );
+    }
+
+    #[test]
+    fn a_rate_below_the_floor_halves_the_cap() {
+        let config = config();
+        // 1 of 4 answered = 0.25, below the 0.3 floor.
+        let store = store_with(SalienceKind::Finding, 4, 1);
+        let tightening = tightening(&store, &config, SalienceKind::Finding).unwrap();
+        assert_eq!(tightening.base_cap, 2);
+        assert_eq!(tightening.tightened_cap, 1);
+        assert_eq!(
+            effective_cap(&store, &config, SalienceKind::Finding),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn a_rate_at_the_floor_does_not_tighten() {
+        let config = OutreachConfig {
+            feedback_window: 10,
+            ..config()
+        };
+        // 3 of 10 = exactly the floor. "Below this" is strict.
+        let store = store_with(SalienceKind::Finding, 10, 3);
+        assert!(tightening(&store, &config, SalienceKind::Finding).is_none());
+    }
+
+    #[test]
+    fn development_halves_to_zero_and_says_so() {
+        let config = config();
+        let store = store_with(SalienceKind::Development, 4, 0);
+        let tightening = tightening(&store, &config, SalienceKind::Development).unwrap();
+        assert_eq!(tightening.base_cap, 1);
+        assert_eq!(tightening.tightened_cap, 0);
+
+        let notice = tightening_notice(&tightening);
+        assert!(notice.contains("1 → 0"), "{notice}");
+        assert!(
+            notice.contains("No further `development` outreach"),
+            "a cap of zero must state that the kind is silenced: {notice}"
+        );
+    }
+
+    #[test]
+    fn blocking_is_never_tightened_because_it_is_never_capped() {
+        let config = config();
+        let store = store_with(SalienceKind::Blocking, 20, 0);
+        assert!(tightening(&store, &config, SalienceKind::Blocking).is_none());
+        assert_eq!(effective_cap(&store, &config, SalienceKind::Blocking), None);
+    }
+
+    #[test]
+    fn neglect_tightens_rather_than_loosens() {
+        // Nobody responds to anything: every capped kind ends up halved.
+        let config = config();
+        for kind in [
+            SalienceKind::Finding,
+            SalienceKind::Development,
+            SalienceKind::Callback,
+        ] {
+            let store = store_with(kind, 4, 0);
+            let base = config.cap_for(kind).unwrap();
+            assert_eq!(
+                effective_cap(&store, &config, kind),
+                Some(base / 2),
+                "{kind} must tighten under neglect"
+            );
+        }
+    }
+
+    #[test]
+    fn the_cap_restores_when_responses_return() {
+        let config = config();
+        let mut store = store_with(SalienceKind::Finding, 4, 0);
+        assert_eq!(
+            effective_cap(&store, &config, SalienceKind::Finding),
+            Some(1)
+        );
+
+        // Four fresh answered messages push the silent ones out of the window.
+        for i in 0..4 {
+            store.record_sent(sent(
+                &format!("new{i}"),
+                SalienceKind::Finding,
+                Utc::now(),
+                true,
+            ));
+        }
+        assert_eq!(
+            effective_cap(&store, &config, SalienceKind::Finding),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn the_notice_names_the_rate_the_floor_and_the_movement() {
+        let config = config();
+        let store = store_with(SalienceKind::Finding, 4, 1);
+        let notice =
+            tightening_notice(&tightening(&store, &config, SalienceKind::Finding).unwrap());
+        assert!(notice.contains("25%"), "{notice}");
+        assert!(notice.contains("30%"), "{notice}");
+        assert!(notice.contains("2 → 1"), "{notice}");
+    }
+
+    #[test]
+    fn recording_a_response_lifts_the_rate() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = config();
+        let store = store_with(SalienceKind::Finding, 4, 0);
+        store::save(tmp.path(), &store).unwrap();
+
+        assert!(record_response(tmp.path(), "m0", Some(Rating::Useful), Utc::now()).unwrap());
+        assert!(record_response(tmp.path(), "m1", None, Utc::now()).unwrap());
+        assert!(!record_response(tmp.path(), "missing", None, Utc::now()).unwrap());
+
+        let reloaded = store::load(tmp.path());
+        assert_eq!(
+            response_rate(&reloaded, SalienceKind::Finding, config.feedback_window),
+            Some(0.5)
+        );
+        assert!(tightening(&reloaded, &config, SalienceKind::Finding).is_none());
+    }
+
+    #[test]
+    fn status_reports_cap_movement_and_window_fill() {
+        let config = config();
+        let now: DateTime<Utc> = "2026-08-02T12:00:00Z".parse().unwrap();
+        let store = store_with(SalienceKind::Finding, 4, 0);
+        let status = kind_status(&store, &config, SalienceKind::Finding, "UTC", now);
+
+        assert_eq!(status.base_cap, Some(2));
+        assert_eq!(status.effective_cap, Some(1));
+        assert!(status.tightened);
+        assert!(!status.announced, "nothing has been announced yet");
+        assert_eq!(status.sent_today, 4);
+        assert_eq!(status.window_size, 4);
+    }
+}

--- a/src/outreach/mod.rs
+++ b/src/outreach/mod.rs
@@ -1,0 +1,1357 @@
+//! Interest-triggered outreach — unprompted contact with content behind it.
+//!
+//! PN-94, `interest-triggered-outreach-spec.md`. Every unprompted message the
+//! entity could previously generate was, structurally, a status report: every
+//! event in the bus was about the health of the machinery, never about the
+//! thinking. [`crate::events::EntityEvent::Salience`] is the content event;
+//! this module is what stands between raising one and D's phone buzzing.
+//!
+//! ## What this module is for
+//!
+//! A self-triggered channel converges to noise, and it converges *silently*,
+//! because the entity's own estimate of message quality is exactly the
+//! faculty that would have to notice the drift. So nothing here asks the
+//! entity whether a message is worth sending. Three mechanical checks decide
+//! (§2.3), a clock and a counter decide when (§2.2, §2.5), and D's response
+//! behaviour — the only signal the entity cannot author — decides whether the
+//! checks were any good (§2.4, see [`feedback`]).
+//!
+//! ## Fail-closed everywhere
+//!
+//! Any path that cannot *prove* a candidate should go out rejects it: an
+//! unavailable novelty oracle, an unreadable store, a missing cost line. This
+//! is deliberate and asymmetric. Under-firing this channel is recoverable;
+//! over-firing it is not, because once D starts skimming past unprompted
+//! messages no config change brings the channel back (spec §6.4).
+
+pub mod feedback;
+pub mod novelty;
+pub mod store;
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::LazyLock;
+
+use chrono::{DateTime, Timelike, Utc};
+use chrono_tz::Tz;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::config::{Config, OutreachConfig};
+use crate::events::{EntityEvent, SalienceKind};
+use store::{OutreachStore, RejectedCandidate, SentMessage};
+
+// ---------------------------------------------------------------------------
+// Candidate
+// ---------------------------------------------------------------------------
+
+/// An outreach message before the gate has judged it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutreachCandidate {
+    pub kind: SalienceKind,
+    pub thread_id: Option<String>,
+    /// One sentence — the actual claim.
+    pub headline: String,
+    /// What makes it non-obvious, and where that came from.
+    pub evidence: String,
+    pub confidence: f64,
+}
+
+impl OutreachCandidate {
+    /// Read a candidate off a `Salience` event. Returns `None` for any other
+    /// event, so callers can filter without a second match.
+    #[must_use]
+    pub fn from_event(event: &EntityEvent) -> Option<Self> {
+        match event {
+            EntityEvent::Salience {
+                kind,
+                thread_id,
+                headline,
+                evidence,
+                confidence,
+            } => Some(Self {
+                kind: *kind,
+                thread_id: thread_id.clone(),
+                headline: headline.clone(),
+                evidence: evidence.clone(),
+                confidence: *confidence,
+            }),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gate 3 — what the message asks of D
+// ---------------------------------------------------------------------------
+
+/// What the message asks of D (spec §2.3.3).
+///
+/// Stating it is mandatory. A message that does not say what it wants leaves
+/// D to work that out, which is a cost the message imposed without declaring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Cost {
+    /// Asking for nothing — this is information, not a request.
+    Nothing,
+    /// Asking D to read something.
+    Read,
+    /// Asking D to decide something.
+    Decision,
+}
+
+impl Cost {
+    /// Parse the label used in a `[SALIENCE:]` marker's `cost` field.
+    #[must_use]
+    pub fn from_label(label: &str) -> Option<Self> {
+        let normalized = label.trim().to_ascii_lowercase();
+        if normalized.starts_with("nothing") || normalized == "none" {
+            Some(Self::Nothing)
+        } else if normalized.contains("decision") || normalized.contains("decide") {
+            Some(Self::Decision)
+        } else if normalized.contains("read") {
+            Some(Self::Read)
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Nothing => "nothing",
+            Self::Read => "read",
+            Self::Decision => "decision",
+        }
+    }
+}
+
+impl std::fmt::Display for Cost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A `Cost:` / `Asking:` line anywhere in the evidence.
+static COST_LINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?im)^\s*(?:cost|asking)\s*:\s*(.+)$").unwrap());
+
+/// Find the stated cost in `evidence`, if there is one.
+///
+/// The declaration lives in the evidence rather than in a sixth event field
+/// so that the check is a pure function of the event, whatever raised it —
+/// the self-authored marker today, the tension store in Phase 2.
+#[must_use]
+pub fn stated_cost(evidence: &str) -> Option<Cost> {
+    COST_LINE_RE
+        .captures_iter(evidence)
+        .find_map(|c| Cost::from_label(&c[1]))
+}
+
+// ---------------------------------------------------------------------------
+// Gate 2 — external referent
+// ---------------------------------------------------------------------------
+
+/// An anchor in `evidence` that the entity did not author (spec §2.3.2).
+///
+/// This is the load-bearing gate. "I've been thinking about this" is exactly
+/// the message an LLM can generate infinitely and convincingly with nothing
+/// behind it; the fraction of the content that can correct the entity is the
+/// fraction it did not write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalReferent {
+    /// `path/to/file.rs:128` — a file path with a line number.
+    FileLine(String),
+    /// The id of a prediction that has actually resolved.
+    PredictionId(String),
+    /// A fetched source, cited by URL.
+    Url(String),
+    /// A number attributed to a tool run — a digit inside a backticked span
+    /// or a `$ `-prefixed shell line.
+    ToolMeasurement(String),
+}
+
+impl std::fmt::Display for ExternalReferent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FileLine(v) => write!(f, "file:line {v}"),
+            Self::PredictionId(v) => write!(f, "resolved prediction {v}"),
+            Self::Url(v) => write!(f, "url {v}"),
+            Self::ToolMeasurement(v) => write!(f, "tool measurement {v}"),
+        }
+    }
+}
+
+static FILE_LINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"([A-Za-z0-9_./\-]+\.[A-Za-z0-9_]+:\d+)").unwrap());
+
+static URL_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"https?://[^\s)\]]+").unwrap());
+
+static UUID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+        .unwrap()
+});
+
+/// A backticked span that looks like a command rather than an identifier —
+/// it contains whitespace, so `rg -c unwrap src/` matches and `unwrap` does
+/// not.
+static COMMAND_SPAN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"`[^`\n]*\s[^`\n]*`").unwrap());
+
+/// A line that cites a command *and* reports a number.
+///
+/// "Derived from a tool run" is not mechanically verifiable, so this is the
+/// closest honest proxy: the number and the invocation that produced it, on
+/// one line. Two weaker readings are deliberately rejected. A bare digit is
+/// not enough — "I've been chewing on this for 3 days" would clear a
+/// digits-anywhere check, and would clear it *forever*, gutting the one gate
+/// the spec says must never be softened. A backticked identifier is not a
+/// command, so the span has to contain whitespace.
+fn find_tool_measurement(evidence: &str) -> Option<String> {
+    evidence.lines().find_map(|line| {
+        if !line.chars().any(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        if let Some(command) = COMMAND_SPAN_RE.find(line) {
+            return Some(command.as_str().to_string());
+        }
+        let trimmed = line.trim_start();
+        trimmed
+            .starts_with("$ ")
+            .then(|| trimmed.trim_end().to_string())
+    })
+}
+
+/// Documents the entity writes itself.
+///
+/// A file reference into one of these is self-authored prose wearing a file
+/// path. It still counts for most kinds — quoting your own journal with a
+/// line number is at least checkable — but not for `Development`, the kind
+/// that can be manufactured at will and for which gate 2 should be stricter,
+/// never softer (spec §6.1).
+const SELF_AUTHORED_DOCS: &[&str] = &[
+    "LEARNING.md",
+    "THOUGHTS.md",
+    "CURIOSITY.md",
+    "REFLECTIONS.md",
+    "PRAXIS.md",
+    "FINDINGS.md",
+    "LOGBOOK.md",
+    "SELF.md",
+    "MEMORY.md",
+    "EPHEMERAL.md",
+    "THOUGHT_STACK.md",
+];
+
+/// Whether `path` names one of the entity's own journal documents.
+fn is_self_authored(path: &str) -> bool {
+    let file = path.rsplit('/').next().unwrap_or(path);
+    let file = file.split(':').next().unwrap_or(file);
+    SELF_AUTHORED_DOCS
+        .iter()
+        .any(|d| d.eq_ignore_ascii_case(file))
+}
+
+/// Find the strongest external referent in `evidence`, if any.
+///
+/// `resolved_predictions` gates the prediction-id form: an id that has not
+/// resolved points at the entity's own expectation, which is not evidence of
+/// anything yet.
+#[must_use]
+pub fn find_referent(
+    evidence: &str,
+    kind: SalienceKind,
+    resolved_predictions: &HashSet<String>,
+) -> Option<ExternalReferent> {
+    if let Some(id) = UUID_RE
+        .find_iter(evidence)
+        .map(|m| m.as_str().to_string())
+        .find(|id| resolved_predictions.contains(id))
+    {
+        return Some(ExternalReferent::PredictionId(id));
+    }
+
+    if let Some(url) = URL_RE.find(evidence) {
+        return Some(ExternalReferent::Url(url.as_str().to_string()));
+    }
+
+    if let Some(file) = FILE_LINE_RE
+        .find_iter(evidence)
+        .map(|m| m.as_str().to_string())
+        .find(|f| kind != SalienceKind::Development || !is_self_authored(f))
+    {
+        return Some(ExternalReferent::FileLine(file));
+    }
+
+    find_tool_measurement(evidence).map(ExternalReferent::ToolMeasurement)
+}
+
+// ---------------------------------------------------------------------------
+// Gate 1 — novelty against the record
+// ---------------------------------------------------------------------------
+
+/// Semantic novelty oracle for gate 1 (spec §2.3.1).
+///
+/// Kept as a trait so the gate can be tested without loading an ONNX model,
+/// and so a future corpus (the graph, the tension store) can be swapped in
+/// without touching the gate. Implementors must return a similarity in
+/// `[0, 1]`; an `Err` means novelty is *unknown*, which the gate treats as a
+/// rejection, never as a pass.
+pub trait NoveltyIndex: Send + Sync {
+    /// Highest similarity between `headline` and any entry in `corpus`.
+    /// An empty corpus is maximal novelty: `0.0`.
+    fn max_similarity(&self, headline: &str, corpus: &[String]) -> Result<f64, String>;
+}
+
+// ---------------------------------------------------------------------------
+// Rejections
+// ---------------------------------------------------------------------------
+
+/// Why a candidate did not go out.
+///
+/// Recorded in `outreach.json` and shown by `outreach status`. A gate whose
+/// rejections are invisible cannot be audited by anyone, including by the
+/// thing it is gating (spec §7.2); a gate that never rejects is not a gate
+/// (spec §8).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RejectionReason {
+    /// `[outreach] enabled = false`.
+    Disabled,
+    /// The candidate is not well-formed enough to judge.
+    Malformed { detail: String },
+    /// Gate 2: nothing in the evidence that the entity did not author.
+    NoExternalReferent,
+    /// Gate 3: the message never says what it is asking for.
+    NoCostStated,
+    /// Gate 1: the headline restates something already on the record.
+    Restatement { similarity: f64 },
+    /// Gate 1 could not be evaluated. Unknown novelty is not novelty.
+    NoveltyUnavailable { detail: String },
+    /// Inside the quiet window, and not `Blocking`.
+    QuietHours { local_hour: u32 },
+    /// The kind has spent its budget for D's local day.
+    DailyCapReached { cap: u32, sent_today: u32 },
+    /// The store could not be read or written. Nothing goes out blind.
+    StoreUnavailable { detail: String },
+}
+
+impl std::fmt::Display for RejectionReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disabled => write!(f, "outreach disabled"),
+            Self::Malformed { detail } => write!(f, "malformed candidate: {detail}"),
+            Self::NoExternalReferent => write!(
+                f,
+                "no external referent — evidence is entirely self-authored"
+            ),
+            Self::NoCostStated => write!(f, "no stated cost to D"),
+            Self::Restatement { similarity } => {
+                write!(f, "restates the record (similarity {similarity:.3})")
+            }
+            Self::NoveltyUnavailable { detail } => {
+                write!(f, "novelty could not be checked: {detail}")
+            }
+            Self::QuietHours { local_hour } => {
+                write!(f, "quiet hours (local hour {local_hour})")
+            }
+            Self::DailyCapReached { cap, sent_today } => {
+                write!(f, "daily cap reached ({sent_today}/{cap})")
+            }
+            Self::StoreUnavailable { detail } => write!(f, "outreach store unavailable: {detail}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+/// What the gate found when a candidate passed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GatePass {
+    pub referent: ExternalReferent,
+    pub cost: Cost,
+    pub similarity: f64,
+}
+
+/// Everything the gate needs that is not in the candidate.
+pub struct GateContext<'a> {
+    pub novelty: &'a dyn NoveltyIndex,
+    /// Prior outreach headlines plus journal entries.
+    pub corpus: &'a [String],
+    pub resolved_predictions: &'a HashSet<String>,
+    pub novelty_similarity_max: f64,
+}
+
+/// Run the three checks of spec §2.3. All three must pass.
+///
+/// Order is cheapest-first — referent, cost, then novelty — rather than the
+/// spec's numbering. The result is identical (a candidate passes only by
+/// clearing all three) but a message with no URL in it no longer loads a
+/// 130 MB embedding model to find that out, and the reported reason is the
+/// more actionable of the two.
+pub fn evaluate_gate(
+    candidate: &OutreachCandidate,
+    ctx: &GateContext<'_>,
+) -> Result<GatePass, RejectionReason> {
+    if candidate.headline.trim().is_empty() {
+        return Err(RejectionReason::Malformed {
+            detail: "empty headline".into(),
+        });
+    }
+    if candidate.evidence.trim().is_empty() {
+        return Err(RejectionReason::Malformed {
+            detail: "empty evidence".into(),
+        });
+    }
+    if !(0.0..=1.0).contains(&candidate.confidence) {
+        return Err(RejectionReason::Malformed {
+            detail: format!("confidence {} outside [0,1]", candidate.confidence),
+        });
+    }
+
+    // Gate 2 — external referent.
+    let referent = find_referent(
+        &candidate.evidence,
+        candidate.kind,
+        ctx.resolved_predictions,
+    )
+    .ok_or(RejectionReason::NoExternalReferent)?;
+
+    // Gate 3 — cost to D is stated.
+    let cost = stated_cost(&candidate.evidence).ok_or(RejectionReason::NoCostStated)?;
+
+    // Gate 1 — novelty against the record.
+    let similarity = ctx
+        .novelty
+        .max_similarity(&candidate.headline, ctx.corpus)
+        .map_err(|detail| RejectionReason::NoveltyUnavailable { detail })?;
+    if similarity >= ctx.novelty_similarity_max {
+        return Err(RejectionReason::Restatement { similarity });
+    }
+
+    Ok(GatePass {
+        referent,
+        cost,
+        similarity,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Timing and budget
+// ---------------------------------------------------------------------------
+
+/// Whether `hour` falls inside the quiet window, which may wrap midnight.
+///
+/// `start == end` means *no* quiet hours, not a 24-hour blackout. A blackout
+/// is a channel-killing configuration and has to be spelled with an explicit
+/// `enabled = false`, where it is visible.
+#[must_use]
+pub fn is_quiet_hour(hour: u32, start: u32, end: u32) -> bool {
+    if start == end {
+        return false;
+    }
+    if start < end {
+        hour >= start && hour < end
+    } else {
+        hour >= start || hour < end
+    }
+}
+
+/// Quiet-hours check. `Blocking` overrides the window; nothing else does
+/// (spec §2.5) — work stalling overnight is worse than a buzz at 3am.
+pub fn check_quiet_hours(
+    kind: SalienceKind,
+    local_hour: u32,
+    config: &OutreachConfig,
+) -> Result<(), RejectionReason> {
+    if kind == SalienceKind::Blocking {
+        return Ok(());
+    }
+    if is_quiet_hour(local_hour, config.quiet_hours_start, config.quiet_hours_end) {
+        return Err(RejectionReason::QuietHours { local_hour });
+    }
+    Ok(())
+}
+
+/// Daily-budget check. `effective_cap` of `None` is uncapped (`Blocking`).
+pub fn check_cap(sent_today: u32, effective_cap: Option<u32>) -> Result<(), RejectionReason> {
+    match effective_cap {
+        None => Ok(()),
+        Some(cap) if sent_today < cap => Ok(()),
+        Some(cap) => Err(RejectionReason::DailyCapReached { cap, sent_today }),
+    }
+}
+
+/// Resolve the configured scheduler timezone, falling back to UTC.
+///
+/// The fallback is loud but not fatal: a bad timezone must not silence the
+/// channel, and UTC is at worst an hour or two off D's quiet window.
+#[must_use]
+pub fn resolve_timezone(name: &str) -> Tz {
+    name.parse().unwrap_or_else(|_| {
+        tracing::warn!(timezone = name, "Invalid timezone for outreach, using UTC");
+        Tz::UTC
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Admission
+// ---------------------------------------------------------------------------
+
+/// The verdict on one candidate.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decision {
+    /// Cleared to send; `id` identifies the recorded [`SentMessage`].
+    Admitted {
+        id: String,
+    },
+    Rejected(RejectionReason),
+}
+
+/// The outcome of one admission, including anything D must be told.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Admission {
+    pub decision: Decision,
+    /// Set when the cap for this kind is halved and D has not been told yet.
+    ///
+    /// Carried on rejections as well as admissions, deliberately: a cap
+    /// halved to zero admits nothing, so a notice conditional on admission
+    /// would never fire — the exact silent death §2.4 forbids.
+    pub pending_notice: Option<feedback::Tightening>,
+}
+
+#[cfg(test)]
+impl Admission {
+    fn is_admitted(&self) -> bool {
+        matches!(self.decision, Decision::Admitted { .. })
+    }
+}
+
+/// Everything one admission depends on that is not the candidate.
+pub struct AdmissionContext<'a> {
+    pub root_dir: &'a Path,
+    pub config: &'a Config,
+    pub novelty: &'a dyn NoveltyIndex,
+    pub now: DateTime<Utc>,
+}
+
+/// Judge one candidate and, if it survives, record it as sent.
+///
+/// The decision and the write that records it happen inside a single locked
+/// read-modify-write, so two candidates racing on a cap of one cannot both
+/// observe an empty budget.
+///
+/// Blocking: loads the store under an flock and may load the embedding model.
+/// Async callers must go through [`admit_async`].
+pub fn admit(ctx: &AdmissionContext<'_>, candidate: &OutreachCandidate) -> Admission {
+    let outreach = &ctx.config.outreach;
+    if !outreach.enabled {
+        return Admission {
+            decision: Decision::Rejected(RejectionReason::Disabled),
+            pending_notice: None,
+        };
+    }
+
+    let tz = resolve_timezone(&ctx.config.scheduler.timezone);
+    let local_hour = ctx.now.with_timezone(&tz).hour();
+    let resolved_predictions = store::resolved_prediction_ids(ctx.root_dir);
+    let root_dir = ctx.root_dir.to_path_buf();
+
+    let result = store::save_delta(ctx.root_dir, |s| {
+        let notice = reconcile_tightening(s, outreach, candidate.kind);
+        let decision = decide(DecisionInputs {
+            store: s,
+            candidate,
+            outreach,
+            novelty: ctx.novelty,
+            resolved_predictions: &resolved_predictions,
+            root_dir: &root_dir,
+            tz,
+            local_hour,
+            now: ctx.now,
+        });
+        if let Decision::Rejected(ref reason) = decision {
+            s.record_rejection(RejectedCandidate {
+                kind: candidate.kind,
+                headline: candidate.headline.clone(),
+                reason: reason.clone(),
+                rejected_at: ctx.now,
+            });
+        }
+        Admission {
+            decision,
+            pending_notice: notice,
+        }
+    });
+
+    result.unwrap_or_else(|e| {
+        // The store is the only memory the caps have. Without it there is no
+        // way to know what has already gone out today, so nothing goes out.
+        tracing::error!(error = %e, "Outreach store unavailable — candidate rejected");
+        Admission {
+            decision: Decision::Rejected(RejectionReason::StoreUnavailable {
+                detail: e.to_string(),
+            }),
+            pending_notice: None,
+        }
+    })
+}
+
+/// Async wrapper for [`admit`] — the flock and the ONNX model load must never
+/// park a tokio worker.
+pub async fn admit_async(
+    root_dir: std::path::PathBuf,
+    config: std::sync::Arc<Config>,
+    candidate: OutreachCandidate,
+    now: DateTime<Utc>,
+) -> Admission {
+    let joined = tokio::task::spawn_blocking(move || {
+        let novelty = novelty::EmbeddingNovelty::new(&root_dir);
+        admit(
+            &AdmissionContext {
+                root_dir: &root_dir,
+                config: &config,
+                novelty: &novelty,
+                now,
+            },
+            &candidate,
+        )
+    })
+    .await;
+
+    joined.unwrap_or_else(|e| {
+        tracing::error!(error = %e, "Outreach admission panicked — candidate rejected");
+        Admission {
+            decision: Decision::Rejected(RejectionReason::StoreUnavailable {
+                detail: format!("admission task failed: {e}"),
+            }),
+            pending_notice: None,
+        }
+    })
+}
+
+/// Inputs to [`decide`], grouped so the decision reads as one step.
+struct DecisionInputs<'a> {
+    store: &'a mut OutreachStore,
+    candidate: &'a OutreachCandidate,
+    outreach: &'a OutreachConfig,
+    novelty: &'a dyn NoveltyIndex,
+    resolved_predictions: &'a HashSet<String>,
+    root_dir: &'a Path,
+    tz: Tz,
+    local_hour: u32,
+    now: DateTime<Utc>,
+}
+
+/// Gate, then timing, then budget — and record the send on success.
+fn decide(inputs: DecisionInputs<'_>) -> Decision {
+    let DecisionInputs {
+        store,
+        candidate,
+        outreach,
+        novelty,
+        resolved_predictions,
+        root_dir,
+        tz,
+        local_hour,
+        now,
+    } = inputs;
+
+    if let Err(reason) = check_quiet_hours(candidate.kind, local_hour, outreach) {
+        return Decision::Rejected(reason);
+    }
+
+    let cap = feedback::effective_cap(store, outreach, candidate.kind);
+    if let Err(reason) = check_cap(store.sent_today(candidate.kind, tz, now), cap) {
+        return Decision::Rejected(reason);
+    }
+
+    let corpus = novelty::build_corpus(root_dir, store);
+    let gate = evaluate_gate(
+        candidate,
+        &GateContext {
+            novelty,
+            corpus: &corpus,
+            resolved_predictions,
+            novelty_similarity_max: outreach.novelty_similarity_max,
+        },
+    );
+    let pass = match gate {
+        Ok(pass) => pass,
+        Err(reason) => return Decision::Rejected(reason),
+    };
+
+    let id = format!("outreach-{}", &uuid::Uuid::new_v4().to_string()[..8]);
+    store.record_sent(SentMessage {
+        id: id.clone(),
+        kind: candidate.kind,
+        thread_id: candidate.thread_id.clone(),
+        headline: candidate.headline.clone(),
+        evidence: candidate.evidence.clone(),
+        confidence: candidate.confidence,
+        cost: pass.cost,
+        sent_at: now,
+        responded_at: None,
+        rating: None,
+    });
+    Decision::Admitted { id }
+}
+
+/// Bring the store's announcement bookkeeping in line with the current
+/// response rate, returning the notice D still owes.
+///
+/// Returns `Some` only on the transition into a tightening D has not been
+/// told about. A lifted tightening clears the record silently — restoring a
+/// cap is not throttling, and spending the channel to say so would be.
+fn reconcile_tightening(
+    store: &mut OutreachStore,
+    config: &OutreachConfig,
+    kind: SalienceKind,
+) -> Option<feedback::Tightening> {
+    let Some(tightening) = feedback::tightening(store, config, kind) else {
+        store.clear_announcement(kind);
+        return None;
+    };
+    let already_told = store
+        .announced(kind)
+        .is_some_and(|a| a.tightened_cap == tightening.tightened_cap);
+    (!already_told).then_some(tightening)
+}
+
+#[cfg(test)]
+pub mod test_support {
+    use super::*;
+    use crate::config::test_support::minimal_config;
+    use store::SentMessage;
+
+    /// A novelty oracle that always returns the same similarity.
+    pub struct FixedNovelty(pub f64);
+
+    impl NoveltyIndex for FixedNovelty {
+        fn max_similarity(&self, _headline: &str, _corpus: &[String]) -> Result<f64, String> {
+            Ok(self.0)
+        }
+    }
+
+    /// A novelty oracle that cannot answer — the fail-closed path.
+    pub struct BrokenNovelty;
+
+    impl NoveltyIndex for BrokenNovelty {
+        fn max_similarity(&self, _headline: &str, _corpus: &[String]) -> Result<f64, String> {
+            Err("model unavailable".into())
+        }
+    }
+
+    /// Evidence that clears gates 2 and 3.
+    pub fn good_evidence() -> String {
+        "src/scheduler/runner.rs:536 parses markers before the isolation check.\nCost: read"
+            .to_string()
+    }
+
+    /// A candidate that clears every mechanical check.
+    pub fn candidate(kind: SalienceKind, headline: &str) -> OutreachCandidate {
+        OutreachCandidate {
+            kind,
+            thread_id: None,
+            headline: headline.to_string(),
+            evidence: good_evidence(),
+            confidence: 0.7,
+        }
+    }
+
+    /// A config with outreach at spec defaults and a fixed timezone.
+    pub fn config(timezone: &str) -> Config {
+        let mut config = minimal_config();
+        config.scheduler.timezone = timezone.to_string();
+        config
+    }
+
+    /// A sent message, optionally already responded to.
+    pub fn sent(id: &str, kind: SalienceKind, at: DateTime<Utc>, responded: bool) -> SentMessage {
+        SentMessage {
+            id: id.to_string(),
+            kind,
+            thread_id: None,
+            headline: format!("headline {id}"),
+            evidence: good_evidence(),
+            confidence: 0.7,
+            cost: Cost::Read,
+            sent_at: at,
+            responded_at: responded.then_some(at),
+            rating: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::*;
+    use super::*;
+    use tempfile::TempDir;
+
+    fn no_predictions() -> HashSet<String> {
+        HashSet::new()
+    }
+
+    // --- gate 2: external referent ---------------------------------------
+
+    #[test]
+    fn self_authored_prose_has_no_referent() {
+        let evidence = "I have been thinking about this for a while and it feels important.";
+        assert!(find_referent(evidence, SalienceKind::Finding, &no_predictions()).is_none());
+    }
+
+    #[test]
+    fn file_and_line_is_a_referent() {
+        let evidence = "See src/events/listener.rs:117 — isolation sheds before translate.";
+        assert_eq!(
+            find_referent(evidence, SalienceKind::Finding, &no_predictions()),
+            Some(ExternalReferent::FileLine(
+                "src/events/listener.rs:117".into()
+            ))
+        );
+    }
+
+    #[test]
+    fn a_bare_file_path_without_a_line_is_not_a_referent() {
+        let evidence = "See src/events/listener.rs for the details.";
+        assert!(find_referent(evidence, SalienceKind::Finding, &no_predictions()).is_none());
+    }
+
+    #[test]
+    fn url_is_a_referent() {
+        let evidence = "Per https://doc.rust-lang.org/nomicon/ the invariant holds.";
+        assert_eq!(
+            find_referent(evidence, SalienceKind::Callback, &no_predictions()),
+            Some(ExternalReferent::Url(
+                "https://doc.rust-lang.org/nomicon/".into()
+            ))
+        );
+    }
+
+    #[test]
+    fn only_a_resolved_prediction_id_is_a_referent() {
+        let id = "6f1f7b3a-2c4d-4e5f-8a9b-0c1d2e3f4a5b";
+        let evidence = format!("Prediction {id} came in low.");
+        assert!(find_referent(&evidence, SalienceKind::Callback, &no_predictions()).is_none());
+
+        let resolved: HashSet<String> = [id.to_string()].into_iter().collect();
+        assert_eq!(
+            find_referent(&evidence, SalienceKind::Callback, &resolved),
+            Some(ExternalReferent::PredictionId(id.into()))
+        );
+    }
+
+    #[test]
+    fn a_bare_number_is_not_a_tool_measurement() {
+        // The trivial bypass: any prose can carry a digit.
+        let evidence = "I have been chewing on this for 3 days and it changed shape.";
+        assert!(find_referent(evidence, SalienceKind::Development, &no_predictions()).is_none());
+    }
+
+    #[test]
+    fn a_number_beside_a_cited_command_is_a_tool_measurement() {
+        let evidence = "`rg -c 'unwrap' src/ | wc -l` returns 412 call sites.";
+        assert!(matches!(
+            find_referent(evidence, SalienceKind::Finding, &no_predictions()),
+            Some(ExternalReferent::ToolMeasurement(_))
+        ));
+        // A shell transcript line works too.
+        let evidence = "  $ cargo test --features discord-text  # 901 passing";
+        assert!(matches!(
+            find_referent(evidence, SalienceKind::Finding, &no_predictions()),
+            Some(ExternalReferent::ToolMeasurement(_))
+        ));
+    }
+
+    #[test]
+    fn a_backticked_identifier_is_not_a_command() {
+        // `outreach` is a name, not an invocation; pairing it with a digit
+        // must not manufacture evidence out of prose.
+        let evidence = "The `outreach` module has 3 gates.";
+        assert!(find_referent(evidence, SalienceKind::Finding, &no_predictions()).is_none());
+    }
+
+    #[test]
+    fn a_cited_command_without_a_number_is_not_a_measurement() {
+        let evidence = "I ran `cargo clippy --all-targets` and thought about it.";
+        assert!(find_referent(evidence, SalienceKind::Finding, &no_predictions()).is_none());
+    }
+
+    #[test]
+    fn the_number_must_share_a_line_with_the_command() {
+        // Otherwise any command citation anywhere licenses any number
+        // anywhere, which is the digits-anywhere check with extra steps.
+        let evidence = "I ran `cargo clippy --all-targets`.\nIt has been 3 days since then.";
+        assert!(find_referent(evidence, SalienceKind::Finding, &no_predictions()).is_none());
+    }
+
+    #[test]
+    fn development_gets_no_referent_from_the_entitys_own_journal() {
+        // Spec §6.1: gate 2 must be stricter for Development, never softer.
+        // Quoting your own THOUGHTS.md with a line number is still prose you
+        // wrote.
+        let evidence = "THOUGHTS.md:42 says the same thing I am saying now.\nCost: nothing";
+        assert!(find_referent(evidence, SalienceKind::Development, &no_predictions()).is_none());
+        // Other kinds may still cite it — the strictness is targeted.
+        assert!(find_referent(evidence, SalienceKind::Finding, &no_predictions()).is_some());
+    }
+
+    #[test]
+    fn development_still_accepts_a_real_external_file() {
+        let evidence = "src/outreach/mod.rs:12 changed shape once the caps landed.";
+        assert!(find_referent(evidence, SalienceKind::Development, &no_predictions()).is_some());
+    }
+
+    // --- gate 3: stated cost ---------------------------------------------
+
+    #[test]
+    fn cost_is_parsed_from_either_keyword() {
+        assert_eq!(stated_cost("Cost: nothing"), Some(Cost::Nothing));
+        assert_eq!(stated_cost("asking: a decision"), Some(Cost::Decision));
+        assert_eq!(stated_cost("  Cost:  a read  "), Some(Cost::Read));
+        assert_eq!(
+            stated_cost("evidence\nCost: DECISION"),
+            Some(Cost::Decision)
+        );
+    }
+
+    #[test]
+    fn missing_cost_line_is_none() {
+        assert_eq!(stated_cost("no declaration anywhere"), None);
+        assert_eq!(stated_cost("Cost: something unparseable"), None);
+    }
+
+    // --- the gate as a whole ---------------------------------------------
+
+    #[test]
+    fn a_complete_candidate_passes() {
+        let candidate = candidate(SalienceKind::Finding, "The listener sheds during isolation");
+        let pass = evaluate_gate(
+            &candidate,
+            &GateContext {
+                novelty: &FixedNovelty(0.2),
+                corpus: &[],
+                resolved_predictions: &no_predictions(),
+                novelty_similarity_max: 0.85,
+            },
+        )
+        .unwrap();
+        assert_eq!(pass.cost, Cost::Read);
+    }
+
+    #[test]
+    fn a_restatement_is_rejected() {
+        let candidate = candidate(SalienceKind::Finding, "Something I already said");
+        let err = evaluate_gate(
+            &candidate,
+            &GateContext {
+                novelty: &FixedNovelty(0.91),
+                corpus: &["Something I already said".to_string()],
+                resolved_predictions: &no_predictions(),
+                novelty_similarity_max: 0.85,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, RejectionReason::Restatement { .. }));
+    }
+
+    #[test]
+    fn unknown_novelty_fails_closed() {
+        // An oracle that cannot answer must not be read as "novel enough".
+        let candidate = candidate(SalienceKind::Finding, "A genuinely new claim");
+        let err = evaluate_gate(
+            &candidate,
+            &GateContext {
+                novelty: &BrokenNovelty,
+                corpus: &[],
+                resolved_predictions: &no_predictions(),
+                novelty_similarity_max: 0.85,
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, RejectionReason::NoveltyUnavailable { .. }));
+    }
+
+    #[test]
+    fn gate_two_is_not_softened_for_development() {
+        // The whole point of PN-94's risk §6.1.
+        let mut candidate = candidate(SalienceKind::Development, "My thinking changed shape");
+        candidate.evidence = "I sat with this and it reorganized itself.\nCost: nothing".into();
+        let err = evaluate_gate(
+            &candidate,
+            &GateContext {
+                novelty: &FixedNovelty(0.0),
+                corpus: &[],
+                resolved_predictions: &no_predictions(),
+                novelty_similarity_max: 0.85,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, RejectionReason::NoExternalReferent);
+    }
+
+    #[test]
+    fn missing_cost_is_rejected_even_with_a_referent() {
+        let mut candidate = candidate(SalienceKind::Finding, "A real finding");
+        candidate.evidence = "src/main.rs:12 does the thing".into();
+        let err = evaluate_gate(
+            &candidate,
+            &GateContext {
+                novelty: &FixedNovelty(0.0),
+                corpus: &[],
+                resolved_predictions: &no_predictions(),
+                novelty_similarity_max: 0.85,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, RejectionReason::NoCostStated);
+    }
+
+    #[test]
+    fn malformed_candidates_are_rejected_before_anything_else() {
+        let mut empty = candidate(SalienceKind::Finding, "  ");
+        assert!(matches!(
+            evaluate_gate(
+                &empty,
+                &GateContext {
+                    novelty: &BrokenNovelty,
+                    corpus: &[],
+                    resolved_predictions: &no_predictions(),
+                    novelty_similarity_max: 0.85,
+                }
+            ),
+            Err(RejectionReason::Malformed { .. })
+        ));
+
+        empty = candidate(SalienceKind::Finding, "ok");
+        empty.confidence = 1.4;
+        assert!(matches!(
+            evaluate_gate(
+                &empty,
+                &GateContext {
+                    novelty: &BrokenNovelty,
+                    corpus: &[],
+                    resolved_predictions: &no_predictions(),
+                    novelty_similarity_max: 0.85,
+                }
+            ),
+            Err(RejectionReason::Malformed { .. })
+        ));
+    }
+
+    // --- quiet hours ------------------------------------------------------
+
+    #[test]
+    fn quiet_window_wraps_midnight() {
+        for hour in [23, 0, 3, 7] {
+            assert!(is_quiet_hour(hour, 23, 8), "hour {hour} should be quiet");
+        }
+        for hour in [8, 12, 22] {
+            assert!(!is_quiet_hour(hour, 23, 8), "hour {hour} should be loud");
+        }
+    }
+
+    #[test]
+    fn quiet_window_without_wrap() {
+        assert!(is_quiet_hour(2, 1, 5));
+        assert!(!is_quiet_hour(5, 1, 5));
+        assert!(!is_quiet_hour(0, 1, 5));
+    }
+
+    #[test]
+    fn equal_bounds_mean_no_quiet_hours_not_a_blackout() {
+        for hour in 0..24 {
+            assert!(!is_quiet_hour(hour, 0, 0));
+        }
+    }
+
+    #[test]
+    fn blocking_overrides_quiet_hours_and_nothing_else_does() {
+        let config = OutreachConfig::default();
+        assert!(check_quiet_hours(SalienceKind::Blocking, 3, &config).is_ok());
+        for kind in [
+            SalienceKind::Finding,
+            SalienceKind::Development,
+            SalienceKind::Callback,
+        ] {
+            assert!(matches!(
+                check_quiet_hours(kind, 3, &config),
+                Err(RejectionReason::QuietHours { local_hour: 3 })
+            ));
+        }
+    }
+
+    // --- caps -------------------------------------------------------------
+
+    #[test]
+    fn cap_admits_below_and_rejects_at_the_limit() {
+        assert!(check_cap(0, Some(1)).is_ok());
+        assert!(check_cap(1, Some(1)).is_err());
+        assert!(check_cap(9_999, None).is_ok(), "Blocking is uncapped");
+        assert!(
+            check_cap(0, Some(0)).is_err(),
+            "a cap of zero admits nothing"
+        );
+    }
+
+    // --- admission end to end --------------------------------------------
+
+    fn admit_at(
+        root: &Path,
+        config: &Config,
+        candidate: &OutreachCandidate,
+        now: DateTime<Utc>,
+    ) -> Admission {
+        admit(
+            &AdmissionContext {
+                root_dir: root,
+                config,
+                novelty: &FixedNovelty(0.1),
+                now,
+            },
+            candidate,
+        )
+    }
+
+    #[test]
+    fn admission_records_the_send_and_enforces_the_daily_cap() {
+        let tmp = TempDir::new().unwrap();
+        let config = config("UTC");
+        let noon: DateTime<Utc> = "2026-08-02T12:00:00Z".parse().unwrap();
+
+        // cap_development = 1: the first lands, the second does not.
+        let first = candidate(SalienceKind::Development, "first development");
+        let second = candidate(SalienceKind::Development, "second development");
+        assert!(admit_at(tmp.path(), &config, &first, noon).is_admitted());
+        let rejected = admit_at(tmp.path(), &config, &second, noon);
+        assert!(matches!(
+            rejected.decision,
+            Decision::Rejected(RejectionReason::DailyCapReached { cap: 1, .. })
+        ));
+
+        let store = store::load(tmp.path());
+        assert_eq!(store.sent.len(), 1);
+        assert_eq!(store.rejections.len(), 1);
+
+        // Tomorrow the budget is fresh.
+        let tomorrow: DateTime<Utc> = "2026-08-03T12:00:00Z".parse().unwrap();
+        assert!(admit_at(tmp.path(), &config, &second, tomorrow).is_admitted());
+    }
+
+    #[test]
+    fn blocking_is_uncapped_and_ignores_quiet_hours() {
+        let tmp = TempDir::new().unwrap();
+        let config = config("UTC");
+        let three_am: DateTime<Utc> = "2026-08-02T03:00:00Z".parse().unwrap();
+
+        for i in 0..5 {
+            let candidate = candidate(SalienceKind::Blocking, &format!("blocked on thing {i}"));
+            assert!(
+                admit_at(tmp.path(), &config, &candidate, three_am).is_admitted(),
+                "Blocking #{i} must go out"
+            );
+        }
+        assert_eq!(store::load(tmp.path()).sent.len(), 5);
+    }
+
+    #[test]
+    fn quiet_hours_reject_non_blocking_kinds() {
+        let tmp = TempDir::new().unwrap();
+        let config = config("UTC");
+        let three_am: DateTime<Utc> = "2026-08-02T03:00:00Z".parse().unwrap();
+        let candidate = candidate(SalienceKind::Finding, "a quiet-hours finding");
+        assert!(matches!(
+            admit_at(tmp.path(), &config, &candidate, three_am).decision,
+            Decision::Rejected(RejectionReason::QuietHours { .. })
+        ));
+    }
+
+    #[test]
+    fn quiet_hours_follow_ds_local_time_not_utc() {
+        let tmp = TempDir::new().unwrap();
+        let config = config("Europe/Madrid");
+        // 22:30 UTC is 00:30 in Madrid in August — quiet there, loud in UTC.
+        let late: DateTime<Utc> = "2026-08-02T22:30:00Z".parse().unwrap();
+        let candidate = candidate(SalienceKind::Finding, "a late finding");
+        assert!(matches!(
+            admit_at(tmp.path(), &config, &candidate, late).decision,
+            Decision::Rejected(RejectionReason::QuietHours { .. })
+        ));
+    }
+
+    #[test]
+    fn disabled_outreach_admits_nothing() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = config("UTC");
+        config.outreach.enabled = false;
+        let candidate = candidate(SalienceKind::Blocking, "even blocking");
+        assert_eq!(
+            admit_at(tmp.path(), &config, &candidate, Utc::now()).decision,
+            Decision::Rejected(RejectionReason::Disabled)
+        );
+        // Disabled means untouched, not merely unsent.
+        assert!(store::load(tmp.path()).sent.is_empty());
+    }
+
+    #[test]
+    fn a_rejected_candidate_is_logged_with_its_reason() {
+        let tmp = TempDir::new().unwrap();
+        let config = config("UTC");
+        let noon: DateTime<Utc> = "2026-08-02T12:00:00Z".parse().unwrap();
+        let mut candidate = candidate(SalienceKind::Finding, "unsupported claim");
+        candidate.evidence = "just my own prose\nCost: nothing".into();
+
+        admit_at(tmp.path(), &config, &candidate, noon);
+
+        let store = store::load(tmp.path());
+        assert_eq!(store.rejections.len(), 1);
+        assert_eq!(
+            store.rejections[0].reason,
+            RejectionReason::NoExternalReferent
+        );
+        assert_eq!(store.rejections[0].headline, "unsupported claim");
+    }
+
+    /// Seed `count` unanswered messages of `kind` so the rolling rate is 0.
+    fn seed_ignored(root: &Path, kind: SalienceKind, count: usize, at: DateTime<Utc>) {
+        store::save_delta(root, |s| {
+            for i in 0..count {
+                s.record_sent(test_support::sent(
+                    &format!("old-{kind}-{i}"),
+                    kind,
+                    at,
+                    false,
+                ));
+            }
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn a_tightening_is_announced_once_and_only_once() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = config("UTC");
+        config.outreach.feedback_window = 4;
+        let yesterday: DateTime<Utc> = "2026-08-01T12:00:00Z".parse().unwrap();
+        let noon: DateTime<Utc> = "2026-08-02T12:00:00Z".parse().unwrap();
+
+        // Four ignored Findings: rate 0, below the 0.3 floor.
+        seed_ignored(tmp.path(), SalienceKind::Finding, 4, yesterday);
+
+        let fresh = candidate(SalienceKind::Finding, "a fresh finding");
+        let first = admit_at(tmp.path(), &config, &fresh, noon);
+        let tightening = first
+            .pending_notice
+            .expect("the halving must be announced, never silent");
+        assert_eq!(tightening.base_cap, 2);
+        assert_eq!(tightening.tightened_cap, 1);
+
+        // The listener confirms delivery; only then is it recorded.
+        crate::outreach::store::save_delta(tmp.path(), |s| {
+            s.record_announcement(tightening.kind, tightening.tightened_cap, noon);
+        })
+        .unwrap();
+
+        let another = candidate(SalienceKind::Finding, "another fresh finding");
+        assert!(
+            admit_at(tmp.path(), &config, &another, noon)
+                .pending_notice
+                .is_none(),
+            "D must not be told the same tightening twice"
+        );
+    }
+
+    #[test]
+    fn an_undelivered_notice_is_retried_on_the_next_candidate() {
+        // The listener records the announcement only after the webhook
+        // confirms. Simulate a failed delivery by not recording it.
+        let tmp = TempDir::new().unwrap();
+        let mut config = config("UTC");
+        config.outreach.feedback_window = 4;
+        let yesterday: DateTime<Utc> = "2026-08-01T12:00:00Z".parse().unwrap();
+        let noon: DateTime<Utc> = "2026-08-02T12:00:00Z".parse().unwrap();
+        seed_ignored(tmp.path(), SalienceKind::Finding, 4, yesterday);
+
+        let first = candidate(SalienceKind::Finding, "first");
+        assert!(admit_at(tmp.path(), &config, &first, noon)
+            .pending_notice
+            .is_some());
+        let second = candidate(SalienceKind::Finding, "second");
+        assert!(
+            admit_at(tmp.path(), &config, &second, noon)
+                .pending_notice
+                .is_some(),
+            "a notice that never reached D must keep trying"
+        );
+    }
+
+    #[test]
+    fn a_cap_halved_to_zero_still_announces_although_it_admits_nothing() {
+        // The silent-death case: Development halves 1 → 0, so no candidate
+        // can ever be admitted again. If the notice rode on admission, D
+        // would never learn the channel had closed.
+        let tmp = TempDir::new().unwrap();
+        let mut config = config("UTC");
+        config.outreach.feedback_window = 4;
+        let yesterday: DateTime<Utc> = "2026-08-01T12:00:00Z".parse().unwrap();
+        let noon: DateTime<Utc> = "2026-08-02T12:00:00Z".parse().unwrap();
+        seed_ignored(tmp.path(), SalienceKind::Development, 4, yesterday);
+
+        let candidate = candidate(SalienceKind::Development, "a development");
+        let admission = admit_at(tmp.path(), &config, &candidate, noon);
+
+        assert!(matches!(
+            admission.decision,
+            Decision::Rejected(RejectionReason::DailyCapReached { cap: 0, .. })
+        ));
+        let tightening = admission
+            .pending_notice
+            .expect("a channel closing itself must say so");
+        assert_eq!(tightening.tightened_cap, 0);
+    }
+
+    #[test]
+    fn a_lifted_tightening_clears_its_announcement() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = config("UTC");
+        config.outreach.feedback_window = 4;
+        let noon: DateTime<Utc> = "2026-08-02T12:00:00Z".parse().unwrap();
+
+        // Answered messages: no tightening, so a stale record must go, or a
+        // later re-tightening would look already-announced and stay silent.
+        store::save_delta(tmp.path(), |s| {
+            for i in 0..4 {
+                s.record_sent(test_support::sent(
+                    &format!("ok-{i}"),
+                    SalienceKind::Callback,
+                    noon,
+                    true,
+                ));
+            }
+            s.record_announcement(SalienceKind::Callback, 1, noon);
+        })
+        .unwrap();
+
+        let candidate = candidate(SalienceKind::Callback, "a callback");
+        let admission = admit_at(tmp.path(), &config, &candidate, noon);
+        assert!(admission.pending_notice.is_none());
+        assert!(store::load(tmp.path())
+            .announced(SalienceKind::Callback)
+            .is_none());
+    }
+
+    #[test]
+    fn an_unreadable_store_rejects_rather_than_sends_blind() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("outreach.json"), "{ corrupt").unwrap();
+        let config = config("UTC");
+        let candidate = candidate(SalienceKind::Blocking, "urgent");
+        assert!(matches!(
+            admit_at(tmp.path(), &config, &candidate, Utc::now()).decision,
+            Decision::Rejected(RejectionReason::StoreUnavailable { .. })
+        ));
+    }
+}

--- a/src/outreach/mod.rs
+++ b/src/outreach/mod.rs
@@ -148,6 +148,18 @@ pub fn stated_cost(evidence: &str) -> Option<Cost> {
         .find_map(|c| Cost::from_label(&c[1]))
 }
 
+/// Append a normalized `Cost:` line to `evidence` unless one is already there.
+///
+/// Used when a marker supplies `cost` as its own field: the gate then sees a
+/// single canonical form regardless of how the candidate was authored.
+#[must_use]
+pub fn with_cost_line(evidence: &str, cost: Cost) -> String {
+    if stated_cost(evidence).is_some() {
+        return evidence.to_string();
+    }
+    format!("{}\nCost: {cost}", evidence.trim_end())
+}
+
 // ---------------------------------------------------------------------------
 // Gate 2 — external referent
 // ---------------------------------------------------------------------------
@@ -166,8 +178,8 @@ pub enum ExternalReferent {
     PredictionId(String),
     /// A fetched source, cited by URL.
     Url(String),
-    /// A number attributed to a tool run — a digit inside a backticked span
-    /// or a `$ `-prefixed shell line.
+    /// A number attributed to a tool run — reported on the same line as the
+    /// command that produced it.
     ToolMeasurement(String),
 }
 
@@ -922,6 +934,16 @@ mod tests {
     fn missing_cost_line_is_none() {
         assert_eq!(stated_cost("no declaration anywhere"), None);
         assert_eq!(stated_cost("Cost: something unparseable"), None);
+    }
+
+    #[test]
+    fn with_cost_line_does_not_duplicate() {
+        let already = "evidence\nCost: read";
+        assert_eq!(with_cost_line(already, Cost::Decision), already);
+        assert_eq!(
+            with_cost_line("evidence", Cost::Nothing),
+            "evidence\nCost: nothing"
+        );
     }
 
     // --- the gate as a whole ---------------------------------------------

--- a/src/outreach/novelty.rs
+++ b/src/outreach/novelty.rs
@@ -1,0 +1,265 @@
+//! Gate 1's oracle — novelty against the record (PN-94, spec §2.3.1).
+//!
+//! The dominant failure of a self-triggered channel is restating: the entity
+//! rediscovers something it already wrote down and sends it as news. So a
+//! headline is compared against what is already on the record, and "already
+//! on the record" means two things — every prior outreach message, and every
+//! entry heading in the journal documents.
+//!
+//! Similarity is cosine distance over recall-echo's embedding path
+//! (fastembed, BGE-Small-EN-v1.5, 384 dimensions) — the same model the
+//! knowledge graph indexes episodes with, so "semantically matches" means
+//! here exactly what it means in memory retrieval. The model cache is shared
+//! with the graph's, so the first candidate on a machine that has already
+//! ingested an episode pays nothing.
+//!
+//! Loading the ONNX runtime is slow and can fail (no cache, no network on
+//! first ever use). Both are handled the same way: an `Err` from
+//! [`NoveltyIndex::max_similarity`] means novelty is *unknown*, and the gate
+//! reads unknown as a rejection. Under-firing is the recoverable direction.
+
+use std::path::Path;
+
+use recall_echo::graph::embed::{Embedder, LazyEmbedder};
+
+use super::store::OutreachStore;
+use super::NoveltyIndex;
+
+/// Upper bound on corpus entries compared against one headline.
+///
+/// Bounds the per-candidate embedding cost. The newest entries are kept: an
+/// eight-month-old journal heading is a weaker claim to "already said this"
+/// than last week's outreach.
+const MAX_CORPUS: usize = 400;
+
+/// Journal documents whose entry headings form the second half of the corpus.
+const JOURNAL_DOCS: &[&str] = &[
+    "LEARNING.md",
+    "THOUGHTS.md",
+    "CURIOSITY.md",
+    "REFLECTIONS.md",
+    "PRAXIS.md",
+    "FINDINGS.md",
+];
+
+/// Novelty backed by recall-echo's local embedding model.
+pub struct EmbeddingNovelty {
+    embedder: LazyEmbedder,
+}
+
+impl EmbeddingNovelty {
+    /// Construction is free — the model loads on first actual comparison.
+    #[must_use]
+    pub fn new(root_dir: &Path) -> Self {
+        Self {
+            embedder: LazyEmbedder::new(&root_dir.join("memory").join("graph").join("models")),
+        }
+    }
+}
+
+impl NoveltyIndex for EmbeddingNovelty {
+    fn max_similarity(&self, headline: &str, corpus: &[String]) -> Result<f64, String> {
+        if corpus.is_empty() {
+            // Nothing on the record yet, so nothing can be a restatement.
+            return Ok(0.0);
+        }
+
+        let embedder = self.embedder.get().map_err(|e| e.to_string())?;
+        let mut texts: Vec<&str> = Vec::with_capacity(corpus.len() + 1);
+        texts.push(headline);
+        texts.extend(corpus.iter().map(String::as_str));
+
+        let vectors = embedder.embed(texts).map_err(|e| e.to_string())?;
+        let (query, rest) = vectors
+            .split_first()
+            .ok_or_else(|| "embedder returned no vectors".to_string())?;
+        if rest.len() != corpus.len() {
+            return Err(format!(
+                "embedder returned {} vectors for {} corpus entries",
+                rest.len(),
+                corpus.len()
+            ));
+        }
+
+        Ok(rest
+            .iter()
+            .map(|entry| cosine_similarity(query, entry))
+            .fold(0.0_f64, f64::max))
+    }
+}
+
+/// Cosine similarity clamped to `[0, 1]`.
+///
+/// The clamp is not cosmetic: the gate compares against a `[0, 1]` threshold,
+/// and a negative similarity (semantically opposed text) is maximal novelty,
+/// not a value that should wrap round into a different meaning.
+#[must_use]
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+    let mut dot = 0.0_f64;
+    let mut norm_a = 0.0_f64;
+    let mut norm_b = 0.0_f64;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += f64::from(*x) * f64::from(*y);
+        norm_a += f64::from(*x) * f64::from(*x);
+        norm_b += f64::from(*y) * f64::from(*y);
+    }
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 0.0;
+    }
+    (dot / (norm_a.sqrt() * norm_b.sqrt())).clamp(0.0, 1.0)
+}
+
+/// Assemble the corpus a headline is judged against.
+///
+/// Prior outreach headlines first, then journal entry headings. Both are
+/// short, declarative and roughly headline-shaped, which is the granularity
+/// the comparison is meaningful at — embedding a whole 8 KB THOUGHTS.md
+/// against one sentence measures topic overlap, not restatement.
+#[must_use]
+pub fn build_corpus(root_dir: &Path, store: &OutreachStore) -> Vec<String> {
+    let mut corpus = store.sent_headlines();
+    corpus.extend(journal_headings(root_dir));
+    if corpus.len() > MAX_CORPUS {
+        corpus.drain(..corpus.len() - MAX_CORPUS);
+    }
+    corpus
+}
+
+/// Entry headings from the journal documents.
+fn journal_headings(root_dir: &Path) -> Vec<String> {
+    let docs_dir = crate::scheduler::evaluator::resolve_docs_dir(root_dir);
+    JOURNAL_DOCS
+        .iter()
+        .filter_map(|name| std::fs::read_to_string(docs_dir.join(name)).ok())
+        .flat_map(|content| headings(&content))
+        .collect()
+}
+
+/// Markdown headings in `content`, stripped of their `#` markers.
+///
+/// Level-1 headings are skipped: they are the document title
+/// ("# LEARNING"), which every entry in the file would trivially match.
+fn headings(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            if !trimmed.starts_with("##") {
+                return None;
+            }
+            let text = trimmed.trim_start_matches('#').trim();
+            (!text.is_empty()).then(|| text.to_string())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::SalienceKind;
+    use crate::outreach::test_support::sent;
+    use chrono::Utc;
+    use tempfile::TempDir;
+
+    #[test]
+    fn headings_skip_titles_and_prose() {
+        let content = "\
+# LEARNING
+
+Some intro prose.
+
+## Thread: the listener sheds during isolation
+
+Body text that is not a heading.
+
+### Sub-point about leases
+
+##
+
+##   Trailing spaces are trimmed
+";
+        assert_eq!(
+            headings(content),
+            vec![
+                "Thread: the listener sheds during isolation",
+                "Sub-point about leases",
+                "Trailing spaces are trimmed",
+            ]
+        );
+    }
+
+    #[test]
+    fn corpus_joins_prior_headlines_and_journal_headings() {
+        let tmp = TempDir::new().unwrap();
+        let journal = tmp.path().join("journal");
+        std::fs::create_dir_all(&journal).unwrap();
+        std::fs::write(
+            journal.join("THOUGHTS.md"),
+            "# THOUGHTS\n\n## A thought about caps\n",
+        )
+        .unwrap();
+
+        let mut store = OutreachStore::default();
+        store.record_sent(sent("m1", SalienceKind::Finding, Utc::now(), false));
+
+        let corpus = build_corpus(tmp.path(), &store);
+        assert!(corpus.contains(&"headline m1".to_string()));
+        assert!(corpus.contains(&"A thought about caps".to_string()));
+    }
+
+    #[test]
+    fn corpus_is_bounded() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = OutreachStore::default();
+        for i in 0..(MAX_CORPUS + 50) {
+            store.record_sent(sent(
+                &format!("m{i}"),
+                SalienceKind::Finding,
+                Utc::now(),
+                false,
+            ));
+        }
+        assert!(build_corpus(tmp.path(), &store).len() <= MAX_CORPUS);
+    }
+
+    #[test]
+    fn corpus_on_a_fresh_entity_is_empty() {
+        let tmp = TempDir::new().unwrap();
+        assert!(build_corpus(tmp.path(), &OutreachStore::default()).is_empty());
+    }
+
+    #[test]
+    fn an_empty_corpus_is_maximal_novelty_without_loading_a_model() {
+        // Must not touch the ONNX runtime: the first message an entity ever
+        // sends cannot be a restatement of nothing.
+        let tmp = TempDir::new().unwrap();
+        let novelty = EmbeddingNovelty::new(tmp.path());
+        assert_eq!(novelty.max_similarity("anything", &[]).unwrap(), 0.0);
+    }
+
+    #[test]
+    fn cosine_of_identical_vectors_is_one() {
+        let v = vec![0.3_f32, -0.4, 0.5];
+        assert!((cosine_similarity(&v, &v) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cosine_of_orthogonal_vectors_is_zero() {
+        assert_eq!(cosine_similarity(&[1.0, 0.0], &[0.0, 1.0]), 0.0);
+    }
+
+    #[test]
+    fn cosine_clamps_opposed_vectors_to_zero() {
+        // Semantically opposed is maximally novel, not negatively similar.
+        assert_eq!(cosine_similarity(&[1.0, 0.0], &[-1.0, 0.0]), 0.0);
+    }
+
+    #[test]
+    fn cosine_of_mismatched_or_zero_vectors_is_zero() {
+        assert_eq!(cosine_similarity(&[1.0, 0.0], &[1.0]), 0.0);
+        assert_eq!(cosine_similarity(&[0.0, 0.0], &[1.0, 1.0]), 0.0);
+    }
+}

--- a/src/outreach/store.rs
+++ b/src/outreach/store.rs
@@ -1,0 +1,615 @@
+//! `{entity}/outreach.json` — the sent log, D's responses, and the rejection
+//! log (PN-94, spec §4).
+//!
+//! ## Persistence discipline
+//!
+//! Identical to `predictions.json` (PN-86): every write is a locked
+//! read-modify-write via [`save_delta`], serialized in-process by a static
+//! mutex and cross-process by an exclusive lock on `outreach.json.lock`, and
+//! applied against a fresh load from disk. The atomic rename in [`save`]
+//! prevents torn files; the lock prevents lost updates.
+//!
+//! ## Fail-closed
+//!
+//! [`load`] fail-opens so `outreach status` can still render something on a
+//! damaged file. [`load_strict`], used inside [`save_delta`], fail-*closes*:
+//! an existing file that cannot be read or parsed aborts the delta rather
+//! than silently wiping the record of what was already sent. Wiping it would
+//! reset every daily cap and the whole response-rate window at once — the
+//! store is the only memory the caps have.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
+use serde::{Deserialize, Serialize};
+
+use super::{Cost, RejectionReason};
+use crate::events::SalienceKind;
+
+/// File name for the outreach log on disk.
+const OUTREACH_FILE: &str = "outreach.json";
+
+/// Temporary file used during atomic writes.
+const OUTREACH_TMP: &str = "outreach.json.tmp";
+
+/// Sent messages retained. Comfortably exceeds `feedback_window` × kinds so
+/// the rolling response rate never runs off the end of the log.
+const MAX_SENT: usize = 200;
+
+/// Rejections retained for `outreach status`. The rejection log is the only
+/// evidence about whether the gate is calibrated (spec §8), so it is kept —
+/// but bounded, because nothing else prunes it.
+const MAX_REJECTIONS: usize = 100;
+
+/// How D reacted to a message, when he said so explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Rating {
+    Useful,
+    Noise,
+}
+
+impl Rating {
+    /// Parse the one-word ratings from spec §2.4 (`/useful`, `/noise`).
+    #[must_use]
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label
+            .trim()
+            .trim_start_matches('/')
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "useful" => Some(Self::Useful),
+            "noise" => Some(Self::Noise),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Useful => "useful",
+            Self::Noise => "noise",
+        }
+    }
+}
+
+impl std::fmt::Display for Rating {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One outreach message that cleared the gate.
+///
+/// Recorded at admission, not at delivery. Counting sends at admission
+/// over-counts if a queued intent never runs, which tightens the channel;
+/// counting at delivery would let an unbounded number of admitted messages
+/// sit in the queue under a cap of one, which loosens it. Over-firing is the
+/// unrecoverable direction (spec §6.4), so the count is taken early.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SentMessage {
+    pub id: String,
+    pub kind: SalienceKind,
+    #[serde(default)]
+    pub thread_id: Option<String>,
+    pub headline: String,
+    pub evidence: String,
+    pub confidence: f64,
+    pub cost: Cost,
+    pub sent_at: DateTime<Utc>,
+    /// When D responded. `None` is the fail-closed reading: no evidence of a
+    /// response counts as no response (spec §2.4).
+    #[serde(default)]
+    pub responded_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub rating: Option<Rating>,
+}
+
+impl SentMessage {
+    /// Whether D responded to this message.
+    #[must_use]
+    pub fn responded(&self) -> bool {
+        self.responded_at.is_some()
+    }
+
+    /// Time from send to response, when there was one.
+    #[must_use]
+    pub fn response_latency(&self) -> Option<chrono::Duration> {
+        self.responded_at.map(|at| at - self.sent_at)
+    }
+}
+
+/// One candidate the gate turned away, kept so the gate can be audited.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RejectedCandidate {
+    pub kind: SalienceKind,
+    pub headline: String,
+    pub reason: RejectionReason,
+    pub rejected_at: DateTime<Utc>,
+}
+
+/// A cap tightening that has already been announced to D.
+///
+/// Presence means the notice went out; absence means it has not. Without
+/// this the notice would re-fire on every candidate while the response rate
+/// stayed low, which is the same channel erosion the caps exist to prevent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnnouncedTightening {
+    pub kind: SalienceKind,
+    pub tightened_cap: u32,
+    pub announced_at: DateTime<Utc>,
+}
+
+/// The persisted outreach record.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OutreachStore {
+    #[serde(default)]
+    pub sent: Vec<SentMessage>,
+    #[serde(default)]
+    pub rejections: Vec<RejectedCandidate>,
+    #[serde(default)]
+    pub announced_tightenings: Vec<AnnouncedTightening>,
+}
+
+impl OutreachStore {
+    /// Append a sent message and prune the log back to its bound.
+    pub fn record_sent(&mut self, message: SentMessage) {
+        self.sent.push(message);
+        prune_front(&mut self.sent, MAX_SENT);
+    }
+
+    /// Append a rejection and prune the log back to its bound.
+    pub fn record_rejection(&mut self, rejection: RejectedCandidate) {
+        self.rejections.push(rejection);
+        prune_front(&mut self.rejections, MAX_REJECTIONS);
+    }
+
+    /// The most recent `window` messages of `kind`, oldest first.
+    #[must_use]
+    pub fn recent(&self, kind: SalienceKind, window: usize) -> Vec<&SentMessage> {
+        let mut of_kind: Vec<&SentMessage> = self.sent.iter().filter(|m| m.kind == kind).collect();
+        if of_kind.len() > window {
+            of_kind.drain(..of_kind.len() - window);
+        }
+        of_kind
+    }
+
+    /// How many messages of `kind` were sent on the local calendar day that
+    /// `now` falls on. The day boundary is D's local midnight, not UTC's —
+    /// a cap of one per day means one per *his* day.
+    #[must_use]
+    pub fn sent_today(&self, kind: SalienceKind, tz: Tz, now: DateTime<Utc>) -> u32 {
+        let today = now.with_timezone(&tz).date_naive();
+        self.sent
+            .iter()
+            .filter(|m| m.kind == kind && m.sent_at.with_timezone(&tz).date_naive() == today)
+            .count()
+            .try_into()
+            .unwrap_or(u32::MAX)
+    }
+
+    /// Record D's response to a message. Returns false when the id is unknown.
+    ///
+    /// Re-recording a response is idempotent on the timestamp (the first
+    /// response is the one that measures latency) but always applies the
+    /// newest explicit rating, so `/useful` can correct a `/noise`.
+    pub fn mark_responded(&mut self, id: &str, at: DateTime<Utc>, rating: Option<Rating>) -> bool {
+        let Some(message) = self.sent.iter_mut().find(|m| m.id == id) else {
+            return false;
+        };
+        message.responded_at.get_or_insert(at);
+        if rating.is_some() {
+            message.rating = rating;
+        }
+        true
+    }
+
+    /// The tightening already announced for `kind`, if any.
+    #[must_use]
+    pub fn announced(&self, kind: SalienceKind) -> Option<&AnnouncedTightening> {
+        self.announced_tightenings.iter().find(|a| a.kind == kind)
+    }
+
+    /// Record that D has been told the cap for `kind` is halved.
+    pub fn record_announcement(
+        &mut self,
+        kind: SalienceKind,
+        tightened_cap: u32,
+        at: DateTime<Utc>,
+    ) {
+        self.announced_tightenings.retain(|a| a.kind != kind);
+        self.announced_tightenings.push(AnnouncedTightening {
+            kind,
+            tightened_cap,
+            announced_at: at,
+        });
+    }
+
+    /// Forget the announcement for `kind` — the tightening has lifted, so a
+    /// future one must be announced again rather than assumed known.
+    pub fn clear_announcement(&mut self, kind: SalienceKind) {
+        self.announced_tightenings.retain(|a| a.kind != kind);
+    }
+
+    /// Every headline already sent — one half of gate 1's corpus.
+    #[must_use]
+    pub fn sent_headlines(&self) -> Vec<String> {
+        self.sent.iter().map(|m| m.headline.clone()).collect()
+    }
+
+    /// Ids of messages still awaiting a response, newest first. This is the
+    /// list `outreach respond` picks from.
+    #[must_use]
+    pub fn unanswered(&self) -> Vec<&SentMessage> {
+        let mut open: Vec<&SentMessage> = self.sent.iter().filter(|m| !m.responded()).collect();
+        open.reverse();
+        open
+    }
+}
+
+/// Drop the oldest entries until `items` fits inside `max`.
+fn prune_front<T>(items: &mut Vec<T>, max: usize) {
+    if items.len() > max {
+        items.drain(..items.len() - max);
+    }
+}
+
+/// Load the outreach store, fail-open.
+///
+/// A missing, unreadable or corrupt file yields an empty store so read-only
+/// callers (`outreach status`) always render. Writers must use
+/// [`save_delta`], which fail-closes instead.
+#[must_use]
+pub fn load(root_dir: &Path) -> OutreachStore {
+    let path = root_dir.join(OUTREACH_FILE);
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(path = %path.display(), error = %e, "Failed to read outreach log");
+            }
+            return OutreachStore::default();
+        }
+    };
+    serde_json::from_str(&content).unwrap_or_else(|e| {
+        tracing::warn!(path = %path.display(), error = %e, "Corrupt outreach log");
+        OutreachStore::default()
+    })
+}
+
+/// Fail-closed load for read-modify-write callers.
+///
+/// A missing file is a fresh entity and starts empty. An existing file that
+/// cannot be read or parsed is an error and the delta is aborted — writing
+/// back an empty store would reset every daily cap and the entire response
+/// window in one stroke. A corrupt file is quarantined to
+/// `outreach.json.corrupt.<ts>` so the failure costs one loud cycle instead
+/// of wedging every future write, matching `predictions.json` (SEC-003).
+fn load_strict(root_dir: &Path) -> Result<OutreachStore, Box<dyn std::error::Error + Send + Sync>> {
+    let path = root_dir.join(OUTREACH_FILE);
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(OutreachStore::default()),
+        Err(e) => return Err(Box::new(e)),
+    };
+    match serde_json::from_str(&content) {
+        Ok(store) => Ok(store),
+        Err(e) => {
+            let quarantine = root_dir.join(format!(
+                "{OUTREACH_FILE}.corrupt.{}",
+                Utc::now().format("%Y%m%dT%H%M%S")
+            ));
+            match fs::rename(&path, &quarantine) {
+                Ok(()) => Err(format!(
+                    "corrupt outreach.json quarantined to {} ({e})",
+                    quarantine.display()
+                )
+                .into()),
+                Err(rename_err) => Err(format!(
+                    "corrupt outreach.json, quarantine also failed ({rename_err}): {e}"
+                )
+                .into()),
+            }
+        }
+    }
+}
+
+/// Locked read-modify-write on the outreach store.
+///
+/// The admission decision and the write that records it happen inside one
+/// call, so two candidates racing on a cap of one cannot both observe zero
+/// sent today.
+pub fn save_delta<T>(
+    root_dir: &Path,
+    apply: impl FnOnce(&mut OutreachStore) -> T,
+) -> Result<T, Box<dyn std::error::Error + Send + Sync>> {
+    static IN_PROCESS: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = IN_PROCESS.lock().unwrap_or_else(|p| p.into_inner());
+
+    fs::create_dir_all(root_dir)?;
+    let lock_file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(root_dir.join(format!("{OUTREACH_FILE}.lock")))?;
+    lock_file.lock()?;
+
+    let mut store = load_strict(root_dir)?;
+    let out = apply(&mut store);
+    save(root_dir, &store)?;
+    Ok(out)
+    // lock_file drop releases the flock
+}
+
+/// Async wrapper for [`save_delta`] — offloads the locked IO (and, for the
+/// admission path, the embedding model load) to a blocking thread so neither
+/// the flock nor the ONNX runtime ever parks a tokio worker.
+pub async fn save_delta_async<T: Send + 'static>(
+    root_dir: PathBuf,
+    apply: impl FnOnce(&mut OutreachStore) -> T + Send + 'static,
+) -> Result<T, Box<dyn std::error::Error + Send + Sync>> {
+    match tokio::task::spawn_blocking(move || save_delta(&root_dir, apply)).await {
+        Ok(result) => result,
+        Err(join_err) => Err(Box::new(join_err)),
+    }
+}
+
+/// Save the store atomically (tmp file, then rename).
+pub fn save(
+    root_dir: &Path,
+    store: &OutreachStore,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    fs::create_dir_all(root_dir)?;
+    let path = root_dir.join(OUTREACH_FILE);
+    let tmp_path = root_dir.join(OUTREACH_TMP);
+
+    // Pretty-printed: unlike predictions.json this file is small, bounded,
+    // and the first thing a human reads when asking "why did the cap move?".
+    let content = serde_json::to_string_pretty(store)?;
+    fs::write(&tmp_path, &content)?;
+    fs::rename(&tmp_path, &path)?;
+    Ok(())
+}
+
+/// Ids of predictions that have actually resolved.
+///
+/// Gate 2 accepts a prediction id as an external referent only if it names a
+/// prediction that resolved — an unresolved id is a pointer to the entity's
+/// own expectation, which is exactly the self-authored evidence the gate
+/// exists to reject.
+#[must_use]
+pub fn resolved_prediction_ids(root_dir: &Path) -> HashSet<String> {
+    crate::prediction::store::load(root_dir, crate::config::PredictionConfig::default())
+        .predictions
+        .iter()
+        .filter(|p| p.resolution.is_some())
+        .map(|p| p.id.clone())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::outreach::test_support::sent;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_returns_empty_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let store = load(tmp.path());
+        assert!(store.sent.is_empty());
+        assert!(store.rejections.is_empty());
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let mut store = OutreachStore::default();
+        store.record_sent(sent("m1", SalienceKind::Finding, Utc::now(), false));
+        save(tmp.path(), &store).unwrap();
+
+        let loaded = load(tmp.path());
+        assert_eq!(loaded.sent.len(), 1);
+        assert_eq!(loaded.sent[0].id, "m1");
+    }
+
+    #[test]
+    fn sent_today_counts_the_local_day_not_the_utc_day() {
+        // 00:30 UTC on the 2nd is 01:30 on the 2nd in Madrid but still the
+        // 1st in New York. A cap of one per day must mean one per D's day.
+        let madrid: Tz = "Europe/Madrid".parse().unwrap();
+        let new_york: Tz = "America/New_York".parse().unwrap();
+        let now: DateTime<Utc> = "2026-08-02T00:30:00Z".parse().unwrap();
+        let earlier: DateTime<Utc> = "2026-08-01T22:00:00Z".parse().unwrap();
+
+        let mut store = OutreachStore::default();
+        store.record_sent(sent("m1", SalienceKind::Finding, earlier, false));
+
+        // Madrid: 2026-08-02 00:30 vs 2026-08-02 00:00 — same local day.
+        assert_eq!(store.sent_today(SalienceKind::Finding, madrid, now), 1);
+        // New York: 2026-08-01 20:30 vs 2026-08-01 18:00 — same local day.
+        assert_eq!(store.sent_today(SalienceKind::Finding, new_york, now), 1);
+        // A different kind shares no budget.
+        assert_eq!(store.sent_today(SalienceKind::Callback, madrid, now), 0);
+    }
+
+    #[test]
+    fn sent_today_excludes_yesterday() {
+        let utc: Tz = "UTC".parse().unwrap();
+        let now: DateTime<Utc> = "2026-08-02T09:00:00Z".parse().unwrap();
+        let yesterday: DateTime<Utc> = "2026-08-01T09:00:00Z".parse().unwrap();
+        let mut store = OutreachStore::default();
+        store.record_sent(sent("m1", SalienceKind::Finding, yesterday, false));
+        assert_eq!(store.sent_today(SalienceKind::Finding, utc, now), 0);
+    }
+
+    #[test]
+    fn mark_responded_is_idempotent_on_time_but_not_on_rating() {
+        let first: DateTime<Utc> = "2026-08-02T09:00:00Z".parse().unwrap();
+        let later: DateTime<Utc> = "2026-08-02T11:00:00Z".parse().unwrap();
+        let mut store = OutreachStore::default();
+        store.record_sent(sent("m1", SalienceKind::Finding, first, false));
+
+        assert!(store.mark_responded("m1", first, Some(Rating::Noise)));
+        assert!(store.mark_responded("m1", later, Some(Rating::Useful)));
+        assert_eq!(store.sent[0].responded_at, Some(first));
+        assert_eq!(store.sent[0].rating, Some(Rating::Useful));
+        assert!(!store.mark_responded("nope", later, None));
+    }
+
+    #[test]
+    fn recent_takes_the_newest_window_of_that_kind() {
+        let mut store = OutreachStore::default();
+        for i in 0..5 {
+            let kind = if i % 2 == 0 {
+                SalienceKind::Finding
+            } else {
+                SalienceKind::Callback
+            };
+            store.record_sent(sent(&format!("m{i}"), kind, Utc::now(), false));
+        }
+        let recent = store.recent(SalienceKind::Finding, 2);
+        assert_eq!(
+            recent.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+            vec!["m2", "m4"]
+        );
+    }
+
+    #[test]
+    fn sent_log_is_bounded() {
+        let mut store = OutreachStore::default();
+        for i in 0..(MAX_SENT + 10) {
+            store.record_sent(sent(
+                &format!("m{i}"),
+                SalienceKind::Finding,
+                Utc::now(),
+                false,
+            ));
+        }
+        assert_eq!(store.sent.len(), MAX_SENT);
+        // The oldest are the ones dropped.
+        assert_eq!(store.sent[0].id, "m10");
+    }
+
+    #[test]
+    fn rejection_log_is_bounded() {
+        let mut store = OutreachStore::default();
+        for _ in 0..(MAX_REJECTIONS + 5) {
+            store.record_rejection(RejectedCandidate {
+                kind: SalienceKind::Finding,
+                headline: "h".into(),
+                reason: RejectionReason::NoCostStated,
+                rejected_at: Utc::now(),
+            });
+        }
+        assert_eq!(store.rejections.len(), MAX_REJECTIONS);
+    }
+
+    #[test]
+    fn save_delta_applies_against_fresh_disk_state() {
+        let tmp = TempDir::new().unwrap();
+
+        // Stale in-memory snapshot taken by caller A, never written back.
+        let mut stale = load(tmp.path());
+        stale.record_sent(sent("a-memory", SalienceKind::Finding, Utc::now(), false));
+
+        save_delta(tmp.path(), |s| {
+            s.record_sent(sent("b-disk", SalienceKind::Finding, Utc::now(), false));
+        })
+        .unwrap();
+        save_delta(tmp.path(), |s| {
+            s.record_sent(sent("a-final", SalienceKind::Finding, Utc::now(), false));
+        })
+        .unwrap();
+
+        let ids: Vec<String> = load(tmp.path()).sent.iter().map(|m| m.id.clone()).collect();
+        assert_eq!(ids, vec!["b-disk", "a-final"]);
+    }
+
+    #[test]
+    fn save_delta_concurrent_writers_lose_nothing() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let root = root.clone();
+                std::thread::spawn(move || {
+                    save_delta(&root, |s| {
+                        s.record_sent(sent(
+                            &format!("w{i}"),
+                            SalienceKind::Finding,
+                            Utc::now(),
+                            false,
+                        ));
+                    })
+                    .unwrap();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(load(tmp.path()).sent.len(), 8);
+    }
+
+    #[test]
+    fn save_delta_aborts_and_quarantines_corrupt_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join(OUTREACH_FILE);
+        fs::write(&path, "{ not valid json").unwrap();
+
+        let result = save_delta(tmp.path(), |s| {
+            s.record_sent(sent("nope", SalienceKind::Finding, Utc::now(), false));
+        });
+        assert!(result.is_err(), "a corrupt log must not be silently wiped");
+        assert!(!path.exists());
+
+        let quarantined: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("outreach.json.corrupt.")
+            })
+            .collect();
+        assert_eq!(quarantined.len(), 1);
+
+        // The next delta self-heals from empty.
+        save_delta(tmp.path(), |s| {
+            s.record_sent(sent("after", SalienceKind::Finding, Utc::now(), false));
+        })
+        .unwrap();
+        assert_eq!(load(tmp.path()).sent.len(), 1);
+    }
+
+    #[test]
+    fn announcements_are_one_per_kind_and_clearable() {
+        let now = Utc::now();
+        let mut store = OutreachStore::default();
+        store.record_announcement(SalienceKind::Finding, 1, now);
+        store.record_announcement(SalienceKind::Finding, 0, now);
+        assert_eq!(store.announced_tightenings.len(), 1);
+        assert_eq!(
+            store
+                .announced(SalienceKind::Finding)
+                .unwrap()
+                .tightened_cap,
+            0
+        );
+
+        store.clear_announcement(SalienceKind::Finding);
+        assert!(store.announced(SalienceKind::Finding).is_none());
+    }
+
+    #[test]
+    fn rating_parses_slash_commands() {
+        assert_eq!(Rating::from_label("/useful"), Some(Rating::Useful));
+        assert_eq!(Rating::from_label("NOISE"), Some(Rating::Noise));
+        assert_eq!(Rating::from_label("meh"), None);
+    }
+}

--- a/src/plugins/manager.rs
+++ b/src/plugins/manager.rs
@@ -316,8 +316,8 @@ mod tests {
     use super::*;
     use crate::config::{
         AutonomyConfig, Config, EntityConfig, GraphConfig, LlmConfig, MemoryConfig,
-        MonitoringConfig, PipelineConfig, PlatformConfig, PredictionConfig, PulseConfig,
-        SchedulerConfig, SecurityConfig, ServerConfig, SessionConfig, TrustConfig,
+        MonitoringConfig, OutreachConfig, PipelineConfig, PlatformConfig, PredictionConfig,
+        PulseConfig, SchedulerConfig, SecurityConfig, ServerConfig, SessionConfig, TrustConfig,
     };
 
     fn test_config() -> Config {
@@ -357,6 +357,7 @@ mod tests {
             pulse: PulseConfig::default(),
             graph: GraphConfig::default(),
             prediction: PredictionConfig::default(),
+            outreach: OutreachConfig::default(),
             sessions: SessionConfig::default(),
             context_buffer: crate::context_buffer::ContextBufferConfig::default(),
             session_health: crate::session_health::SessionHealthConfig::default(),

--- a/src/scheduler/intent.rs
+++ b/src/scheduler/intent.rs
@@ -310,6 +310,97 @@ pub fn create_intent_from_marker(
     })
 }
 
+/// Parse a `[SALIENCE: {...}]` JSON marker into a `Salience` event (PN-94).
+///
+/// This is Phase 1's trigger, and knowingly the weak version: the entity
+/// decides when it is interesting, which is unaudited. It ships first anyway
+/// because it makes the behaviour observable, and observable behaviour is
+/// what makes Phase 2 falsifiable (spec §3).
+///
+/// Emitting the marker is not sending anything. The event goes on the bus and
+/// the listener runs the quality gate, quiet hours and the daily cap before
+/// any of it reaches D.
+///
+/// Fields: `kind` and `headline` and `evidence` are required; `confidence`
+/// (default 0.5), `thread_id` and `cost` are optional. A `cost` field is
+/// normalized onto the evidence as a `Cost:` line, so gate 3 stays a pure
+/// check on the event whatever raised it — the marker today, the tension
+/// store in Phase 2.
+///
+/// `kind` is never defaulted: a typo must not silently inherit `Blocking`'s
+/// uncapped, quiet-hours-overriding budget.
+pub fn create_salience_from_marker(
+    json_str: &str,
+) -> Result<EntityEvent, crate::errors::PulseError> {
+    let value: serde_json::Value = serde_json::from_str(json_str)?;
+
+    let kind_label = value["kind"]
+        .as_str()
+        .ok_or("Missing 'kind' in salience marker")?;
+    let kind = crate::events::SalienceKind::from_label(kind_label).ok_or_else(|| {
+        format!("Unknown salience kind '{kind_label}' (finding|development|blocking|callback)")
+    })?;
+
+    let headline = value["headline"]
+        .as_str()
+        .map(str::trim)
+        .filter(|h| !h.is_empty())
+        .ok_or("Missing 'headline' in salience marker")?
+        .to_string();
+
+    let evidence = value["evidence"]
+        .as_str()
+        .map(str::trim)
+        .filter(|e| !e.is_empty())
+        .ok_or("Missing 'evidence' in salience marker")?
+        .to_string();
+
+    let evidence = match value["cost"]
+        .as_str()
+        .and_then(crate::outreach::Cost::from_label)
+    {
+        Some(cost) => crate::outreach::with_cost_line(&evidence, cost),
+        None => evidence,
+    };
+
+    let confidence = value["confidence"].as_f64().unwrap_or(0.5).clamp(0.0, 1.0);
+    let thread_id = value["thread_id"]
+        .as_str()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_string);
+
+    Ok(EntityEvent::Salience {
+        kind,
+        thread_id,
+        headline,
+        evidence,
+        confidence,
+    })
+}
+
+/// Raise every `[SALIENCE:]` marker in a response onto the event bus.
+///
+/// Shared by the task path and the intent path so a marker means the same
+/// thing wherever it is written. Invalid markers are warned about and
+/// dropped: a malformed candidate is not a silent one, but it is not an
+/// outreach either.
+pub fn emit_salience_markers(state: &Arc<AppState>, parsed: &output::ParsedOutput, origin: &str) {
+    for salience_json in &parsed.salience_requests {
+        match create_salience_from_marker(salience_json) {
+            Ok(event) => {
+                tracing::info!(
+                    origin,
+                    event_type = %event.event_type(),
+                    "Salience candidate raised"
+                );
+                state.event_bus.emit(event);
+            }
+            Err(e) => tracing::warn!(origin, "Invalid [SALIENCE:] marker: {e}"),
+        }
+    }
+}
+
 /// Parse a [CHAIN: {...}] JSON marker into an IntentChain.
 pub fn create_chain_from_marker(json_str: &str) -> Result<IntentChain, crate::errors::PulseError> {
     let value: serde_json::Value = serde_json::from_str(json_str)?;
@@ -736,6 +827,10 @@ async fn execute_intent(
             Err(e) => tracing::warn!("Invalid [INTENT:] marker from intent: {}", e),
         }
     }
+
+    // [SALIENCE:] — raise outreach candidates (PN-94). Nothing is sent from
+    // here: the event listener runs the gate, quiet hours and the daily cap.
+    emit_salience_markers(state, &parsed, &intent.id);
 
     // Handle [SHARE:] content
     for content in &parsed.share_content {
@@ -1431,6 +1526,89 @@ mod tests {
 
         let json = r#"{"prompt": "No description"}"#;
         assert!(create_intent_from_marker(json, IntentSource::EntityMarker).is_err());
+    }
+
+    // --- [SALIENCE:] marker (PN-94) --------------------------------------
+
+    fn salience_parts(event: &EntityEvent) -> (crate::events::SalienceKind, String, String, f64) {
+        match event {
+            EntityEvent::Salience {
+                kind,
+                headline,
+                evidence,
+                confidence,
+                ..
+            } => (*kind, headline.clone(), evidence.clone(), *confidence),
+            other => panic!("expected a Salience event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_salience_from_valid_marker() {
+        let json = r#"{"kind":"finding","headline":"The listener sheds during isolation","evidence":"src/events/listener.rs:117\nCost: read","confidence":0.8,"thread_id":"t-1"}"#;
+        let event = create_salience_from_marker(json).unwrap();
+        let (kind, headline, evidence, confidence) = salience_parts(&event);
+        assert_eq!(kind, crate::events::SalienceKind::Finding);
+        assert_eq!(headline, "The listener sheds during isolation");
+        assert!(evidence.contains("listener.rs:117"));
+        assert!((confidence - 0.8).abs() < f64::EPSILON);
+        assert_eq!(event.event_type(), "salience_finding");
+    }
+
+    #[test]
+    fn salience_marker_rejects_an_unknown_kind() {
+        // Defaulting would hand a typo Blocking's uncapped budget.
+        let json = r#"{"kind":"urgent","headline":"h","evidence":"e"}"#;
+        assert!(create_salience_from_marker(json).is_err());
+
+        let json = r#"{"headline":"h","evidence":"e"}"#;
+        assert!(create_salience_from_marker(json).is_err());
+    }
+
+    #[test]
+    fn salience_marker_requires_a_headline_and_evidence() {
+        assert!(create_salience_from_marker(r#"{"kind":"finding","evidence":"e"}"#).is_err());
+        assert!(create_salience_from_marker(r#"{"kind":"finding","headline":"h"}"#).is_err());
+        assert!(
+            create_salience_from_marker(r#"{"kind":"finding","headline":"  ","evidence":"e"}"#)
+                .is_err(),
+            "whitespace is not a headline"
+        );
+    }
+
+    #[test]
+    fn salience_marker_folds_the_cost_field_onto_the_evidence() {
+        // Gate 3 checks the event, so a marker-level cost has to land there.
+        let json = r#"{"kind":"callback","headline":"h","evidence":"https://example.com/x","cost":"a decision"}"#;
+        let (_, _, evidence, _) = salience_parts(&create_salience_from_marker(json).unwrap());
+        assert!(evidence.ends_with("Cost: decision"), "{evidence}");
+        assert_eq!(
+            crate::outreach::stated_cost(&evidence),
+            Some(crate::outreach::Cost::Decision)
+        );
+    }
+
+    #[test]
+    fn salience_marker_does_not_duplicate_an_inline_cost_line() {
+        let json = r#"{"kind":"callback","headline":"h","evidence":"https://example.com/x\nCost: nothing","cost":"decision"}"#;
+        let (_, _, evidence, _) = salience_parts(&create_salience_from_marker(json).unwrap());
+        assert_eq!(evidence.matches("Cost:").count(), 1);
+        assert_eq!(
+            crate::outreach::stated_cost(&evidence),
+            Some(crate::outreach::Cost::Nothing),
+            "the inline line is the one the entity wrote in context"
+        );
+    }
+
+    #[test]
+    fn salience_marker_clamps_and_defaults_confidence() {
+        let json = r#"{"kind":"finding","headline":"h","evidence":"e"}"#;
+        let (_, _, _, confidence) = salience_parts(&create_salience_from_marker(json).unwrap());
+        assert!((confidence - 0.5).abs() < f64::EPSILON);
+
+        let json = r#"{"kind":"finding","headline":"h","evidence":"e","confidence":9.0}"#;
+        let (_, _, _, confidence) = salience_parts(&create_salience_from_marker(json).unwrap());
+        assert!((confidence - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/scheduler/output.rs
+++ b/src/scheduler/output.rs
@@ -24,6 +24,8 @@ pub struct ParsedOutput {
     pub chain_requests: Vec<String>,
     /// JSON content extracted from [FARM:] markers (Stage 3 subtask farming)
     pub farm_requests: Vec<String>,
+    /// JSON content extracted from [SALIENCE:] markers (PN-94 outreach)
+    pub salience_requests: Vec<String>,
 }
 
 static SHARE_RE: LazyLock<Regex> =
@@ -114,7 +116,14 @@ pub fn parse_output(content: &str) -> ParsedOutput {
     // FARM first: its payload legitimately contains `}]`, which the simple
     // lazy regexes below would mis-slice if they ran across it.
     let (farm_requests, content_no_farm) = extract_json_markers(content, "FARM");
-    let content = content_no_farm.as_str();
+
+    // SALIENCE uses the same brace-balanced scan: its `evidence` field
+    // carries free-form text that routinely contains brackets (file paths,
+    // citations, `[SHARE:]` examples), and a lazy regex would truncate it —
+    // which would silently strip the very external referent gate 2 checks for.
+    let (salience_requests, content_no_salience) =
+        extract_json_markers(&content_no_farm, "SALIENCE");
+    let content = content_no_salience.as_str();
 
     let share_content: Vec<String> = SHARE_RE
         .captures_iter(content)
@@ -158,6 +167,7 @@ pub fn parse_output(content: &str) -> ParsedOutput {
         intent_requests,
         chain_requests,
         farm_requests,
+        salience_requests,
     }
 }
 
@@ -320,6 +330,21 @@ mod tests {
         assert!(!parsed.clean_content.contains("FARM"));
         assert!(parsed.clean_content.contains("Delegating."));
         assert!(parsed.clean_content.contains("Done."));
+    }
+
+    #[test]
+    fn salience_marker_survives_brackets_in_its_evidence() {
+        // The evidence field is where the external referent lives; a lazy
+        // regex stopping at the first `}]` would cut it off.
+        let content = r#"Thinking done. [SALIENCE: {"kind":"finding","headline":"The gate never fires","evidence":"src/outreach/mod.rs:12 shows the check [never runs] when {enabled} is false.\nCost: read","confidence":0.8}] Continuing."#;
+        let parsed = parse_output(content);
+        assert_eq!(parsed.salience_requests.len(), 1);
+        let value: serde_json::Value = serde_json::from_str(&parsed.salience_requests[0])
+            .expect("captured JSON must be complete");
+        assert!(value["evidence"].as_str().unwrap().contains("[never runs]"));
+        assert!(!parsed.clean_content.contains("SALIENCE"));
+        assert!(parsed.clean_content.contains("Thinking done."));
+        assert!(parsed.clean_content.contains("Continuing."));
     }
 
     #[test]

--- a/src/scheduler/runner.rs
+++ b/src/scheduler/runner.rs
@@ -904,6 +904,10 @@ async fn route_output_markers(
         }
     }
 
+    // [SALIENCE:] — raise outreach candidates (PN-94). Nothing is sent from
+    // here: the event listener runs the gate, quiet hours and the daily cap.
+    intent::emit_salience_markers(state, parsed, &task.id);
+
     // [SHARE:] — route via alert queue + legacy webhook
     for content in &parsed.share_content {
         let alert = super::alerts::alert_from_share(&task.name, content);

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -100,8 +100,8 @@ mod tests {
     use super::*;
     use crate::config::{
         AutonomyConfig, Config, EntityConfig, GraphConfig, LlmConfig, MemoryConfig,
-        MonitoringConfig, PipelineConfig, PredictionConfig, PulseConfig, SchedulerConfig,
-        SecurityConfig, ServerConfig, SessionConfig, TrustConfig,
+        MonitoringConfig, OutreachConfig, PipelineConfig, PredictionConfig, PulseConfig,
+        SchedulerConfig, SecurityConfig, ServerConfig, SessionConfig, TrustConfig,
     };
     use crate::events::EventBus;
     use crate::persist::PersistCoordinator;
@@ -142,6 +142,7 @@ mod tests {
             pulse: PulseConfig::default(),
             graph: GraphConfig::default(),
             prediction: PredictionConfig::default(),
+            outreach: OutreachConfig::default(),
             sessions: SessionConfig::default(),
             context_buffer: crate::context_buffer::ContextBufferConfig::default(),
             session_health: crate::session_health::SessionHealthConfig::default(),
@@ -316,6 +317,7 @@ mod tests {
             pulse: PulseConfig::default(),
             graph: GraphConfig::default(),
             prediction: PredictionConfig::default(),
+            outreach: OutreachConfig::default(),
             sessions: SessionConfig::default(),
             context_buffer: crate::context_buffer::ContextBufferConfig::default(),
             session_health: crate::session_health::SessionHealthConfig::default(),

--- a/src/server/e2e_tests.rs
+++ b/src/server/e2e_tests.rs
@@ -14,8 +14,8 @@ use tower::ServiceExt;
 
 use crate::config::{
     AutonomyConfig, Config, EntityConfig, GraphConfig, LlmConfig, MemoryConfig, MonitoringConfig,
-    PipelineConfig, PredictionConfig, PulseConfig, SchedulerConfig, SecurityConfig, ServerConfig,
-    SessionConfig, TrustConfig,
+    OutreachConfig, PipelineConfig, PredictionConfig, PulseConfig, SchedulerConfig, SecurityConfig,
+    ServerConfig, SessionConfig, TrustConfig,
 };
 use crate::events::EventBus;
 use crate::persist::PersistCoordinator;
@@ -190,6 +190,7 @@ fn test_config() -> Config {
         pulse: PulseConfig::default(),
         graph: GraphConfig::default(),
         prediction: PredictionConfig::default(),
+        outreach: OutreachConfig::default(),
         sessions: SessionConfig::default(),
         context_buffer: crate::context_buffer::ContextBufferConfig::default(),
         session_health: crate::session_health::SessionHealthConfig::default(),

--- a/src/server/prompt.rs
+++ b/src/server/prompt.rs
@@ -1370,7 +1370,7 @@ pub fn write_awareness_file(
 
 /// Build context block for autonomous sessions (scheduled tasks and intents).
 /// Includes: tool list, output markers, queue status, cost status.
-pub fn build_autonomy_context(root_dir: &Path, _config: &Config) -> String {
+pub fn build_autonomy_context(root_dir: &Path, config: &Config) -> String {
     let mut sections = Vec::new();
 
     // Tool documentation
@@ -1397,6 +1397,33 @@ pub fn build_autonomy_context(root_dir: &Path, _config: &Config) -> String {
         Use markers sparingly. Only share content worth surfacing. Only queue intents for genuine follow-up work."
             .to_string(),
     );
+
+    // Outreach marker (PN-94). Documented only when the channel is on, so the
+    // entity is never told about a marker that will be discarded.
+    if config.outreach.enabled {
+        sections.push(
+            "You can also raise unprompted outreach — telling the owner something you judge \
+            worth telling, without being asked:\n\
+            - [SALIENCE: {\"kind\": \"finding|development|blocking|callback\", \
+            \"headline\": \"one sentence, the actual claim\", \
+            \"evidence\": \"what makes it non-obvious\", \
+            \"cost\": \"nothing|read|decision\", \"confidence\": 0.0-1.0}]\n\n\
+            Raising it is not sending it. A mechanical gate decides, and it rejects more than \
+            it passes:\n\
+            1. The headline must not restate anything already in your journal or a previous \
+            outreach message.\n\
+            2. The evidence must cite something you did not write: a file path with a line \
+            number, a URL you fetched, the id of a prediction that resolved, or a number from \
+            a command you ran (quote the command). Prose about your own thinking is not \
+            evidence, and this check is stricter for 'development', not looser.\n\
+            3. The cost must be stated: are you asking for nothing, a read, or a decision?\n\n\
+            Kinds carry different budgets. 'blocking' means the owner's work is stalled \
+            pending his decision — it is uncapped and ignores quiet hours, so using it for \
+            anything else spends the channel's credibility. 'development' is capped at one a \
+            day. Under-using this is recoverable; over-using it is not."
+                .to_string(),
+        );
+    }
 
     // Intent queue status
     let queue = IntentQueue::load(root_dir);

--- a/src/server/prompt.rs
+++ b/src/server/prompt.rs
@@ -1457,6 +1457,7 @@ mod tests {
             pulse: PulseConfig::default(),
             graph: GraphConfig::default(),
             prediction: PredictionConfig::default(),
+            outreach: OutreachConfig::default(),
             sessions: SessionConfig::default(),
             context_buffer: crate::context_buffer::ContextBufferConfig::default(),
             session_health: crate::session_health::SessionHealthConfig::default(),

--- a/src/server/setup.rs
+++ b/src/server/setup.rs
@@ -195,15 +195,16 @@ pub fn spawn_event_listener(
     if config.autonomy.enabled {
         let listener_rx = event_bus.subscribe();
         let listener_queue = Arc::clone(intent_queue);
-        let events_config = config.autonomy.events.clone();
-        let max_queue_size = config.autonomy.max_queue_size;
+        // The whole config, not a slice of it: the listener now also owns the
+        // outreach admission, which needs the caps, the quiet window and the
+        // share webhook the tightening notice goes out on.
+        let listener_config = Arc::new(config.clone());
         let root_dir = root_dir.to_path_buf();
         tokio::spawn(async move {
             crate::events::listener::event_listener(
                 listener_rx,
                 listener_queue,
-                events_config,
-                max_queue_size,
+                listener_config,
                 root_dir,
             )
             .await;

--- a/src/server/trust.rs
+++ b/src/server/trust.rs
@@ -77,8 +77,8 @@ mod tests {
     use super::*;
     use crate::config::{
         AutonomyConfig, Config, EntityConfig, GraphConfig, LlmConfig, MemoryConfig,
-        MonitoringConfig, PipelineConfig, PredictionConfig, PulseConfig, SchedulerConfig,
-        SecurityConfig, ServerConfig, SessionConfig, TrustConfig,
+        MonitoringConfig, OutreachConfig, PipelineConfig, PredictionConfig, PulseConfig,
+        SchedulerConfig, SecurityConfig, ServerConfig, SessionConfig, TrustConfig,
     };
 
     fn test_config() -> Config {
@@ -118,6 +118,7 @@ mod tests {
             pulse: PulseConfig::default(),
             graph: GraphConfig::default(),
             prediction: PredictionConfig::default(),
+            outreach: OutreachConfig::default(),
             sessions: SessionConfig::default(),
             context_buffer: crate::context_buffer::ContextBufferConfig::default(),
             session_health: crate::session_health::SessionHealthConfig::default(),


### PR DESCRIPTION
Closes #94.

Spec: `/opt/pulse-vault/pulse-null/specs/in-progress/interest-triggered-outreach-spec.md` (v1.0, D + Echo).

**Merge order: before PN-95 (#96)** per spec §9 — this is the outlet; the tension store is its Phase 2 trigger.

## What's in (Phase 1)
- `EntityEvent::Salience` + `SalienceKind` (Finding / Development / Blocking / Callback); `[SALIENCE:]` marker parsed alongside `[INTENT:]`/`[SCHEDULE:]`; listener converts to a Share-routed intent.
- **Quality gate** (`src/outreach/`), cheapest-first (referent → cost → novelty), pass requires all three:
  - Gate 1 novelty via real embeddings (`recall_echo` `LazyEmbedder`, BGE-Small, shared model cache); embedder error = rejection, never a pass.
  - Gate 2 external referent, mechanically defined (file:line / prediction id / URL / number+command on the same line). **Stricter for `Development`**: journal-internal file paths don't count — self-authored prose wearing a path is still self-authored.
  - Gate 3 stated cost, normalized onto `evidence` as a `Cost:` line so the event stays five fields.
- **Feedback loop**: `{entity}/outreach.json` (flock-guarded fail-closed), rolling response rate per kind over 20, cap auto-halves below 0.3 with an announced notice — recorded as announced only after the webhook confirms delivery; fires on rejections too, since a 1→0 halving admits nothing.
- Per-kind daily caps; quiet hours 23–08 local; `Blocking` uncapped and quiet-hours-exempt, also exempt from the listener's generic cooldown/circuit-breaker (which would silently throttle it). `allow_call_routing = false`, no automatic Call.
- CLI: `pulse-null outreach status` + `pulse-null outreach respond <id> [--rating useful|noise]` (the response signal needed an inbound path; Discord reply detection remains unwired).

## Verification
fmt clean; `clippy --all-targets --features discord-text -- -D warnings` zero warnings; `cargo test --features discord-text` **910 passed / 0 failed** (~120 new); release build OK; `outreach status` smoke-tested on a scratch entity. Pre-existing unrelated flake in `claude_code_provider::tests` (`ExecutableFileBusy`, ~1 in 3) reproduced on unmodified main.

## Known seams (deliberate, documented)
1. Literal §2.4 halving takes `cap_development` 1 → 0 (silences the kind until responses restore the window) — no `.max(1)` floor was added; the notice says how to recover.
2. Sends counted at admission, not delivery (loud log if a queued intent never runs).
3. `IntentOutput::Share` is set per spec but `output_routing` has no consumer anywhere — delivery actually rides `[SHARE:]`; the intent instructs the prompt to emit it. Cleanup issue worth filing.
4. **Operationally inert until `[autonomy] enabled = true`** — the listener only spawns with autonomy on (off in prod since 2026-08-16, with 16 stranded intents that will replay when flipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDtGQtXxs4fVK4g484Y1Fj